### PR TITLE
Hotfix for Azure Policy Exemptions. Updated Policy Assignment ID and extended date

### DIFF
--- a/arm/Microsoft.Authorization/policyExemptions/.parameters/parameters.json
+++ b/arm/Microsoft.Authorization/policyExemptions/.parameters/parameters.json
@@ -9,7 +9,7 @@
             "value": "[Test] policy exempt"
         },
         "policyAssignmentId": {
-            "value": "/subscriptions/<<subscriptionId>>/providers/Microsoft.Authorization/policyAssignments/Addatagtoresources"
+            "value": "/subscriptions/<<subscriptionId>>/providers/Microsoft.Authorization/policyAssignments/Add-a-tag-to-resources"
         },
         "exemptionCategory": {
             "value": "Waiver"
@@ -20,7 +20,7 @@
             }
         },
         "expiresOn": {
-            "value": "2023-10-02T03:57:00.000Z"
+            "value": "2025-10-02T03:57:00.000Z"
         },
         "subscriptionId": {
             "value": "<<subscriptionId>>"


### PR DESCRIPTION
# Change

- Updated Policy Assignment ID. Previous ID was available on the IACS Sandbox. But now aligning to the ID that gets produced from the 'Policy Assignment' workflow.
- Extended Expiry Date

[![Authorization: policyExemptions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml/badge.svg?branch=hotfix%2Fusers%2Fahmad%2FpolicyExemptions)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
