### PR TITLE
Disable MD034 Bare URLs rule + order settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,11 @@
     "editor.insertSpaces": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
+    "markdown.extension.orderedList.marker": "one",
+    "markdown.extension.tableFormatter.enabled": false,
+    "markdownlint.config": {
+        "MD034": true
+    },
     "powershell.codeFormatting.autoCorrectAliases": true,
     "powershell.codeFormatting.newLineAfterCloseBrace": false,
     "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
@@ -28,14 +33,13 @@
     "powershell.codeFormatting.useConstantStrings": true,
     "powershell.codeFormatting.useCorrectCasing": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
-    "yaml.format.singleQuote": true,
-    "markdown.extension.tableFormatter.enabled": false,
-    "spellright.language": [
-        "en"
-    ],
     "spellright.documentTypes": [
         "markdown",
         "latex",
         "plaintext"
-    ]
+    ],
+    "spellright.language": [
+        "en"
+    ],
+    "yaml.format.singleQuote": true
 }


### PR DESCRIPTION
# Change

Adding config in VScode to ignore bare URLs.

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034---bare-url-used

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
