### PR TITLE
Updated OMS to use `existing`

### DIFF
--- a/arm/Microsoft.OperationalInsights/workspaces/.parameters/min.parameters.json
+++ b/arm/Microsoft.OperationalInsights/workspaces/.parameters/min.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "logAnalyticsWorkspaceName": {
+        "name": {
             "value": "sxx-az-la-x-002"
         }
     }

--- a/arm/Microsoft.OperationalInsights/workspaces/.parameters/parameters.json
+++ b/arm/Microsoft.OperationalInsights/workspaces/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "logAnalyticsWorkspaceName": {
+        "name": {
             "value": "sxx-az-la-x-001"
         },
         "publicNetworkAccessForIngestion": {

--- a/arm/Microsoft.OperationalInsights/workspaces/dataSources/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/dataSources/deploy.bicep
@@ -61,28 +61,35 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource workspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
 resource dataSource 'Microsoft.OperationalInsights/workspaces/dataSources@2020-08-01' = {
-  name: '${logAnalyticsWorkspaceName}/${name}'
+  name: name
+  parent: workspace
   kind: kind
   tags: tags
   properties: {
-    linkedResourceId: (!empty(kind) && kind == 'AzureActivityLog') ? linkedResourceId : null
-    eventLogName: (!empty(kind) && kind == 'WindowsEvent') ? eventLogName : null
-    eventTypes: (!empty(kind) && kind == 'WindowsEvent') ? eventTypes : null
-    objectName: (!empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject')) ? objectName : null
-    instanceName: (!empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject')) ? instanceName : null
-    intervalSeconds: (!empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject')) ? intervalSeconds : null
-    counterName: (!empty(kind) && kind == 'WindowsPerformanceCounter') ? counterName : null
-    state: (!empty(kind) && (kind == 'IISLogs' || kind == 'LinuxSyslogCollection' || kind == 'LinuxPerformanceCollection')) ? state : null
-    syslogName: (!empty(kind) && kind == 'LinuxSyslog') ? syslogName : null
-    syslogSeverities: (!empty(kind) && (kind == 'LinuxSyslog' || kind == 'LinuxPerformanceObject')) ? syslogSeverities : null
-    performanceCounters: (!empty(kind) && kind == 'LinuxPerformanceObject') ? performanceCounters : null
+    linkedResourceId: !empty(kind) && kind == 'AzureActivityLog' ? linkedResourceId : null
+    eventLogName: !empty(kind) && kind == 'WindowsEvent' ? eventLogName : null
+    eventTypes: !empty(kind) && kind == 'WindowsEvent' ? eventTypes : null
+    objectName: !empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject') ? objectName : null
+    instanceName: !empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject') ? instanceName : null
+    intervalSeconds: !empty(kind) && (kind == 'WindowsPerformanceCounter' || kind == 'LinuxPerformanceObject') ? intervalSeconds : null
+    counterName: !empty(kind) && kind == 'WindowsPerformanceCounter' ? counterName : null
+    state: !empty(kind) && (kind == 'IISLogs' || kind == 'LinuxSyslogCollection' || kind == 'LinuxPerformanceCollection') ? state : null
+    syslogName: !empty(kind) && kind == 'LinuxSyslog' ? syslogName : null
+    syslogSeverities: !empty(kind) && (kind == 'LinuxSyslog' || kind == 'LinuxPerformanceObject') ? syslogSeverities : null
+    performanceCounters: !empty(kind) && kind == 'LinuxPerformanceObject' ? performanceCounters : null
   }
 }
 
-@description('The resource Id of the deployed data source')
+@description('The resource ID of the deployed data source')
 output dataSourceResourceId string = dataSource.id
+
 @description('The resource group where the data source is deployed')
 output dataSourceResourceGroup string = resourceGroup().name
+
 @description('The name of the deployed data source')
 output dataSourceName string = dataSource.name

--- a/arm/Microsoft.OperationalInsights/workspaces/dataSources/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/dataSources/readme.md
@@ -35,7 +35,7 @@ This template deploys a data source for a Log Analytics workspace.
 | :-- | :-- | :-- |
 | `dataSourceName` | string | The name of the deployed data source |
 | `dataSourceResourceGroup` | string | The resource group where the data source is deployed |
-| `dataSourceResourceId` | string | The resource Id of the deployed data source |
+| `dataSourceResourceId` | string | The resource ID of the deployed data source |
 
 ## Template references
 

--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. Name of the Log Analytics workspace')
-param logAnalyticsWorkspaceName string
+param name string
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -80,7 +80,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
   location: location
-  name: logAnalyticsWorkspaceName
+  name: name
   tags: tags
   properties: {
     features: {
@@ -183,11 +183,14 @@ module logAnalyticsWorkspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignm
   }
 }]
 
-@description('The resource Id of the deployed log analytics workspace')
+@description('The resource ID of the deployed log analytics workspace')
 output logAnalyticsResourceId string = logAnalyticsWorkspace.id
+
 @description('The resource group where the log analytics will be deployed')
 output logAnalyticsResourceGroup string = resourceGroup().name
+
 @description('The name of the deployed log analytics workspace')
 output logAnalyticsName string = logAnalyticsWorkspace.name
+
 @description('The ID associated with the workspace')
 output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.properties.customerId

--- a/arm/Microsoft.OperationalInsights/workspaces/linkedServices/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/linkedServices/deploy.bicep
@@ -21,8 +21,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource workspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
 resource linkedService 'Microsoft.OperationalInsights/workspaces/linkedServices@2020-08-01' = {
-  name: '${logAnalyticsWorkspaceName}/${name}'
+  name: name
+  parent: workspace
   tags: tags
   properties: {
     resourceId: resourceId
@@ -30,9 +35,11 @@ resource linkedService 'Microsoft.OperationalInsights/workspaces/linkedServices@
   }
 }
 
-@description('The resource Id of the deployed linked service')
+@description('The resource ID of the deployed linked service')
 output linkedServiceResourceId string = linkedService.id
+
 @description('The resource group where the linked service is deployed')
 output linkedServiceResourceGroup string = resourceGroup().name
+
 @description('The name of the deployed linked service')
 output linkedServiceName string = linkedService.name

--- a/arm/Microsoft.OperationalInsights/workspaces/linkedServices/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/linkedServices/readme.md
@@ -25,7 +25,7 @@ This template deploys a linked service for a Log Analytics workspace.
 | :-- | :-- | :-- |
 | `linkedServiceName` | string | The name of the deployed linked service |
 | `linkedServiceResourceGroup` | string | The resource group where the linked service is deployed |
-| `linkedServiceResourceId` | string | The resource Id of the deployed linked service |
+| `linkedServiceResourceId` | string | The resource ID of the deployed linked service |
 
 ## Template references
 

--- a/arm/Microsoft.OperationalInsights/workspaces/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/readme.md
@@ -27,7 +27,7 @@ This template deploys Log Analytics.
 | `linkedServices` | _[linkedServices](linkedServices/readme.md)_ array | `[]` |  | Optional. List of services to be linked. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
-| `logAnalyticsWorkspaceName` | string |  |  | Required. Name of the Log Analytics workspace |
+| `name` | string |  |  | Required. Name of the Log Analytics workspace |
 | `publicNetworkAccessForIngestion` | string | `Enabled` | `[Enabled, Disabled]` | Optional. The network access type for accessing Log Analytics ingestion. |
 | `publicNetworkAccessForQuery` | string | `Enabled` | `[Enabled, Disabled]` | Optional. The network access type for accessing Log Analytics query. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
@@ -123,7 +123,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | :-- | :-- | :-- |
 | `logAnalyticsName` | string | The name of the deployed log analytics workspace |
 | `logAnalyticsResourceGroup` | string | The resource group where the log analytics will be deployed |
-| `logAnalyticsResourceId` | string | The resource Id of the deployed log analytics workspace |
+| `logAnalyticsResourceId` | string | The resource ID of the deployed log analytics workspace |
 | `logAnalyticsWorkspaceId` | string | The ID associated with the workspace |
 
 ## Template references

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
@@ -33,8 +33,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource workspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
 resource savedSearch 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' = {
-  name: '${logAnalyticsWorkspaceName}/${name}'
+  name: name
+  parent: workspace
   properties: {
     tags: tags
     displayName: displayName
@@ -46,9 +51,11 @@ resource savedSearch 'Microsoft.OperationalInsights/workspaces/savedSearches@202
   }
 }
 
-@description('The resource Id of the deployed saved search')
+@description('The resource ID of the deployed saved search')
 output savedSearchResourceId string = savedSearch.id
+
 @description('The resource group where the saved search is deployed')
 output savedSearchResourceGroup string = resourceGroup().name
+
 @description('The name of the deployed saved search')
 output savedSearchName string = savedSearch.name

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
@@ -29,7 +29,7 @@ This template deploys a saved search for a Log Analytics workspace.
 | :-- | :-- | :-- |
 | `savedSearchName` | string | The name of the deployed saved search |
 | `savedSearchResourceGroup` | string | The resource group where the saved search is deployed |
-| `savedSearchResourceId` | string | The resource Id of the deployed saved search |
+| `savedSearchResourceId` | string | The resource ID of the deployed saved search |
 
 ## Template references
 

--- a/arm/Microsoft.OperationalInsights/workspaces/storageInsightConfigs/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/storageInsightConfigs/readme.md
@@ -15,6 +15,7 @@ This template deploys a storage insights configuration for a Log Analytics works
 | `containers` | array | `[]` |  | Optional. The names of the blob containers that the workspace should read. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `logAnalyticsWorkspaceName` | string |  |  | Required. Name of the Log Analytics workspace. |
+| `name` | string | `[last(split(parameters('storageAccountId'), '/'))]` |  | The name of the storage insights config |
 | `storageAccountId` | string |  |  | Required. The Azure Resource Manager ID of the storage account resource. |
 | `tables` | array | `[]` |  | Optional. The names of the Azure tables that the workspace should read. |
 | `tags` | object | `{object}` |  | Optional. Tags to configure in the resource. |
@@ -25,7 +26,7 @@ This template deploys a storage insights configuration for a Log Analytics works
 | :-- | :-- | :-- |
 | `storageinsightconfigName` | string | The name of the storage insights configuration |
 | `storageinsightconfigResourceGroup` | string | The resource group where the storage insight configuration is deployed |
-| `storageinsightconfigResourceId` | string | The resource Id of the deployed storage insights configuration |
+| `storageinsightconfigResourceId` | string | The resource ID of the deployed storage insights configuration |
 
 ## Template references
 

--- a/utilities/pipelines/dependencies/Microsoft.OperationalInsights/workspaces/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.OperationalInsights/workspaces/parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "logAnalyticsWorkspaceName": {
+        "name": {
             "value": "adp-sxx-az-la-x-001"
         }
     }


### PR DESCRIPTION
# Change

- Updated OMS to use `existing`
- Updated output

Pipeline reference
[![OperationalInsights: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml/badge.svg?branch=users%2Falsehr%2F573_oms__child)](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
