### PR TITLE
Hotfix - Private DNS Zone Name was using Token

### DIFF
--- a/arm/Microsoft.Network/privateDnsZones/.parameters/parameters.json
+++ b/arm/Microsoft.Network/privateDnsZones/.parameters/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>.az-privdns-x-001"
+            "value": "sxx.az-privdns-x-001"
         },
         "roleAssignments": {
             "value": [
@@ -18,7 +18,7 @@
         "virtualNetworkLinks": {
             "value": [
                 {
-                    "virtualNetworkId": "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001",
+                    "virtualNetworkId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-sxx-az-vnet-x-001",
                     "registrationEnabled": true
                 }
             ]


### PR DESCRIPTION
# Change

There is a single file that still uses the `<<namePrefix>>` token that we removed. Maybe it came in after the token rollout got merged, or maybe it got missed.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

> Note if the pipeline is failing, that is due to the 'removeModule' step

[![Network: Privatednszones](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatednszones.yml/badge.svg?branch=users%2Fahmad%2FhotFixDnsZone)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatednszones.yml)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
