### PR TITLE
Updated expressRouteCircuits module with Local tier

### DIFF
--- a/arm/Microsoft.Network/expressRouteCircuits/deploy.bicep
+++ b/arm/Microsoft.Network/expressRouteCircuits/deploy.bicep
@@ -10,8 +10,9 @@ param peeringLocation string
 @description('Required. This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call.')
 param bandwidthInMbps int
 
-@description('Required. Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers.')
+@description('Required. Chosen SKU Tier of ExpressRoute circuit. Choose from Local, Premium or Standard SKU tiers.')
 @allowed([
+  'Local'
   'Standard'
   'Premium'
 ])
@@ -168,7 +169,7 @@ resource expressRouteCircuits 'Microsoft.Network/expressRouteCircuits@2021-02-01
   sku: {
     name: '${skuTier}_${skuFamily}'
     tier: skuTier
-    family: skuFamily
+    family: (skuTier == 'Local' ? 'UnlimitedData' : skuFamily)
   }
   properties: {
     serviceProviderProperties: {

--- a/arm/Microsoft.Network/expressRouteCircuits/readme.md
+++ b/arm/Microsoft.Network/expressRouteCircuits/readme.md
@@ -15,7 +15,7 @@ This template deploys a ExrepressRoute Circuit.
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `bandwidthInMbps` | int |  |  | Required. This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call. |
+| `bandwidthInMbps` | int |  |  | Required. This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call. SkuTier 'Local' has special bandwith requirements. It requires minimum 1000mbps.|
 | `circuitName` | string |  |  | Required. This is the name of the ExpressRoute circuit |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |

--- a/arm/Microsoft.Network/expressRouteCircuits/readme.md
+++ b/arm/Microsoft.Network/expressRouteCircuits/readme.md
@@ -36,7 +36,7 @@ This template deploys a ExrepressRoute Circuit.
 | `serviceProviderName` | string |  |  | Required. This is the name of the ExpressRoute Service Provider. It must exactly match one of the Service Providers from List ExpressRoute Service Providers API call. |
 | `sharedKey` | string |  |  | Optional. The shared key for peering configuration. Router does MD5 hash comparison to validate the packets sent by BGP connection. This parameter is optional and can be removed from peering configuration if not required. |
 | `skuFamily` | string | `MeteredData` | `[MeteredData, UnlimitedData]` | Required. Chosen SKU family of ExpressRoute circuit. Choose from MeteredData or UnlimitedData SKU families. |
-| `skuTier` | string | `Standard` | `[Standard, Premium]` | Required. Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers. |
+| `skuTier` | string | `Standard` | `[Local, Standard, Premium]` | Required. Chosen SKU Tier of ExpressRoute circuit. Choose from Local, Premium or Standard SKU tiers. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `vlanId` | int |  |  | Optional. Specifies the identifier that is used to identify the customer. |
 | `workspaceId` | string |  |  | Optional. Resource identifier of Log Analytics. |


### PR DESCRIPTION
# Change

Added Local to list of allowed tiers on expressRouteCircuits skuTier parameters. Could not choose Local when testing this module locally ( #357 ). This change adds the possibility for setting Local as a Sku Tier.

Also added some logic on the skuFamily property, because Local setting only allows Unlimited data.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
