### PR TITLE
Refactored RSV to use `existing`

### DIFF
--- a/arm/Microsoft.RecoveryServices/vaults/backupPolicies/deploy.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/backupPolicies/deploy.bicep
@@ -16,16 +16,21 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource rsv 'Microsoft.RecoveryServices/vaults@2021-08-01' existing = {
+  name: recoveryVaultName
+}
+
 resource backupPolicy 'Microsoft.RecoveryServices/vaults/backupPolicies@2021-08-01' = {
-  name: '${recoveryVaultName}/${name}'
+  name: name
+  parent: rsv
   properties: backupPolicyProperties
 }
 
 @description('The name of the backup policy')
 output backupPolicyName string = backupPolicy.name
 
-@description('The ResourceId of the backup policy')
-output backupPolicyId string = backupPolicy.id
+@description('The Resource ID of the backup policy')
+output backupPolicyResourceId string = backupPolicy.id
 
 @description('The name of the Resource Group the backup policy was created in.')
 output backupPolicyResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.RecoveryServices/vaults/backupPolicies/readme.md
+++ b/arm/Microsoft.RecoveryServices/vaults/backupPolicies/readme.md
@@ -12,10 +12,10 @@ This module deploys a Backup Policy for a Recovery Services Vault
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `recoveryVaultName` | string | `` |  | Required. Name of the Azure Recovery Service Vault |
-| `name` | string | `` |  | Required. Name of the Azure Recovery Service Vault Backup Policy |
-| `backupPolicyProperties` | object | `{}` |  | Required. Configuration of the Azure Recovery Service Vault Backup Policy |
+| `backupPolicyProperties` | object |  |  | Required. Configuration of the Azure Recovery Service Vault Backup Policy |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `name` | string |  |  | Required. Name of the Azure Recovery Service Vault Backup Policy |
+| `recoveryVaultName` | string |  |  | Required. Name of the Azure Recovery Service Vault |
 
 ### Parameter Usage: `backupPolicyProperties`
 
@@ -107,12 +107,12 @@ Object continaining the configuration for backup policies. It needs to be proper
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `backupPolicyName` | string |
-| `backupPolicyId` | string |
-| `backupPolicyResourceGroup` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `backupPolicyName` | string | The name of the backup policy |
+| `backupPolicyResourceGroup` | string | The name of the Resource Group the backup policy was created in. |
+| `backupPolicyResourceId` | string | The Resource ID of the backup policy |
 
 ## Template references
 
-- [Vaults/Backuppolicies](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2019-06-15/vaults/backupPolicies)
+- [Vaults/Backuppolicies](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupPolicies)

--- a/arm/Microsoft.RecoveryServices/vaults/backupStorageConfig/deploy.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/backupStorageConfig/deploy.bicep
@@ -2,6 +2,9 @@
 @minLength(1)
 param recoveryVaultName string
 
