### PR TITLE
Implemented `existing` for key vault children

### DIFF
--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -210,7 +210,7 @@ module keyVault_secrets 'secrets/deploy.bicep' = [for (secret, index) in secrets
   params: {
     name: secret.name
     value: secret.value
-    vaultName: keyVault.name
+    keyVaultName: keyVault.name
     attributesEnabled: contains(secret, 'attributesEnabled') ? secret.attributesEnabled : true
     attributesExp: contains(secret, 'attributesExp') ? secret.attributesExp : -1
     attributesNbf: contains(secret, 'attributesNbf') ? secret.attributesNbf : -1
@@ -226,7 +226,7 @@ module keyVault_keys 'keys/deploy.bicep' = [for (key, index) in keys: {
   name: '${uniqueString(deployment().name, location)}-Key-${index}'
   params: {
     name: key.name
-    vaultName: keyVault.name
+    keyVaultName: keyVault.name
     attributesEnabled: contains(key, 'attributesEnabled') ? key.attributesEnabled : true
     attributesExp: contains(key, 'attributesExp') ? key.attributesExp : -1
     attributesNbf: contains(key, 'attributesNbf') ? key.attributesNbf : -1

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -260,7 +260,7 @@ module keyVault_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   }
 }]
 
-@description('The Resource Id of the Key Vault.')
+@description('The Resource ID of the Key Vault.')
 output keyVaultResourceId string = keyVault.id
 
 @description('The name of the Resource Group the Key Vault was created in.')

--- a/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the key vault')
-param vaultName string
+param keyVaultName string
 
 @description('Required. The name of the key')
 param name string
@@ -58,7 +58,7 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
-  name: vaultName
+  name: keyVaultName
 }
 
 resource key 'Microsoft.KeyVault/vaults/keys@2019-09-01' = {

--- a/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
@@ -78,7 +78,7 @@ resource key 'Microsoft.KeyVault/vaults/keys@2019-09-01' = {
   }
 }
 
-@description('The Name of the key.')
+@description('The name of the key.')
 output keyName string = key.name
 
 @description('The Resource ID of the key.')

--- a/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
@@ -57,8 +57,13 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
+  name: vaultName
+}
+
 resource key 'Microsoft.KeyVault/vaults/keys@2019-09-01' = {
-  name: '${vaultName}/${name}'
+  name: name
+  parent: keyVault
   tags: tags
   properties: {
     attributes: {
@@ -76,7 +81,7 @@ resource key 'Microsoft.KeyVault/vaults/keys@2019-09-01' = {
 @description('The Name of the key.')
 output keyName string = key.name
 
-@description('The Resource Id of the key.')
+@description('The Resource ID of the key.')
 output keyResourceId string = key.id
 
 @description('The name of the Resource Group the key was created in.')

--- a/arm/Microsoft.KeyVault/vaults/keys/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/keys/readme.md
@@ -45,7 +45,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `keyName` | string | The Name of the key. |
+| `keyName` | string | The name of the key. |
 | `keyResourceGroup` | string | The name of the Resource Group the key was created in. |
 | `keyResourceId` | string | The Resource ID of the key. |
 

--- a/arm/Microsoft.KeyVault/vaults/keys/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/keys/readme.md
@@ -47,7 +47,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | :-- | :-- | :-- |
 | `keyName` | string | The Name of the key. |
 | `keyResourceGroup` | string | The name of the Resource Group the key was created in. |
-| `keyResourceId` | string | The Resource Id of the key. |
+| `keyResourceId` | string | The Resource ID of the key. |
 
 ## Template references
 

--- a/arm/Microsoft.KeyVault/vaults/keys/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/keys/readme.md
@@ -19,10 +19,10 @@ This module deploys a key vault key.
 | `curveName` | string | `P-256` | `[P-256, P-256K, P-384, P-521]` | Optional. The elliptic curve name. |
 | `keyOps` | array | `[]` | `[decrypt, encrypt, import, sign, unwrapKey, verify, wrapKey]` | Optional. Array of JsonWebKeyOperation |
 | `keySize` | int | `-1` |  | Optional. The key size in bits. For example: 2048, 3072, or 4096 for RSA. |
+| `keyVaultName` | string |  |  | Required. The name of the key vault |
 | `kty` | string | `EC` | `[EC, EC-HSM, RSA, RSA-HSM]` | Optional. The type of the key. |
 | `name` | string |  |  | Required. The name of the key |
 | `tags` | object | `{object}` |  | Optional. Resource tags. |
-| `vaultName` | string |  |  | Required. The name of the key vault |
 
 ### Parameter Usage: `tags`
 

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -183,7 +183,7 @@ To use Private Endpoint the following dependencies must be deployed:
 | :-- | :-- | :-- |
 | `keyVaultName` | string | The Name of the Key Vault. |
 | `keyVaultResourceGroup` | string | The name of the Resource Group the Key Vault was created in. |
-| `keyVaultResourceId` | string | The Resource Id of the Key Vault. |
+| `keyVaultResourceId` | string | The Resource ID of the Key Vault. |
 | `keyVaultUrl` | string | The URL of the Key Vault. |
 
 ## Template references

--- a/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the key vault')
-param vaultName string
+param keyVaultName string
 
 @description('Required. The name of the secret')
 param name string
@@ -33,7 +33,7 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
-  name: vaultName
+  name: keyVaultName
 }
 
 resource secret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {

--- a/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
@@ -32,8 +32,13 @@ module pid_cuaId './.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
+  name: vaultName
+}
+
 resource secret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
-  name: '${vaultName}/${name}'
+  name: name
+  parent: keyVault
   tags: tags
   properties: {
     contentType: contentType
@@ -49,7 +54,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
 @description('The Name of the secret.')
 output secretName string = secret.name
 
-@description('The Resource Id of the secret.')
+@description('The Resource ID of the secret.')
 output secretResourceId string = secret.id
 
 @description('The name of the Resource Group the secret was created in.')

--- a/arm/Microsoft.KeyVault/vaults/secrets/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/secrets/readme.md
@@ -45,7 +45,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | :-- | :-- | :-- |
 | `secretName` | string | The Name of the secret. |
 | `secretResourceGroup` | string | The name of the Resource Group the secret was created in. |
-| `secretResourceId` | string | The Resource Id of the secret. |
+| `secretResourceId` | string | The Resource ID of the secret. |
 
 ## Template references
 

--- a/arm/Microsoft.KeyVault/vaults/secrets/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/secrets/readme.md
@@ -17,10 +17,10 @@ This module deploys a key vault secret.
 | `attributesNbf` | int | `-1` |  | Optional. Not before date in seconds since 1970-01-01T00:00:00Z. |
 | `contentType` | secureString |  |  | Optional. The content type of the secret. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
+| `keyVaultName` | string |  |  | Required. The name of the key vault |
 | `name` | string |  |  | Required. The name of the secret |
 | `tags` | object | `{object}` |  | Optional. Resource tags. |
 | `value` | secureString |  |  | Required. The value of the secret. NOTE: "value" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets. |
-| `vaultName` | string |  |  | Required. The name of the key vault |
 
 ### Parameter Usage: `tags`
 


### PR DESCRIPTION
# Change

- Implemented `existing` for key vault children

Parameter reference
[![KeyVault: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Falsehr%2F565_kv_child)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
