### PR TITLE
Users/ahmad/policy assignment output bugfix

### DIFF
--- a/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_sub.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_sub.bicep
@@ -46,5 +46,5 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
 }]
 
 output policyAssignmentName string = policyAssignment.name
-output policyAssignmentId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policySetDefinitions', policyAssignment.name)
+output policyAssignmentId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policyAssignments', policyAssignment.name)
 output policyAssignmentPrincipalId string = identity == 'SystemAssigned' ? policyAssignment.identity.principalId : ''


### PR DESCRIPTION
# Change

Fixed a bug with the output policy assignment ID coming out as 'Policy Set Definition' for subscription scope assignments.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
