### PR TITLE
Updated ManagedClusters to use `existing`

### DIFF
--- a/arm/Microsoft.ContainerService/managedClusters/.parameters/azure.parameters.json
+++ b/arm/Microsoft.ContainerService/managedClusters/.parameters/azure.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "aksClusterName": {
+        "name": {
             "value": "sxx-az-aks-azure"
         },
         "primaryAgentPoolProfile": {

--- a/arm/Microsoft.ContainerService/managedClusters/.parameters/kubenet.parameters.json
+++ b/arm/Microsoft.ContainerService/managedClusters/.parameters/kubenet.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "aksClusterName": {
+        "name": {
             "value": "sxx-az-aks-kubenet"
         },
         "primaryAgentPoolProfile": {

--- a/arm/Microsoft.ContainerService/managedClusters/agentPools/deploy.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/agentPools/deploy.bicep
@@ -8,16 +8,21 @@ param name string
 @description('Required. Properties for the container service agent pool profile.')
 param agentPoolProperties object
 
+resource managedCluster 'Microsoft.ContainerService/managedClusters@2021-08-01' existing = {
+  name: managedClusterName
+}
+
 resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2021-05-01' = {
-  name: '${managedClusterName}/${name}'
+  name: name
+  parent: managedCluster
   properties: agentPoolProperties
 }
 
 @description('The name of the agent pool')
 output agentPoolName string = agentPool.name
 
-@description('The ResourceId of the agent pool')
-output agentPoolId string = agentPool.id
+@description('The resource ID of the agent pool')
+output agentPoolResourceId string = agentPool.id
 
-@description('The name of the Resource Group the agent pool was created in.')
+@description('The resource group the agent pool was deployed into.')
 output agentPoolResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.ContainerService/managedClusters/agentPools/readme.md
+++ b/arm/Microsoft.ContainerService/managedClusters/agentPools/readme.md
@@ -4,7 +4,7 @@ This module deploys an Agent Pool for a Container Service Managed Cluster
 
 ## Resource types
 
-| Resource Type | API Version |
+| Resource Type | Api Version |
 | :-- | :-- |
 | `Microsoft.ContainerService/managedClusters/agentPools` | 2021-05-01 |
 
@@ -61,9 +61,9 @@ For available properties check <https://docs.microsoft.com/en-us/azure/templates
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `agentPoolId` | string | The ResourceId of the agent pool |
 | `agentPoolName` | string | The name of the agent pool |
-| `agentPoolResourceGroup` | string | The name of the Resource Group the agent pool was created in. |
+| `agentPoolResourceGroup` | string | The resource group the agent pool was deployed into. |
+| `agentPoolResourceId` | string | The resource ID of the agent pool |
 
 ## Template references
 

--- a/arm/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -1,11 +1,11 @@
 @description('Required. Specifies the name of the AKS cluster.')
-param aksClusterName string
+param name string
 
 @description('Optional. Specifies the location of AKS cluster. It picks up Resource Group\'s location by default.')
 param location string = resourceGroup().location
 
 @description('Optional. Specifies the DNS prefix specified when creating the managed cluster.')
-param aksClusterDnsPrefix string = aksClusterName
+param aksClusterDnsPrefix string = name
 
 @description('Optional. The identity of the managed cluster.')
 param identity object = {
@@ -98,7 +98,7 @@ param aadProfileManaged bool = true
 param aadProfileEnableAzureRBAC bool = true
 
 @description('Optional. Name of the resource group containing agent pool nodes.')
-param nodeResourceGroup string = '${resourceGroup().name}_aks_${aksClusterName}_nodes'
+param nodeResourceGroup string = '${resourceGroup().name}_aks_${name}_nodes'
 
 @description('Optional. Specifies whether to create the cluster as a private cluster or not.')
 param aksClusterEnablePrivateCluster bool = false
@@ -252,7 +252,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource managedCluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
-  name: aksClusterName
+  name: name
   location: location
   tags: (empty(tags) ? null : tags)
   identity: identity
@@ -367,7 +367,14 @@ module managedCluster_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   }
 }]
 
+@description('The resource ID of the managed cluster')
 output azureKubernetesServiceResourceId string = managedCluster.id
+
+@description('The resource group the managed cluster was deployed into')
 output azureKubernetesServiceResourceGroup string = resourceGroup().name
+
+@description('The name of the managed cluster')
 output azureKubernetesServiceName string = managedCluster.name
+
+@description('The control plane FQDN of the managed cluster')
 output controlPlaneFQDN string = (aksClusterEnablePrivateCluster ? managedCluster.properties.privateFQDN : managedCluster.properties.fqdn)

--- a/arm/Microsoft.ContainerService/managedClusters/readme.md
+++ b/arm/Microsoft.ContainerService/managedClusters/readme.md
@@ -4,7 +4,7 @@ This module deploys Azure Kubernetes Cluster (AKS).
 
 ## Resource types
 
-| Resource Type | API Version |
+| Resource Type | Api Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2016-09-01 |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
@@ -22,17 +22,16 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | `aadProfileManaged` | bool | `True` |  | Optional. Specifies whether to enable managed AAD integration. |
 | `aadProfileServerAppID` | string |  |  | Optional. The server AAD application ID. |
 | `aadProfileServerAppSecret` | string |  |  | Optional. The server AAD application secret. |
-| `aadProfileTenantID` | string | `[subscription().tenantId]` |  | Optional. Specifies the tenant ID of the Azure Active Directory used by the AKS cluster for authentication. |
+| `aadProfileTenantId` | string | `[subscription().tenantId]` |  | Optional. Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication. |
 | `aciConnectorLinuxEnabled` | bool |  |  | Optional. Specifies whether the aciConnectorLinux add-on is enabled or not. |
-| `agentPools` | _[agentPools](agentPools/readme.md)_ array | `[]` |  | Optional. Define one or more secondary/additional nodepools |
+| `agentPools` | _[agentPools](agentPools/readme.md)_ array | `[]` |  | Optional. Define one or more secondary/additional node pools |
 | `aksClusterAdminUsername` | string | `azureuser` |  | Optional. Specifies the administrator username of Linux virtual machines. |
-| `aksClusterDnsPrefix` | string | `[parameters('aksClusterName')]` |  | Optional. Specifies the DNS prefix specified when creating the managed cluster. |
+| `aksClusterDnsPrefix` | string | `[parameters('name')]` |  | Optional. Specifies the DNS prefix specified when creating the managed cluster. |
 | `aksClusterDnsServiceIP` | string |  |  | Optional. Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr. |
 | `aksClusterDockerBridgeCidr` | string |  |  | Optional. Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range. |
 | `aksClusterEnablePrivateCluster` | bool |  |  | Optional. Specifies whether to create the cluster as a private cluster or not. |
 | `aksClusterKubernetesVersion` | string |  |  | Optional. Version of Kubernetes specified when creating the managed cluster. |
 | `aksClusterLoadBalancerSku` | string | `standard` | `[basic, standard]` | Optional. Specifies the sku of the load balancer used by the virtual machine scale sets used by nodepools. |
-| `aksClusterName` | string |  |  | Required. Specifies the name of the AKS cluster. |
 | `aksClusterNetworkPlugin` | string |  | `[, azure, kubenet]` | Optional. Specifies the network plugin used for building Kubernetes network. - azure or kubenet. |
 | `aksClusterNetworkPolicy` | string |  | `[, azure, calico]` | Optional. Specifies the network policy used for building Kubernetes network. - calico or azure |
 | `aksClusterOutboundType` | string | `loadBalancer` | `[loadBalancer, userDefinedRouting]` | Optional. Specifies outbound (egress) routing method. - loadBalancer or userDefinedRouting. |
@@ -51,7 +50,7 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | `autoScalerProfileUtilizationThreshold` | string | `0.5` |  | Optional. Specifies the utilization threshold of the auto-scaler of the AKS cluster. |
 | `azurePolicyEnabled` | bool | `True` |  | Optional. Specifies whether the azurepolicy add-on is enabled or not. |
 | `azurePolicyVersion` | string | `v2` |  | Optional. Specifies the azure policy version to use. |
-| `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
+| `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
 | `diagnosticStorageAccountId` | string |  |  | Optional. Resource identifier of the Diagnostic Storage Account. |
 | `eventHubAuthorizationRuleId` | string |  |  | Optional. Resource ID of the event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
@@ -64,7 +63,8 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | `logsToEnable` | array | `[kube-apiserver, kube-audit, kube-controller-manager, kube-scheduler, cluster-autoscaler]` | `[kube-apiserver, kube-audit, kube-controller-manager, kube-scheduler, cluster-autoscaler]` | Optional. The name of logs that will be streamed. |
 | `managedOutboundIPCount` | int |  |  | Optional. Outbound IP Count for the Load balancer. |
 | `metricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |
-| `nodeResourceGroup` | string | `[format('{0}_aks_{1}_nodes', resourceGroup().name, parameters('aksClusterName'))]` |  | Optional. Name of the resource group containing agent pool nodes. |
+| `name` | string |  |  | Required. Specifies the name of the AKS cluster. |
+| `nodeResourceGroup` | string | `[format('{0}_aks_{1}_nodes', resourceGroup().name, parameters('name'))]` |  | Optional. Name of the resource group containing agent pool nodes. |
 | `omsAgentEnabled` | bool | `True` |  | Optional. Specifies whether the OMS agent is enabled. |
 | `primaryAgentPoolProfile` | array |  |  | Required. Properties of the primary agent pool. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
@@ -211,12 +211,12 @@ For available properties check <https://docs.microsoft.com/en-us/azure/templates
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `azureKubernetesServiceName` | string |
-| `azureKubernetesServiceResourceGroup` | string |
-| `azureKubernetesServiceResourceId` | string |
-| `controlPlaneFQDN` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `azureKubernetesServiceName` | string | The name of the managed cluster |
+| `azureKubernetesServiceResourceGroup` | string | The resource group the managed cluster was deployed into |
+| `azureKubernetesServiceResourceId` | string | The resource ID of the managed cluster |
+| `controlPlaneFQDN` | string | The control plane FQDN of the managed cluster |
 
 ## Template references
 


### PR DESCRIPTION
# Change

- Updated child to use `existing`
- Updated documentation

Pipeline reference
[![ContainerService: Managedclusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Falsehr%2F556_cs_existing)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
