### PR TITLE
Change vpnSharedKey param not Required Parameter

### DIFF
--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -1,7 +1,7 @@
 @description('Required. Remote connection name')
 param connectionName string
 
-@description('Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
+@description('Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
 param vpnSharedKey string 
 
 @description('Required. Specifies the remote Virtual Network Gateway/ExpressRoute')

--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -1,8 +1,8 @@
 @description('Required. Remote connection name')
 param connectionName string
 
-@description('Required. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
-param vpnSharedKey string
+@description('Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
+param vpnSharedKey string 
 
 @description('Required. Specifies the remote Virtual Network Gateway/ExpressRoute')
 param remoteEntityName string
@@ -107,7 +107,7 @@ resource connection 'Microsoft.Network/connections@2021-02-01' = {
     enableBgp: enableBgp
     connectionType: virtualNetworkGatewayConnectionType
     routingWeight: routingWeight
-    sharedKey: vpnSharedKey
+    sharedKey: ((virtualNetworkGatewayConnectionType == 'ExpressRoute') ? vpnSharedKey : json('null'))
     usePolicyBasedTrafficSelectors: usePolicyBasedTrafficSelectors
     ipsecPolicies: (empty(customIPSecPolicy.ipsecEncryption) ? customIPSecPolicy.ipsecEncryption : customIPSecPolicy_var)
   }

--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -2,7 +2,7 @@
 param connectionName string
 
 @description('Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
-param vpnSharedKey string 
+param vpnSharedKey string
 
 @description('Required. Specifies the remote Virtual Network Gateway/ExpressRoute')
 param remoteEntityName string

--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -107,7 +107,7 @@ resource connection 'Microsoft.Network/connections@2021-02-01' = {
     enableBgp: enableBgp
     connectionType: virtualNetworkGatewayConnectionType
     routingWeight: routingWeight
-    sharedKey: ((virtualNetworkGatewayConnectionType == 'ExpressRoute') ? vpnSharedKey : json('null'))
+    sharedKey: virtualNetworkGatewayConnectionType == 'ExpressRoute' ? vpnSharedKey : null
     usePolicyBasedTrafficSelectors: usePolicyBasedTrafficSelectors
     ipsecPolicies: (empty(customIPSecPolicy.ipsecEncryption) ? customIPSecPolicy.ipsecEncryption : customIPSecPolicy_var)
   }

--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -2,7 +2,7 @@
 param connectionName string
 
 @description('Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways')
-param vpnSharedKey string
+param vpnSharedKey string  = ''
 
 @description('Required. Specifies the remote Virtual Network Gateway/ExpressRoute')
 param remoteEntityName string

--- a/arm/Microsoft.Network/connections/readme.md
+++ b/arm/Microsoft.Network/connections/readme.md
@@ -27,7 +27,7 @@ This template deploys Virtual Network Gateway Connection.
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `usePolicyBasedTrafficSelectors` | bool |  |  | Optional. Enable policy-based traffic selectors |
 | `virtualNetworkGatewayConnectionType` | string | `Ipsec` | `[Ipsec, VNet2VNet, ExpressRoute, VPNClient]` | Optional. Gateway connection type. |
-| `vpnSharedKey` | string |  |  | Required. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways |
+| `vpnSharedKey` | string |  |  | Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways |
 
 ### Parameter Usage: `customIPSecPolicy`
 


### PR DESCRIPTION
Changes the vpnSharedKey to a non-required parameter since its not needed with Express Route Connections

# Change

***Feel free to remove this sample text***
>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
