### PR TITLE
Fixed a missing child-structure-update for storage

### DIFF
--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
@@ -33,24 +33,23 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
 
     resource container 'containers@2019-06-01' existing = {
       name: containerName
+
+      resource immutabilityPolicy 'immutabilityPolicies@2019-06-01' = {
+        name: name
+        properties: {
+          immutabilityPeriodSinceCreationInDays: immutabilityPeriodSinceCreationInDays
+          allowProtectedAppendWrites: allowProtectedAppendWrites
+        }
+      }
     }
   }
 }
 
-resource immutabilityPolicy 'Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@2019-06-01' = {
-  name: name
-  parent: storageAccount::blobServices::container
-  properties: {
-    immutabilityPeriodSinceCreationInDays: immutabilityPeriodSinceCreationInDays
-    allowProtectedAppendWrites: allowProtectedAppendWrites
-  }
-}
-
 @description('The name of the deployed immutability policy.')
-output immutabilityPolicyName string = immutabilityPolicy.name
+output immutabilityPolicyName string = storageAccount::blobServices::container::immutabilityPolicy.name
 
 @description('The id of the deployed immutability policy.')
-output immutabilityPolicyResourceId string = immutabilityPolicy.id
+output immutabilityPolicyResourceId string = storageAccount::blobServices::container::immutabilityPolicy.id
 
 @description('The resource group of the deployed immutability policy.')
 output immutabilityPolicyResourceGroup string = resourceGroup().name


### PR DESCRIPTION
# Change

- Fixed a missing child-structure-update for storage

Pipeline reference:
[![Storage: Storage Account](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2FstorageFollowUp&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)