### PR TITLE
Updated cognitive services to use `name` input parameter

### DIFF
--- a/arm/Microsoft.CognitiveServices/accounts/.parameters/parameters.json
+++ b/arm/Microsoft.CognitiveServices/accounts/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "accountName": {
+        "name": {
             "value": "sxx-az-cgs-x-001"
         },
         "kind": {

--- a/arm/Microsoft.CognitiveServices/accounts/deploy.bicep
+++ b/arm/Microsoft.CognitiveServices/accounts/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of Cognitive Services account')
-param accountName string
+param name string
 
 @description('Required. Kind of the Cognitive Services. Use \'Get-AzCognitiveServicesAccountSku\' to determine a valid combinations of \'kind\' and \'sku\' for your Azure region.')
 @allowed([
@@ -159,7 +159,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource cognitiveServices 'Microsoft.CognitiveServices/accounts@2017-04-18' = {
-  name: accountName
+  name: name
   kind: kind
   identity: {
     type: managedIdentity
@@ -217,8 +217,17 @@ module cognitiveServices_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment,
   }
 }]
 
+@description('The name of the cognitive services account')
 output cognitiveServicesName string = cognitiveServices.name
+
+@description('The resource ID of the cognitive services account')
 output cognitiveServicesResourceId string = cognitiveServices.id
+
+@description('The resource group the cognitive services account was deployed into')
 output cognitiveServicesResourceGroup string = resourceGroup().name
+
+@description('The service endpoint of the cognitive services account')
 output cognitiveServicesEndpoint string = cognitiveServices.properties.endpoint
+
+@description('The prinicipal ID of the cognitive services account (if any)')
 output principalId string = managedIdentity != 'None' ? cognitiveServices.identity.principalId : ''

--- a/arm/Microsoft.CognitiveServices/accounts/readme.md
+++ b/arm/Microsoft.CognitiveServices/accounts/readme.md
@@ -17,7 +17,6 @@ This module deploys different kinds of Cognitive Services resources
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `accountName` | string |  |  | Required. The name of Cognitive Services account |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution id (GUID). This GUID must be previously registered |
 | `customSubDomainName` | string |  |  | Optional. Subdomain name used for token-based authentication. Required if 'networkAcls' are set. |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
@@ -30,6 +29,7 @@ This module deploys different kinds of Cognitive Services resources
 | `logsToEnable` | array | `[Audit, RequestResponse]` | `[Audit, RequestResponse]` | Optional. The name of logs that will be streamed. |
 | `managedIdentity` | string | `None` | `[None, SystemAssigned]` | Optional. Type of managed service identity. |
 | `metricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |
+| `name` | string |  |  | Required. The name of Cognitive Services account |
 | `networkAcls` | object | `{object}` |  | Optional. Service endpoint object information |
 | `privateEndpoints` | array | `[]` |  | Optional. Configuration Details for private endpoints. |
 | `publicNetworkAccess` | string | `Enabled` | `[Enabled, Disabled]` | Optional. Subdomain name used for token-based authentication. Must be set if 'networkAcls' are set. |
@@ -142,13 +142,13 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `cognitiveServicesEndpoint` | string |
-| `cognitiveServicesName` | string |
-| `cognitiveServicesResourceGroup` | string |
-| `cognitiveServicesResourceId` | string |
-| `principalId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `cognitiveServicesEndpoint` | string | The service endpoint of the cognitive services account |
+| `cognitiveServicesName` | string | The name of the cognitive services account |
+| `cognitiveServicesResourceGroup` | string | The resource group the cognitive services account was deployed into |
+| `cognitiveServicesResourceId` | string | The resource ID of the cognitive services account |
+| `principalId` | string | The prinicipal ID of the cognitive services account (if any) |
 
 ## Considerations
 


### PR DESCRIPTION
# Change

- Updated cognitive services to use `name` input parameter
- Updated parameter file
- Updated readme

Pipeline reference
[![CognitiveServices: Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.cognitiveservices.accounts.yml/badge.svg?branch=users%2Falsehr%2F551_cog_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cognitiveservices.accounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
