### PR TITLE
Removed description from Outputs

### DIFF
--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/deploy.bicep
@@ -52,11 +52,11 @@ module container_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   }
 }]
 
-@description('The name of the deployed container')
+
 output containerName string = container.name
 
-@description('The ID of the deployed container')
+
 output containerResourceId string = container.id
 
-@description('The resource group of the deployed container')
+
 output containerResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
@@ -27,11 +27,11 @@ resource immutabilityPolicy 'Microsoft.Storage/storageAccounts/blobServices/cont
   }
 }
 
-@description('The name of the deployed immutability policy.')
+
 output immutabilityPolicyName string = immutabilityPolicy.name
 
-@description('The id of the deployed immutability policy.')
+
 output immutabilityPolicyResourceId string = immutabilityPolicy.id
 
-@description('The resource group of the deployed immutability policy.')
+
 output immutabilityPolicyResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/deploy.bicep
@@ -47,11 +47,10 @@ module blobServices_container 'containers/deploy.bicep' = [for (container, index
   ]
 }]
 
-@description('The name of the deployed blob service')
 output blobServiceName string = blobServices.name
 
-@description('The id of the deployed blob service')
+
 output blobServiceResourceId string = blobServices.id
 
-@description('The name of the deployed blob service')
+
 output blobServiceResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -279,17 +279,15 @@ module storageAccount_tableServices 'tableServices/deploy.bicep' = if (!empty(ta
   }
 }
 
-@description('The resource Id of the deployed storage account')
+
 output storageAccountResourceId string = storageAccount.id
 
-@description('The name of the deployed storage account')
+
 output storageAccountName string = storageAccount.name
 
-@description('The resource group of the deployed storage account')
+
 output storageAccountResourceGroup string = resourceGroup().name
 
-@description('The primary blob endpoint reference if blob services are deployed.')
 output storageAccountPrimaryBlobEndpoint string = (!empty(blobServices) && contains(storageAccount_blobService, 'blobContainers')) ? '' : reference('Microsoft.Storage/storageAccounts/${storageAccount.name}', '2019-04-01').primaryEndpoints.blob
 
-@description('The resource id of the assigned identity, if any')
 output assignedIdentityID string = (contains(managedServiceIdentity, 'SystemAssigned') ? reference(storageAccount.id, '2019-06-01', 'full').identity.principalId : '')

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
@@ -43,11 +43,11 @@ module fileService_shares 'shares/deploy.bicep' = [for (share, index) in shares:
   ]
 }]
 
-@description('The name of the deployed file share service')
+
 output fileServiceName string = fileService.name
 
-@description('The id of the deployed file share service')
+
 output fileServiceResourceId string = fileService.id
 
-@description('The resource group of the deployed file share service')
+
 output fileServiceResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
@@ -34,11 +34,11 @@ module fileShare_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   }
 }]
 
-@description('The name of the deployed file share')
+
 output fileShareName string = fileShare.name
 
-@description('The id of the deployed file share')
+
 output fileShareResourceId string = fileShare.id
 
-@description('The resource group of the deployed file share')
+
 output fileShareResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/deploy.bicep
@@ -31,11 +31,11 @@ module queueService_queues 'queues/deploy.bicep' = [for (queue, index) in queues
   ]
 }]
 
-@description('The name of the deployed file share service')
+
 output queueServiceName string = queueService.name
 
-@description('The id of the deployed file share service')
+
 output queueServiceResourceId string = queueService.id
 
-@description('The resource group of the deployed file share service')
+
 output queueServiceResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
@@ -34,11 +34,11 @@ module queue_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   }
 }]
 
-@description('The name of the deployed queue')
+
 output queueName string = queue.name
 
-@description('The ID of the deployed queue')
+
 output queueResourceId string = queue.id
 
-@description('The resource group of the deployed queue')
+
 output queueResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/tableServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/tableServices/deploy.bicep
@@ -29,11 +29,10 @@ module tableService_tables 'tables/deploy.bicep' = [for (tableName, index) in ta
   ]
 }]
 
-@description('The name of the deployed table service')
+
 output tableServiceName string = tableService.name
 
-@description('The id of the deployed table service')
+
 output tableServiceResourceId string = tableService.id
 
-@description('The resource group of the deployed table service')
 output tableServiceResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/tableServices/tables/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/tableServices/tables/deploy.bicep
@@ -17,11 +17,9 @@ resource table 'Microsoft.Storage/storageAccounts/tableServices/tables@2021-06-0
   name: '${storageAccountName}/default/${name}'
 }
 
-@description('The name of the deployed file share service')
+
 output tableName string = table.name
 
-@description('The id of the deployed file share service')
 output tableResourceId string = table.id
 
-@description('The resource group of the deployed file share service')
 output tableResourceGroup string = resourceGroup().name


### PR DESCRIPTION
Removed description from Output parameters, that were causing Errors "Error BCP129: Function "description" cannot be used as an output decorator."

# Change

***Feel free to remove this sample text***
>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