+@description('Optional. The name of the backup storage config')
+param name string = 'vaultstorageconfig'
+
 @description('Optional. Change Vault Storage Type (Works if vault has not registered any backup instance)')
 @allowed([
   'GeoRedundant'
@@ -22,13 +25,24 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource rsv 'Microsoft.RecoveryServices/vaults@2021-08-01' existing = {
+  name: recoveryVaultName
+}
+
 resource backupStorageConfig 'Microsoft.RecoveryServices/vaults/backupstorageconfig@2021-08-01' = {
-  name: '${recoveryVaultName}/vaultstorageconfig'
+  name: name
+  parent: rsv
   properties: {
     storageModelType: storageModelType
     crossRegionRestoreFlag: crossRegionRestoreFlag
   }
 }
+
+@description('The name of the backup storage config')
+output backupStorageConfigName string = backupStorageConfig.name
+
+@description('The resource ID of the backup storage config')
+output backupStorageConfigResourceId string = backupStorageConfig.id
 
 @description('The name of the Resource Group the backup storage configuration was created in.')
 output backupStorageConfigResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.RecoveryServices/vaults/backupStorageConfig/readme.md
+++ b/arm/Microsoft.RecoveryServices/vaults/backupStorageConfig/readme.md
@@ -11,18 +11,21 @@ This module deploys the Backup Storage Configuration for the Recovery Service Va
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `recoveryVaultName` | string | `` |  | Required. Name of the Azure Recovery Service Vault |
-| `storageModelType` | string | `GeoRedundant` | `[LocallyRedundant, GeoRedundant, ReadAccessGeoZoneRedundant, ZoneRedundant]` | Optional. Change Vault Storage Type (Works if vault has not registered any backup instance) |
-| `crossRegionRestoreFlag` | bool | `True` |  | Optional. Opt in details of Cross Region Restore feature. |
+| `crossRegionRestoreFlag` | bool | `True` |  | Optional. Opt in details of Cross Region Restore feature |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `name` | string | `vaultstorageconfig` |  | Optional. The name of the backup storage config |
+| `recoveryVaultName` | string |  |  | Required. Name of the Azure Recovery Service Vault |
+| `storageModelType` | string | `GeoRedundant` | `[GeoRedundant, LocallyRedundant, ReadAccessGeoZoneRedundant, ZoneRedundant]` | Optional. Change Vault Storage Type (Works if vault has not registered any backup instance) |
 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `backupStorageConfigResourceGroup` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `backupStorageConfigName` | string | The name of the backup storage config |
+| `backupStorageConfigResourceGroup` | string | The name of the Resource Group the backup storage configuration was created in. |
+| `backupStorageConfigResourceId` | string | The resource ID of the backup storage config |
 
 ## Template references
 
-- [Vaults/Backupstorageconfig](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2020-02-02/vaults/backupstorageconfig)
+- [Vaults/Backupstorageconfig](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupstorageconfig)

--- a/arm/Microsoft.RecoveryServices/vaults/deploy.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/deploy.bicep
@@ -160,7 +160,7 @@ resource rsv_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock != 'NotS
   name: '${rsv.name}-${lock}-lock'
   properties: {
     level: lock
-    notes: (lock == 'CanNotDelete') ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
+    notes: lock == 'CanNotDelete' ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
   }
   scope: rsv
 }
@@ -168,12 +168,12 @@ resource rsv_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock != 'NotS
 resource rsv_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if ((!empty(diagnosticStorageAccountId)) || (!empty(workspaceId)) || (!empty(eventHubAuthorizationRuleId)) || (!empty(eventHubName))) {
   name: '${rsv.name}-diagnosticSettings'
   properties: {
-    storageAccountId: (empty(diagnosticStorageAccountId) ? null : diagnosticStorageAccountId)
-    workspaceId: (empty(workspaceId) ? null : workspaceId)
-    eventHubAuthorizationRuleId: (empty(eventHubAuthorizationRuleId) ? null : eventHubAuthorizationRuleId)
-    eventHubName: (empty(eventHubName) ? null : eventHubName)
-    metrics: ((empty(diagnosticStorageAccountId) && empty(workspaceId) && empty(eventHubAuthorizationRuleId) && empty(eventHubName)) ? null : diagnosticsMetrics)
-    logs: ((empty(diagnosticStorageAccountId) && empty(workspaceId) && empty(eventHubAuthorizationRuleId) && empty(eventHubName)) ? null : diagnosticsLogs)
+    storageAccountId: empty(diagnosticStorageAccountId) ? null : diagnosticStorageAccountId
+    workspaceId: empty(workspaceId) ? null : workspaceId
+    eventHubAuthorizationRuleId: empty(eventHubAuthorizationRuleId) ? null : eventHubAuthorizationRuleId
+    eventHubName: empty(eventHubName) ? null : eventHubName
+    metrics: (empty(diagnosticStorageAccountId) && empty(workspaceId) && empty(eventHubAuthorizationRuleId) && empty(eventHubName)) ? null : diagnosticsMetrics
+    logs: (empty(diagnosticStorageAccountId) && empty(workspaceId) && empty(eventHubAuthorizationRuleId) && empty(eventHubName)) ? null : diagnosticsLogs
   }
   scope: rsv
 }
@@ -187,7 +187,7 @@ module rsv_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in rol
   }
 }]
 
-@description('The ResourceId of the Recovery Services Vault')
+@description('The resource ID of the Recovery Services Vault')
 output recoveryServicesVaultResourceId string = rsv.id
 
 @description('The name of the Resource Group the Recovery Services Vault was created in')

