### PR TITLE
Restored Service Bus Namespace RBAC, Changed instance name for Namespace and Queues.

### DIFF
--- a/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
@@ -3,7 +3,7 @@ param builtInRoleNames object
 param resourceName string
 
 resource roleAssigment 'Microsoft.ServiceBus/namespaces/providers/roleAssignments@2021-04-01-preview' = [for principalId in roleAssignmentObj.principalIds: {
-  name: '${resourceName}/Microsoft.Authorization/${guid(principalId, resourceName, roleAssignmentObj.roleDefinitionIdOrName)}'
+  name: '${resourceName}/Microsoft.Authorization/${guid(resourceName, principalId, roleAssignmentObj.roleDefinitionIdOrName)}'
   properties: {
     roleDefinitionId: (contains(builtInRoleNames, roleAssignmentObj.roleDefinitionIdOrName) ? builtInRoleNames[roleAssignmentObj.roleDefinitionIdOrName] : roleAssignmentObj.roleDefinitionIdOrName)
     principalId: principalId

--- a/arm/Microsoft.ServiceBus/namespaces/.parameters/parameters.json
+++ b/arm/Microsoft.ServiceBus/namespaces/.parameters/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "serviceBusNamespaceName": {
-            "value": "sxx-az-sbn-weu-x-001"
+            "value": "sxx-az-sbn-weu-x-002"
         },
         "skuName": {
             "value": "Basic"

--- a/arm/Microsoft.ServiceBus/namespacesResources/queues/.parameters/parameters.json
+++ b/arm/Microsoft.ServiceBus/namespacesResources/queues/.parameters/parameters.json
@@ -3,10 +3,10 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "namespaceName": {
-            "value": "sxx-az-sbn-weu-x-001"
+            "value": "sxx-az-sbn-weu-x-002"
         },
         "queueName": {
-            "value": "sxx-az-sbq-weu-x-001"
+            "value": "sxx-az-sbq-weu-x-002"
         },
         "roleAssignments": {
             "value": [


### PR DESCRIPTION
# Change

- Restored RBAC Module for Service Bus Namespace
- Changed the name of the test resource for both Service Bus Namespace and Queues.

# Testing

[![ServiceBus: Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml/badge.svg?branch=quickFix-ServiceBus)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml)

[![ServiceBus: Namespaces Queues](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.queues.yml/badge.svg?branch=quickFix-ServiceBus)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.queues.yml)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
