### PR TITLE
Updated DocumentDB to use `existing`

### DIFF
--- a/arm/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
@@ -262,8 +262,8 @@ module mongodbDatabases_resource 'mongodbDatabases/deploy.bicep' = [for mongodbD
 @description('The name of the database account.')
 output databaseAccountName string = databaseAccount.name
 
-@description('The Resource Id of the database account.')
+@description('The resource ID of the database account.')
 output databaseAccountResourceId string = databaseAccount.id
 
-@description('The name of the Resource Group the database account was created in.')
+@description('The name of the resource group the database account was created in.')
 output databaseAccountResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
@@ -24,8 +24,17 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-07-01-preview' existing = {
+  name: databaseAccountName
+
+  resource mongodbDatabase 'mongodbDatabases@2021-07-01-preview' existing = {
+    name: mongodbDatabaseName
+  }
+}
+
 resource collection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2021-07-01-preview' = {
-  name: '${databaseAccountName}/${mongodbDatabaseName}/${name}'
+  name: name
+  parent: databaseAccount::mongodbDatabase
   properties: {
     options: {
       throughput: throughput
@@ -41,8 +50,8 @@ resource collection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/coll
 @description('The name of the mongodb database.')
 output collectionName string = collection.name
 
-@description('The Resource Id of the mongodb database.')
+@description('The resource ID of the mongodb database.')
 output collectionResourceId string = collection.id
 
-@description('The name of the Resource Group the mongodb database was created in.')
+@description('The name of the resource group the mongodb database was created in.')
 output collectionResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/readme.md
@@ -1,4 +1,4 @@
-# DocumentDB Database Account MongoDB databases Collections `[Microsoft.DocumentDB/databaseAccount/mongodbDatabases/collections]`
+# DocumentDB Database Account MongoDB databases Collections  `[Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections]`
 
 This module deploys a collection within a MongoDB.
 
@@ -83,8 +83,8 @@ The shard key and partition kind pair, only support "Hash" partition kind.
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `collectionName` | string | The name of the mongodb database. |
-| `collectionResourceGroup` | string | The name of the Resource Group the mongodb database was created in. |
-| `collectionResourceId` | string | The Resource Id of the mongodb database. |
+| `collectionResourceGroup` | string | The name of the resource group the mongodb database was created in. |
+| `collectionResourceId` | string | The resource ID of the mongodb database. |
 
 ## Template references
 

--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
@@ -21,8 +21,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-07-01-preview' existing = {
+  name: databaseAccountName
+}
+
 resource mongodbDatabase 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2021-07-01-preview' = {
-  name: '${databaseAccountName}/${name}'
+  name: name
+  parent: databaseAccount
   tags: tags
   properties: {
     resource: {
@@ -48,8 +53,8 @@ module mongodbDatabase_collections 'collections/deploy.bicep' = [for collection 
 @description('The name of the mongodb database.')
 output mongodbDatabaseName string = mongodbDatabase.name
 
-@description('The Resource Id of the mongodb database.')
+@description('The resource ID of the mongodb database.')
 output mongodbDatabaseResourceId string = mongodbDatabase.id
 
-@description('The name of the Resource Group the mongodb database was created in.')
+@description('The name of the resource group the mongodb database was created in.')
 output mongodbDatabaseResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/readme.md
@@ -1,4 +1,4 @@
-# DocumentDB Database Account MongoDB databases `[Microsoft.DocumentDB/databaseAccount/mongodbDatabases]`
+# DocumentDB Database Account MongoDB databases  `[Microsoft.DocumentDB/databaseAccounts/mongodbDatabases]`
 
 This module deploys a MongoDB within a CosmosDB account.
 
@@ -29,8 +29,8 @@ Please reference the documentation for [collections](./collections/readme.md)
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `mongodbDatabaseName` | string | The name of the mongodb database. |
-| `mongodbDatabaseResourceGroup` | string | The name of the Resource Group the mongodb database was created in. |
-| `mongodbDatabaseResourceId` | string | The Resource Id of the mongodb database. |
+| `mongodbDatabaseResourceGroup` | string | The name of the resource group the mongodb database was created in. |
+| `mongodbDatabaseResourceId` | string | The resource ID of the mongodb database. |
 
 ## Template references
 

--- a/arm/Microsoft.DocumentDB/databaseAccounts/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/readme.md
@@ -106,8 +106,8 @@ Please reference the documentation for [mongodbDatabases](./mongodbDatabases/rea
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `databaseAccountName` | string | The name of the database account. |
-| `databaseAccountResourceGroup` | string | The name of the Resource Group the database account was created in. |
-| `databaseAccountResourceId` | string | The Resource Id of the database account. |
+| `databaseAccountResourceGroup` | string | The name of the resource group the database account was created in. |
+| `databaseAccountResourceId` | string | The resource ID of the database account. |
 
 ## Template references
 

--- a/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/deploy.bicep
@@ -32,8 +32,17 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-07-01-preview' existing = {
+  name: databaseAccountName
+
+  resource sqlDatabase 'sqlDatabases@2021-07-01-preview' existing = {
+    name: sqlDatabaseName
+  }
+}
+
 resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2021-07-01-preview' = {
-  name: '${databaseAccountName}/${sqlDatabaseName}/${name}'
+  name: name
+  parent: databaseAccount::sqlDatabase
   tags: tags
   properties: {
     resource: {
@@ -52,8 +61,8 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
 @description('The name of the container.')
 output containerName string = container.name
 
-@description('The Resource Id of the container.')
+@description('The resource ID of the container.')
 output containerResourceId string = container.id
 
-@description('The name of the Resource Group the container was created in.')
+@description('The name of the resource group the container was created in.')
 output containerResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/readme.md
@@ -1,4 +1,4 @@
-# DocumentDB Database Account SQL Databases Containers `[Microsoft.DocumentDB/databaseAccount/sqlDatabases/containers]`
+# DocumentDB Database Account SQL Databases Containers  `[Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers]`
 
 ## Resource Types
 
@@ -28,8 +28,8 @@
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `containerName` | string | The name of the container. |
-| `containerResourceGroup` | string | The name of the Resource Group the container was created in. |
-| `containerResourceId` | string | The Resource Id of the container. |
+| `containerResourceGroup` | string | The name of the resource group the container was created in. |
+| `containerResourceId` | string | The resource ID of the container. |
 
 ## Template references
 

--- a/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/deploy.bicep
@@ -1,19 +1,19 @@
-@description('Required. Id of the Cosmos DB database account.')
+@description('Required. ID of the Cosmos DB database account.')
 param databaseAccountName string
 
-@description('Required. Name of the SQL Database ')
+@description('Required. Name of the SQL database ')
 param name string
 
 @description('Optional. Array of containers to deploy in the SQL database.')
 param containers array = []
 
-@description('Optional. Request Units per second')
+@description('Optional. Request units per second')
 param throughput int = 400
 
-@description('Optional. Tags of the SQL Database resource.')
+@description('Optional. Tags of the SQL database resource.')
 param tags object = {}
 
-@description('Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered')
+@description('Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered')
 param cuaId string = ''
 
 module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
@@ -21,8 +21,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-07-01-preview' existing = {
+  name: databaseAccountName
+}
+
 resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06-15' = {
-  name: '${databaseAccountName}/${name}'
+  name: name
+  parent: databaseAccount
   tags: tags
   properties: {
     resource: {
@@ -45,11 +50,11 @@ module container 'containers/deploy.bicep' = [for container in containers: {
   }
 }]
 
-@description('The name of the sql database.')
+@description('The name of the SQL database.')
 output sqlDatabaseName string = sqlDatabase.name
 
-@description('The Resource Id of the sql database.')
+@description('The resource ID of the SQL database.')
 output sqlDatabaseResourceId string = sqlDatabase.id
 
-@description('The name of the Resource Group the sql database was created in.')
+@description('The name of the resource group the SQL database was created in.')
 output sqlDatabaseResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/readme.md
@@ -1,4 +1,4 @@
-# DocumentDB Database Account SQL Databases `[Microsoft.DocumentDB/databaseAccount/sqlDatabases]`
+# DocumentDB Database Account SQL Databases  `[Microsoft.DocumentDB/databaseAccounts/sqlDatabases]`
 
 ## Resource Types
 
@@ -12,19 +12,19 @@
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `containers` | _[containers](containers/readme.md)_ array | `[]` |  | Optional. Array of containers to deploy in the SQL database. |
-| `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
-| `databaseAccountName` | string |  |  | Required. Id of the Cosmos DB database account. |
-| `name` | string |  |  | Required. Name of the SQL Database  |
-| `tags` | object | `{object}` |  | Optional. Tags of the SQL Database resource. |
-| `throughput` | int | `400` |  | Optional. Request Units per second |
+| `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
+| `databaseAccountName` | string |  |  | Required. ID of the Cosmos DB database account. |
+| `name` | string |  |  | Required. Name of the SQL database  |
+| `tags` | object | `{object}` |  | Optional. Tags of the SQL database resource. |
+| `throughput` | int | `400` |  | Optional. Request units per second |
 
 ## Outputs
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `sqlDatabaseName` | string | The name of the sql database. |
-| `sqlDatabaseResourceGroup` | string | The name of the Resource Group the sql database was created in. |
-| `sqlDatabaseResourceId` | string | The Resource Id of the sql database. |
+| `sqlDatabaseName` | string | The name of the SQL database. |
+| `sqlDatabaseResourceGroup` | string | The name of the resource group the SQL database was created in. |
+| `sqlDatabaseResourceId` | string | The resource ID of the SQL database. |
 
 ## Template references
 


### PR DESCRIPTION
# Change

- Updated DocumentDB to use `existing`
- Updated outputs
- Updated documentation

Pipeline reference
[![DocumentDB: Database Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Falsehr%2F560_cdb_existing)](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