--- a/arm/Microsoft.RecoveryServices/vaults/protectionContainers/deploy.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/protectionContainers/deploy.bicep
@@ -52,10 +52,10 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 resource protectionContainer 'Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers@2021-08-01' = {
   name: '${recoveryVaultName}/Azure/${name}'
   properties: {
-    sourceResourceId: (empty(sourceResourceId) ? null : sourceResourceId)
-    friendlyName: (empty(friendlyName) ? null : friendlyName)
-    backupManagementType: (empty(backupManagementType) ? null : backupManagementType)
-    containerType: (empty(containerType) ? null : containerType)
+    sourceResourceId: !empty(sourceResourceId) ? sourceResourceId : null
+    friendlyName: !empty(friendlyName) ? friendlyName : null
+    backupManagementType: !empty(backupManagementType) ? backupManagementType : null
+    containerType: !empty(containerType) ? containerType : null
   }
 }
 

--- a/arm/Microsoft.RecoveryServices/vaults/protectionContainers/readme.md
+++ b/arm/Microsoft.RecoveryServices/vaults/protectionContainers/readme.md
@@ -1,4 +1,4 @@
-# RecoveryServicesProtectionContainer `[Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers]`
+# RecoveryServicesProtectionContainer  `[Microsoft.RecoveryServices/vaults/protectionContainers]`
 
 This module deploys a Protection Container for a Recovery Services Vault
 
@@ -12,22 +12,22 @@ This module deploys a Protection Container for a Recovery Services Vault
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `recoveryVaultName` | string | `` |  | Required. Name of the Azure Recovery Service Vault |
-| `name` | string | `` |  | Required. Name of the Azure Recovery Service Vault Protection Container |
-| `backupManagementType` | string | `Invalid` | `[AzureBackupServer,AzureIaasVM,AzureSql,AzureStorage,AzureWorkload,DPM,DefaultBackup,Invalid,MAB]` |  Optional. Backup management type to execute the current Protection Container job. |
-| `sourceResourceId` | string | `` |  | Optional. Resource Id of the target resource for the Protection Container |
-| `friendlyName` | string | `` |  | Optional. Friendly name of the Protection Container |
-| `containerType` | string | `` | `[AzureBackupServerContainer,AzureSqlContainer,GenericContainer,Microsoft.ClassicCompute/virtualMachines,Microsoft.Compute/virtualMachines,SQLAGWorkLoadContainer,StorageContainer,VMAppContainer,Windows]` | Optional. Type of the container |
+| `backupManagementType` | string |  | `[AzureBackupServer, AzureIaasVM, AzureSql, AzureStorage, AzureWorkload, DPM, DefaultBackup, Invalid, MAB, ]` | Optional. Backup management type to execute the current Protection Container job. |
+| `containerType` | string |  | `[AzureBackupServerContainer, AzureSqlContainer, GenericContainer, Microsoft.ClassicCompute/virtualMachines, Microsoft.Compute/virtualMachines, SQLAGWorkLoadContainer, StorageContainer, VMAppContainer, Windows, ]` | Optional. Type of the container |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `friendlyName` | string |  |  | Optional. Friendly name of the Protection Container |
+| `name` | string |  |  | Required. Name of the Azure Recovery Service Vault Protection Container |
+| `recoveryVaultName` | string |  |  | Required. Name of the Azure Recovery Service Vault |
+| `sourceResourceId` | string |  |  | Optional. Resource Id of the target resource for the Protection Container  |
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `protectionContainerResourceGroup` | string |
-| `protectionContainerId` | string |
-| `protectionContainerName` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `protectionContainerId` | string | The Resource Id of the Protection Container. |
+| `protectionContainerName` | string | The Name of the Protection Container. |
+| `protectionContainerResourceGroup` | string | The name of the Resource Group the Protection Container was created in. |
 
 ## Template references
 
