### PR TITLE
Add encoding settings for markdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2
     },
+    "[markdown]": {
+        "files.encoding": "utf8"
+    },
     "[powershell]": {
         "editor.insertSpaces": true,
         "editor.tabSize": 4,


### PR DESCRIPTION
# Change

- To prevent new files to be considered as binary by github, settings in vscode have been adjusted to keep md files as utf8.

This will not automatically update existing files, but can be changed in VSCode status bar in the bottom right corner.
![image](https://user-images.githubusercontent.com/17722253/137929698-dd01ec41-c024-4863-8c1f-3c3ad735eab3.png)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
