### PR TITLE
Small hotfix for incorrect removal loop

### DIFF
--- a/arm/Microsoft.Authorization/roleDefinitions/.parameters/parameters.json
+++ b/arm/Microsoft.Authorization/roleDefinitions/.parameters/parameters.json
@@ -31,7 +31,7 @@
             "value": []
         },
         "subscriptionId": {
-            "value": "<<subscriptionId>>"
+            "value": "a7439831-1cd9-435d-a091-4aa863c96556"
         }
     }
 }

--- a/arm/Microsoft.Authorization/roleDefinitions/.parameters/parameters.json
+++ b/arm/Microsoft.Authorization/roleDefinitions/.parameters/parameters.json
@@ -31,7 +31,7 @@
             "value": []
         },
         "subscriptionId": {
-            "value": "a7439831-1cd9-435d-a091-4aa863c96556"
+            "value": "<<subscriptionId>>"
         }
     }
 }

--- a/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
@@ -83,7 +83,7 @@ function Remove-Resource {
             $resourcesToRetry = Remove-ResourceInner -resourceToRemove $resourcesToRetry -Verbose
         }
 
-        if ($resourcesToRetry) {
+        if (-not $resourcesToRetry) {
             break
         }
         Write-Verbose ('Re-try removal of remaining [{0}] resources. Waiting [{1}] seconds. Round [{2}|{3}]' -f (($resourcesToRetry -is [array]) ? $resourcesToRetry.Count : 1), $removalRetryInterval, $removalRetryCount, $removalRetryLimit)

--- a/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
@@ -81,6 +81,8 @@ function Remove-Resource {
     do {
         if ($PSCmdlet.ShouldProcess(("[{0}] Resource(s) with a maximum of [$removalRetryLimit] attempts." -f $resourcesToRetry.Count), 'Remove')) {
             $resourcesToRetry = Remove-ResourceInner -resourceToRemove $resourcesToRetry -Verbose
+        } else {
+            Remove-ResourceInner -resourceToRemove $resourceToRemove -WhatIf
         }
 
         if (-not $resourcesToRetry) {
@@ -95,7 +97,5 @@ function Remove-Resource {
         throw ('The removal failed for resources [{0}]' -f ($resourcesToRetry.Name -join ', '))
     } else {
         Write-Verbose 'The removal completed successfully'
-    } else {
-        Remove-ResourceInner -resourceToRemove $resourceToRemove -WhatIf
     }
 }


### PR DESCRIPTION
# Change

- Fixed incorrect removal break condition

Pipeline reference
[![Compute: Availabilitysets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml/badge.svg?branch=users%2Falsehr%2Fhotfix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