-- [Vaults/Protectioncontainers](https://docs.microsoft.com/en-us/azure/templates/microsoft.recoveryservices/2021-08-01/vaults/backupfabrics/protectioncontainers?tabs=bicep)
+- [Vaults/Backupfabrics/Protectioncontainers](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupFabrics/protectionContainers)

--- a/arm/Microsoft.RecoveryServices/vaults/readme.md
+++ b/arm/Microsoft.RecoveryServices/vaults/readme.md
@@ -10,16 +10,16 @@ This module deploys Recovery Service Vault, with resource lock.
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
 | `Microsoft.RecoveryServices/vaults` | 2021-08-01 |
+| `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers` | 2021-08-01 |
 | `Microsoft.RecoveryServices/vaults/backupPolicies` | 2021-08-01 |
 | `Microsoft.RecoveryServices/vaults/backupstorageconfig` | 2021-08-01 |
-| `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers` | 2021-08-01 |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `backupPolicies` | array | `[]` |  | Optional. List of all backup policies. |
-| `backupStorageConfig` | object | `{}` |  | Optional. The storage configuration for the Azure Recovery Service Vault |
+| `backupPolicies` | _[backupPolicies](backupPolicies/readme.md)_ array | `[]` |  | Optional. List of all backup policies. |
+| `backupStorageConfig` | _[backupStorageConfig](backupStorageConfig/readme.md)_ object | `{object}` |  | Optional. The storage configuration for the Azure Recovery Service Vault |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
 | `diagnosticStorageAccountId` | string |  |  | Optional. Resource identifier of the Diagnostic Storage Account. |
@@ -29,8 +29,8 @@ This module deploys Recovery Service Vault, with resource lock.
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
 | `logsToEnable` | array | `[AzureBackupReport, CoreAzureBackup, AddonAzureBackupJobs, AddonAzureBackupAlerts, AddonAzureBackupPolicy, AddonAzureBackupStorage, AddonAzureBackupProtectedInstance, AzureSiteRecoveryJobs, AzureSiteRecoveryEvents, AzureSiteRecoveryReplicatedItems, AzureSiteRecoveryReplicationStats, AzureSiteRecoveryRecoveryPoints, AzureSiteRecoveryReplicationDataUploadRate, AzureSiteRecoveryProtectedDiskDataChurn]` | `[AzureBackupReport, CoreAzureBackup, AddonAzureBackupJobs, AddonAzureBackupAlerts, AddonAzureBackupPolicy, AddonAzureBackupStorage, AddonAzureBackupProtectedInstance, AzureSiteRecoveryJobs, AzureSiteRecoveryEvents, AzureSiteRecoveryReplicatedItems, AzureSiteRecoveryReplicationStats, AzureSiteRecoveryRecoveryPoints, AzureSiteRecoveryReplicationDataUploadRate, AzureSiteRecoveryProtectedDiskDataChurn]` | Optional. The name of logs that will be streamed. |
 | `metricsToEnable` | array | `[Health]` | `[Health]` | Optional. The name of metrics that will be streamed. |
-| `protectionContainers` | array | `[]` |  | Optional. List of all protection containers. |
 | `name` | string |  |  | Required. Name of the Azure Recovery Service Vault |
+| `protectionContainers` | _[protectionContainers](protectionContainers/readme.md)_ array | `[]` |  | Optional. List of all protection containers. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Optional. Tags of the Recovery Service Vault resource. |
 | `workspaceId` | string |  |  | Optional. Resource identifier of Log Analytics. |
@@ -336,11 +336,11 @@ Array of backup policies. They need to be properly formatted and can be VM backu
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `recoveryServicesVaultName` | string |
-| `recoveryServicesVaultResourceGroup` | string |
-| `recoveryServicesVaultResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `recoveryServicesVaultName` | string | The Name of the Recovery Services Vault |
+| `recoveryServicesVaultResourceGroup` | string | The name of the Resource Group the Recovery Services Vault was created in |
+| `recoveryServicesVaultResourceId` | string | The resource ID of the Recovery Services Vault |
 
 ## Template references
 
@@ -348,6 +348,6 @@ Array of backup policies. They need to be properly formatted and can be VM backu
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-04-01-preview/roleAssignments)
 - [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
 - [Vaults](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults)
-- [Vaults/Backuppolicies](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2019-06-15/vaults/backupPolicies)
-- [Vaults/Backupstorageconfig](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2020-02-02/vaults/backupstorageconfig)
-- [Vaults/Protectioncontainers](https://docs.microsoft.com/en-us/azure/templates/microsoft.recoveryservices/2021-08-01/vaults/backupfabrics/protectioncontainers?tabs=bicep)
+- [Vaults/Backupfabrics/Protectioncontainers](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupFabrics/protectionContainers)
+- [Vaults/Backuppolicies](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupPolicies)
+- [Vaults/Backupstorageconfig](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-08-01/vaults/backupstorageconfig)


### PR DESCRIPTION
# Change

- Refactored RSV to use `existing`
- Minor structural changes
> Note: The nested backupFabric resource cannot exist on its own. Hence we cannot reference the parent

Pipeline reference
[![RecoveryServices: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml/badge.svg?branch=users%2Falsehr%2F574_rsv_child)](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
