### PR TITLE
Re-write of Microsoft.Insights/schedulequeryrules

### DIFF
--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -23,7 +23,7 @@
             "value": "PT5M"
         },
         "queryTimeRange": {
-            "value": "PT25M"
+            "value": "5"
         },
         "criterias": {
             "value": {

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -24,7 +24,7 @@
         },
         "queryTimeRange": {
             "value": "PT25M"
-        }
+        },
         "criterias": {
             "value": {
                 "allOf": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -5,23 +5,49 @@
         "alertName": {
             "value": "myAlert01"
         },
+        "alertDescription": {
+            "value": "My sample Alert"
+        },
         "workspaceResourceId": {
             "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-la-x-001"
         },
-        "query": {
-            "value": "Perf | where ObjectName == \"LogicalDisk\" | where CounterName == \"% Free Space\" | where InstanceName <> \"HarddiskVolume1\" and InstanceName <> \"_Total\" | summarize AggregatedValue = min(CounterValue) by Computer, InstanceName, bin(TimeGenerated,5m)"
+        "evaluationFrequency": {
+            "value": "PT5M"
         },
-        "breachesThresholdOperator": {
-            "value": "LessThan"
+        "windowSize": {
+            "value": "PT5M"
         },
-        "metricColumn": {
-            "value": "Computer,InstanceName"
+        "suppressForMinutes": {
+            "value": "PT5M"
         },
-        "breachesTriggerType": {
-            "value": "Total"
-        },
-        "breachesThreshold": {
-            "value": 3
+        "criterias": {
+            "value": {
+                "allOf": [
+                    {
+                        "query": "Perf | where ObjectName == \"LogicalDisk\" | where CounterName == \"% Free Space\" | where InstanceName <> \"HarddiskVolume1\" and InstanceName <> \"_Total\" | summarize AggregatedValue = min(CounterValue) by Computer, InstanceName, bin(TimeGenerated,5m)",
+                        "timeAggregation": "Average",
+                        "metricMeasureColumn": "AggregatedValue",
+                        "dimensions": [
+                            {
+                                "name": "Computer",
+                                "operator": "Include",
+                                "values": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "name": "InstanceName",
+                                "operator": "Include",
+                                "values": [
+                                    "*"
+                                ]
+                            }
+                        ],
+                        "operator": "GreaterThan",
+                        "threshold": 0
+                    }
+                ]
+            }
         },
         "roleAssignments": {
             "value": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -22,6 +22,9 @@
         "suppressForMinutes": {
             "value": "PT5M"
         },
+        "queryTimeRange": {
+            "value": "PT25M"
+        }
         "criterias": {
             "value": {
                 "allOf": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -22,6 +22,9 @@
         "suppressForMinutes": {
             "value": "PT5M"
         },
+        "queryTimeRange": {
+            "value": "PT5M"
+        },
         "criterias": {
             "value": {
                 "allOf": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -8,8 +8,10 @@
         "alertDescription": {
             "value": "My sample Alert"
         },
-        "workspaceResourceId": {
-            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-la-x-001"
+        "scopes": {
+            "value": [
+                "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-la-x-001"
+            ]
         },
         "evaluationFrequency": {
             "value": "PT5M"

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -25,6 +25,9 @@
         "queryTimeRange": {
             "value": "PT5M"
         },
+        "autoMitigate": {
+            "value": false
+        },
         "criterias": {
             "value": {
                 "allOf": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.parameters/parameters.json
@@ -22,9 +22,6 @@
         "suppressForMinutes": {
             "value": "PT5M"
         },
-        "queryTimeRange": {
-            "value": "5"
-        },
         "criterias": {
             "value": {
                 "allOf": [

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -4,10 +4,10 @@ param alertName string
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Optional. Description of the alert.')
+@description('Optional. The description of the scheduled query rule.')
 param alertDescription string = ''
 
-@description('Optional. Indicates whether this alert is enabled.')
+@description('Optional. The flag which indicates whether this scheduled query rule is enabled.')
 param enabled bool = true
 
 @description('Optional. Indicates the type of scheduled query rule.')
@@ -26,15 +26,16 @@ param queryTimeRange string = 'WindowSize*NumberOfEvaluationPeriods'
 @description('Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert.')
 param skipQueryValidation bool = false
 
+@description('Optional. List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert')
 param targetResourceTypes array = []
 
 @description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'')
 param roleAssignments array = []
 
-@description('Required. Resource ID of the Log Analytics workspace where the query needs to be executed')
-param workspaceResourceId string
+@description('Required. The list of resource IDs that this scheduled query rule is scoped to.')
+param scopes array = []
 
-@description('Optional. The severity of the alert.')
+@description('Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert.')
 @allowed([
   0
   1
@@ -50,7 +51,7 @@ param evaluationFrequency string = ''
 @description('Optional. The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.')
 param windowSize string = ''
 
-@description('Optional. The list of actions to take when alert triggers.')
+@description('Optional. Actions to invoke when the alert fires.')
 param actions array = []
 
 @description('Optional. The rule criteria that defines the conditions of the scheduled query rule.')
@@ -89,9 +90,7 @@ resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' 
     evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : ''
     muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : ''
     overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange: ''
-    scopes: [
-      workspaceResourceId
-    ]
+    scopes: scopes
     severity: contains(kind, 'LogAlert') ? severity : null
     skipQueryValidation: contains(kind, 'LogAlert') ? skipQueryValidation : null
     targetResourceTypes: contains(kind, 'LogAlert') ? targetResourceTypes : null

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -20,23 +20,7 @@ param kind string = 'LogAlert'
 @description('Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert.')
 param autoMitigate bool = true
 
-@description('Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert.')
-@allowed([
-  ''
-  '5'
-  '10'
-  '15'
-  '30'
-  '45'
-  '60'
-  '120'
-  '180'
-  '240'
-  '300'
-  '360'
-  '1440'
-  '2880'
-  ])
+@description('Optional. If specified (in ISO 8601 duration format) then overrides the query time range. Relevant only for rules of the kind LogAlert.')
 param queryTimeRange string = ''
 
 @description('Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert.')

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -21,6 +21,22 @@ param kind string = 'LogAlert'
 param autoMitigate bool = true
 
 @description('Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert.')
+@allowed([
+  ''
+  '5'
+  '10'
+  '15'
+  '30'
+  '45'
+  '60'
+  '120'
+  '180'
+  '240'
+  '300'
+  '360'
+  '1440'
+  '2880'
+  ])
 param queryTimeRange string = ''
 
 @description('Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert.')
@@ -89,7 +105,7 @@ resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' 
     enabled: enabled
     evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : ''
     muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : ''
-    overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange: ''
+    overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange : ''
     scopes: scopes
     severity: contains(kind, 'LogAlert') ? severity : null
     skipQueryValidation: contains(kind, 'LogAlert') ? skipQueryValidation : null
@@ -97,7 +113,6 @@ resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' 
     windowSize: contains(kind, 'LogAlert') ? windowSize : ''
   }
 }
-
 
 module queryAlert_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
   name: '${deployment().name}-rbac-${index}'

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -71,7 +71,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
-resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' = {
+resource queryRule 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' = {
   name: alertName
   location: location
   tags: tags
@@ -98,14 +98,19 @@ resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' 
   }
 }
 
-module queryAlert_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
+module queryRule_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
   name: '${deployment().name}-rbac-${index}'
   params: {
     roleAssignmentObj: roleAssignment
-    resourceName: queryAlert.name
+    resourceName: queryRule.name
   }
 }]
 
-output queryAlertName string = queryAlert.name
-output queryAlertResourceId string = queryAlert.id
+@description('The Name of the created query rule.')
+output queryAlertName string = queryRule.name
+
+@description('The ID of the created query rule.')
+output queryAlertResourceId string = queryRule.id
+
+@description('The Resource Group of the created query rule.')
 output deploymentResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -21,7 +21,7 @@ param kind string = 'LogAlert'
 param autoMitigate bool = true
 
 @description('Optional. If specified (in ISO 8601 duration format) then overrides the query time range. Relevant only for rules of the kind LogAlert.')
-param queryTimeRange string = ''
+param queryTimeRange string
 
 @description('Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert.')
 param skipQueryValidation bool = false
@@ -49,7 +49,7 @@ param severity int = 3
 param evaluationFrequency string = ''
 
 @description('Optional. The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert.')
-param windowSize string = ''
+param windowSize string
 
 @description('Optional. Actions to invoke when the alert fires.')
 param actions array = []
@@ -87,14 +87,14 @@ resource queryAlert 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' 
     description: alertDescription
     displayName: alertName
     enabled: enabled
-    evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : ''
-    muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : ''
-    overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange : ''
+    evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : null
+    muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : null
+    overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange : null
     scopes: scopes
     severity: contains(kind, 'LogAlert') ? severity : null
     skipQueryValidation: contains(kind, 'LogAlert') ? skipQueryValidation : null
     targetResourceTypes: contains(kind, 'LogAlert') ? targetResourceTypes : null
-    windowSize: contains(kind, 'LogAlert') ? windowSize : ''
+    windowSize: contains(kind, 'LogAlert') ? windowSize : null
   }
 }
 

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -57,7 +57,7 @@ param actions array = []
 @description('Optional. The rule criteria that defines the conditions of the scheduled query rule.')
 param criterias object = {}
 
-@description('Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. Relevant only for rules of the kind LogAlert.')
+@description('Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. If set, autoMitigate must be disabled.Relevant only for rules of the kind LogAlert.')
 param suppressForMinutes string = ''
 
 @description('Optional. Tags of the resource.')

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -81,20 +81,20 @@ resource queryRule 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' =
       actionGroups: actions
       customProperties: {}
     }
-    autoMitigate: contains(kind, 'LogAlert') ? autoMitigate : null
+    autoMitigate: (kind == 'LogAlert') ? autoMitigate : null
     criteria: criterias
 
     description: alertDescription
     displayName: name
     enabled: enabled
-    evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : null
-    muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : null
-    overrideQueryTimeRange: contains(kind, 'LogAlert') ? queryTimeRange : null
+    evaluationFrequency: (kind == 'LogAlert') ? evaluationFrequency : null
+    muteActionsDuration: (kind == 'LogAlert') ? suppressForMinutes : null
+    overrideQueryTimeRange: (kind == 'LogAlert') ? queryTimeRange : null
     scopes: scopes
-    severity: contains(kind, 'LogAlert') ? severity : null
-    skipQueryValidation: contains(kind, 'LogAlert') ? skipQueryValidation : null
-    targetResourceTypes: contains(kind, 'LogAlert') ? targetResourceTypes : null
-    windowSize: contains(kind, 'LogAlert') ? windowSize : null
+    severity: (kind == 'LogAlert') ? severity : null
+    skipQueryValidation: (kind == 'LogAlert') ? skipQueryValidation : null
+    targetResourceTypes: (kind == 'LogAlert') ? targetResourceTypes : null
+    windowSize: (kind == 'LogAlert') ? windowSize : null
   }
 }
 

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -63,7 +63,7 @@ param suppressForMinutes string = ''
 @description('Optional. Tags of the resource.')
 param tags object = {}
 
-@description('Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered')
+@description('Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered')
 param cuaId string = ''
 
 module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the Alert.')
-param alertName string
+param name string
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -72,7 +72,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource queryRule 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' = {
-  name: alertName
+  name: name
   location: location
   tags: tags
   kind: kind
@@ -85,7 +85,7 @@ resource queryRule 'Microsoft.Insights/scheduledQueryRules@2021-02-01-preview' =
     criteria: criterias
 
     description: alertDescription
-    displayName: alertName
+    displayName: name
     enabled: enabled
     evaluationFrequency: contains(kind, 'LogAlert') ? evaluationFrequency : null
     muteActionsDuration: contains(kind, 'LogAlert') ? suppressForMinutes : null

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -53,8 +53,8 @@ param windowSize string = ''
 @description('Optional. The list of actions to take when alert triggers.')
 param actions array = []
 
-@description('Optional. The list of action alert creterias.')
-param criterias array = []
+@description('Optional. The rule criteria that defines the conditions of the scheduled query rule.')
+param criterias object = {}
 
 @description('Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. Relevant only for rules of the kind LogAlert.')
 param suppressForMinutes string = ''

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -21,7 +21,7 @@ param kind string = 'LogAlert'
 param autoMitigate bool = true
 
 @description('Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert.')
-param queryTimeRange string = 'WindowSize*NumberOfEvaluationPeriods'
+param queryTimeRange string = ''
 
 @description('Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert.')
 param skipQueryValidation bool = false

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -23,7 +23,7 @@ This module deploys an Alert based on metrics
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `queryTimeRange` | string |  |  | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
+| `queryTimeRange` | string |  | `[, 5, 10, 15, 30, 45, 60, 120, 180, 240, 300, 360, 1440, 2880]` | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |
 | `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -28,7 +28,7 @@ This module deploys an Alert based on metrics
 | `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |
 | `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert. |
 | `skipQueryValidation` | bool |  |  | Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert. |
-| `suppressForMinutes` | string |  |  | Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. Relevant only for rules of the kind LogAlert. |
+| `suppressForMinutes` | string |  |  | Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. If set, autoMitigate must be disabled.Relevant only for rules of the kind LogAlert. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `targetResourceTypes` | array | `[]` |  | Optional. List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert |
 | `windowSize` | string |  |  | Optional. The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -18,7 +18,7 @@ This module deploys an Alert based on metrics
 | `alertName` | string |  |  | Required. The name of the Alert. |
 | `autoMitigate` | bool | `True` |  | Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert. |
 | `criterias` | object | `{object}` |  | Optional. The rule criteria that defines the conditions of the scheduled query rule. |
-| `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `enabled` | bool | `True` |  | Optional. The flag which indicates whether this scheduled query rule is enabled. |
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -4,7 +4,7 @@ This module deploys an Alert based on metrics
 
 ## Resource types
 
-| Resource Type | API Version |
+| Resource Type | Api Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
 | `Microsoft.Insights/scheduledQueryRules` | 2021-02-01-preview |
@@ -18,7 +18,7 @@ This module deploys an Alert based on metrics
 | `alertName` | string |  |  | Required. The name of the Alert. |
 | `autoMitigate` | bool | `True` |  | Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert. |
 | `criterias` | object | `{object}` |  | Optional. The rule criteria that defines the conditions of the scheduled query rule. |
-| `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
+| `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `enabled` | bool | `True` |  | Optional. The flag which indicates whether this scheduled query rule is enabled. |
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
@@ -81,11 +81,11 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `deploymentResourceGroup` | string |
-| `queryAlertName` | string |
-| `queryAlertResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `deploymentResourceGroup` | string | The Resource Group of the created query rule. |
+| `queryAlertName` | string | The Name of the created query rule. |
+| `queryAlertResourceId` | string | The ID of the created query rule. |
 
 ## Template references
 

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -4,7 +4,7 @@ This module deploys an Alert based on metrics
 
 ## Resource types
 
-| Resource Type | Api Version |
+| Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
 | `Microsoft.Insights/scheduledQueryRules` | 2021-02-01-preview |
@@ -15,7 +15,6 @@ This module deploys an Alert based on metrics
 | :-- | :-- | :-- | :-- | :-- |
 | `actions` | array | `[]` |  | Optional. Actions to invoke when the alert fires. |
 | `alertDescription` | string |  |  | Optional. The description of the scheduled query rule. |
-| `alertName` | string |  |  | Required. The name of the Alert. |
 | `autoMitigate` | bool | `True` |  | Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert. |
 | `criterias` | object | `{object}` |  | Optional. The rule criteria that defines the conditions of the scheduled query rule. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
@@ -23,6 +22,7 @@ This module deploys an Alert based on metrics
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
+| `name` | string |  |  | Required. The name of the Alert. |
 | `queryTimeRange` | string |  |  | Optional. If specified (in ISO 8601 duration format) then overrides the query time range. Relevant only for rules of the kind LogAlert. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -4,7 +4,7 @@ This module deploys an Alert based on metrics
 
 ## Resource types
 
-| Resource Type | Api Version |
+| Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
 | `Microsoft.Insights/scheduledQueryRules` | 2021-02-01-preview |
@@ -18,7 +18,7 @@ This module deploys an Alert based on metrics
 | `alertName` | string |  |  | Required. The name of the Alert. |
 | `autoMitigate` | bool | `True` |  | Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert. |
 | `criterias` | object | `{object}` |  | Optional. The rule criteria that defines the conditions of the scheduled query rule. |
-| `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `enabled` | bool | `True` |  | Optional. The flag which indicates whether this scheduled query rule is enabled. |
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -23,7 +23,7 @@ This module deploys an Alert based on metrics
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `queryTimeRange` | string |  | `[, 5, 10, 15, 30, 45, 60, 120, 180, 240, 300, 360, 1440, 2880]` | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
+| `queryTimeRange` | string |  |  | Optional. If specified (in ISO 8601 duration format) then overrides the query time range. Relevant only for rules of the kind LogAlert. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |
 | `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -23,7 +23,7 @@ This module deploys an Alert based on metrics
 | `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
 | `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `queryTimeRange` | string | `WindowSize*NumberOfEvaluationPeriods` |  | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
+| `queryTimeRange` | string |  |  | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |
 | `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert. |

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -7,35 +7,31 @@ This module deploys an Alert based on metrics
 | Resource Type | Api Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
-| `Microsoft.Insights/scheduledQueryRules` | 2018-04-16 |
+| `Microsoft.Insights/scheduledQueryRules` | 2021-02-01-preview |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `actions` | array | `[]` |  | Optional. The list of actions to take when alert triggers. |
-| `alertDescription` | string |  |  | Optional. Description of the alert. |
+| `actions` | array | `[]` |  | Optional. Actions to invoke when the alert fires. |
+| `alertDescription` | string |  |  | Optional. The description of the scheduled query rule. |
 | `alertName` | string |  |  | Required. The name of the Alert. |
-| `authorizedResources` | array | `[]` |  | Optional. The list of resource id's referenced in the query. |
-| `breachesThreshold` | int | `3` |  | Optional. Number of threadshold violation to trigger the alert |
-| `breachesThresholdOperator` | string | `GreaterThan` | `[GreaterThan, Equal, LessThan]` | Optional. If `metricColumn` is specified, operator for the breaches count evaluation to trigger the alert. Not used if using result count trigger. |
-| `breachesTriggerType` | string | `Consecutive` | `[Consecutive, Total]` | Optional. Type of aggregation of threadshold violation |
-| `criterias` | array | `[]` |  | Optional. The list of action alert creterias. |
+| `autoMitigate` | bool | `True` |  | Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert. |
+| `criterias` | object | `{object}` |  | Optional. The rule criteria that defines the conditions of the scheduled query rule. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
-| `enabled` | string | `true` | `[true, false]` | Optional. Indicates whether this alert is enabled. |
-| `evaluationFrequency` | int | `5` | `[5, 10, 15, 30, 45, 60, 120, 180, 240, 300, 360, 1440]` | Optional. How often the metric alert is evaluated (in minutes). |
+| `enabled` | bool | `True` |  | Optional. The flag which indicates whether this scheduled query rule is enabled. |
+| `evaluationFrequency` | string |  |  | Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert. |
+| `kind` | string | `LogAlert` | `[LogAlert, LogToMetric]` | Optional. Indicates the type of scheduled query rule. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `metricColumn` | string |  |  | Optional. Variable (column) on which the query result will be grouped and then evaluated for trigger condition. Use comma to specify more than one. Leave empty to use "Number of results" type of alert logic |
-| `metricResultCountThreshold` | int |  |  | Optional. Operator for metric or number of result evaluation. |
-| `metricResultCountThresholdOperator` | string | `GreaterThan` | `[GreaterThan, Equal, LessThan]` | Optional. Operator of threshold breaches to trigger the alert. |
-| `odataType` | string | `AlertingAction` | `[AlertingAction, LogToMetricAction]` | Optional. Type of the alert criteria. |
-| `query` | string |  |  | Optional. The query to execute |
+| `queryTimeRange` | string | `WindowSize*NumberOfEvaluationPeriods` |  | Optional. If specified then overrides the query time range. Relevant only for rules of the kind LogAlert. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
-| `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. The severity of the alert. |
-| `suppressForMinutes` | int |  |  | Optional. Suppress Alert for (in minutes). |
+| `scopes` | array | `[]` |  | Required. The list of resource IDs that this scheduled query rule is scoped to. |
+| `severity` | int | `3` | `[0, 1, 2, 3, 4]` | Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert. |
+| `skipQueryValidation` | bool |  |  | Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert. |
+| `suppressForMinutes` | string |  |  | Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. Relevant only for rules of the kind LogAlert. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
-| `windowSize` | int | `60` | `[5, 10, 15, 30, 45, 60, 120, 180, 240, 300, 360, 1440, 2880]` | Optional. The period of time (in minutes) that is used to monitor alert activity based on the threshold. |
-| `workspaceResourceId` | string |  |  | Required. Resource ID of the Log Analytics workspace where the query needs to be executed |
+| `targetResourceTypes` | array | `[]` |  | Optional. List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert |
+| `windowSize` | string |  |  | Optional. The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert. |
 
 ### Parameter Usage: `roleAssignments`
 
@@ -94,4 +90,4 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 ## Template references
 
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-04-01-preview/roleAssignments)
-- [Scheduledqueryrules](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2018-04-16/scheduledQueryRules)
+- [Scheduledqueryrules](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-02-01-preview/scheduledQueryRules)


### PR DESCRIPTION
# Change

Primary goal was to update the api-version from 2018-04-16 to a newer one.
But since the newer api-versions change the complete structure of the resource, a rewrite was necessary.

Successful sample deployment: https://github.com/Azure/ResourceModules/actions/runs/1482016915

For comparison, the old api documentation...
https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/2018-04-16/scheduledqueryrules?tabs=bicep

... and the new one:
https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/2021-02-01-preview/scheduledqueryrules?tabs=bicep

FYI: I have used api version 2021-02-01-preview and not 2021-08-01 as the latter one is not yet supported by the bicep linter in vscode.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
