### PR TITLE
Updated AVD namespace to use `existing`

### DIFF
--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/applications/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/applications/deploy.bicep
@@ -41,8 +41,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource applicationGroup 'Microsoft.DesktopVirtualization/applicationGroups@2021-09-03-preview' existing = {
+  name: appGroupName
+}
+
 resource application 'Microsoft.DesktopVirtualization/applicationGroups/applications@2021-07-12' = {
-  name: '${appGroupName}/${name}'
+  name: name
+  parent: applicationGroup
   properties: {
     description: description
     friendlyName: friendlyName
@@ -57,7 +62,9 @@ resource application 'Microsoft.DesktopVirtualization/applicationGroups/applicat
 
 @sys.description('The resource id of the deployed Application.')
 output applicationResourceIds string = application.id
+
 @sys.description('The name of the Resource Group the AVD Application was created in.')
 output applicationResourceGroup string = resourceGroup().name
+
 @sys.description('The Name of the Application Group to register the Application in.')
 output appGroupName string = appGroupName

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep
@@ -146,6 +146,11 @@ module appGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   }
 }]
 
+@sys.description('The resource ID  of the AVD application group')
 output appGroupResourceId string = appGroup.id
+
+@sys.description('The resource group the AVD application group was deployed into')
 output appGroupResourceGroup string = resourceGroup().name
+
+@sys.description('The name of the AVD application group')
 output appGroupName string = appGroup.name

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/readme.md
@@ -82,11 +82,11 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `appGroupName` | string |
-| `appGroupResourceGroup` | string |
-| `appGroupResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `appGroupName` | string | The name of the AVD application group |
+| `appGroupResourceGroup` | string | The resource group the AVD application group was deployed into |
+| `appGroupResourceId` | string | The resource ID  of the AVD application group |
 
 ## Template references
 

--- a/arm/Microsoft.DesktopVirtualization/hostpools/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/deploy.bicep
@@ -189,8 +189,14 @@ module hostPool_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   }
 }]
 
+@description('The resource ID of the AVD host pool')
 output hostPoolResourceId string = hostPool.id
+
+@description('The resource group the AVD host pool was deployed into')
 output hostPoolResourceGroup string = resourceGroup().name
+
+@description('The name of the AVD host pool')
 output hostPoolName string = hostPool.name
+
+@description('The expiration time for the registration token')
 output tokenExpirationTime string = dateTimeAdd(baseTime, tokenValidityLength)
-output hostpoolToken string = '${hostPool.properties.registrationInfo.token}'

--- a/arm/Microsoft.DesktopVirtualization/hostpools/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/readme.md
@@ -124,13 +124,12 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `hostPoolName` | string |
-| `hostPoolResourceGroup` | string |
-| `hostPoolResourceId` | string |
-| `hostpoolToken` | string |
-| `tokenExpirationTime` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `hostPoolName` | string | The name of the AVD host pool |
+| `hostPoolResourceGroup` | string | The resource group the AVD host pool was deployed into |
+| `hostPoolResourceId` | string | The resource ID of the AVD host pool |
+| `tokenExpirationTime` | string | The expiration time for the registration token |
 
 ## Template references
 

--- a/arm/Microsoft.DesktopVirtualization/workspaces/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/deploy.bicep
@@ -116,6 +116,11 @@ module workspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   }
 }]
 
+@description('The resource ID of the AVD workspace')
 output workspaceResourceId string = workspace.id
+
+@description('The resource group the AVD workspace was deployed into')
 output workspaceResourceGroup string = resourceGroup().name
+
+@description('The name of the AVD workspace')
 output workspaceName string = workspace.name

--- a/arm/Microsoft.DesktopVirtualization/workspaces/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/readme.md
@@ -80,11 +80,11 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `workspaceName` | string |
-| `workspaceResourceGroup` | string |
-| `workspaceResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `workspaceName` | string | The name of the AVD workspace |
+| `workspaceResourceGroup` | string | The resource group the AVD workspace was deployed into |
+| `workspaceResourceId` | string | The resource ID of the AVD workspace |
 
 ## Template references
 


### PR DESCRIPTION
# Change

- Updated AVD namespace to use `existing`
- Added output descriptions
- Removed Host Pool Key output
- Updated documentation

Pipeline references
[![DesktopVirtualization: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.applicationgroups.yml/badge.svg?branch=users%2Falsehr%2F559_avd_input)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.applicationgroups.yml)
[![DesktopVirtualization: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml/badge.svg?branch=users%2Falsehr%2F559_avd_input)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml)
[![DesktopVirtualization: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml/badge.svg?branch=users%2Falsehr%2F559_avd_input)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
