### PR TITLE
Update AutoManage to use `name` input parameter

### DIFF
--- a/arm/Microsoft.Automanage/accounts/.parameters/parameters.json
+++ b/arm/Microsoft.Automanage/accounts/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "vmResourceGroupName": {
+        "name": {
             "value": "validation-rg"
         },
         "vmName": {

--- a/arm/Microsoft.Automanage/accounts/deploy.bicep
+++ b/arm/Microsoft.Automanage/accounts/deploy.bicep
@@ -4,7 +4,7 @@ targetScope = 'subscription'
 param autoManageAccountResourceGroupName string = '${replace(subscription().displayName, ' ', '')}_group'
 
 @description('Optional. The name of automanage account')
-param autoManageAccountName string = '${replace(subscription().displayName, ' ', '')}-AutoManage'
+param name string = '${replace(subscription().displayName, ' ', '')}-AutoManage'
 
 @description('Optional. The location of automanage')
 param location string = deployment().location
@@ -34,17 +34,17 @@ module pidName '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 module autoManageAccount '.bicep/nested_autoManageAccount.bicep' = {
-  name: 'autoManageAccount-${uniqueString(subscription().subscriptionId, autoManageAccountResourceGroupName, autoManageAccountName)}'
+  name: 'autoManageAccount-${uniqueString(subscription().subscriptionId, autoManageAccountResourceGroupName, name)}'
   scope: resourceGroup(autoManageAccountResourceGroupName)
   params: {
     location: location
-    autoManageAccountName: autoManageAccountName
+    autoManageAccountName: name
   }
 }
 
 //principalId: (createAutoManageAccount ? autoManageAccount.outputs.principalId : 'resource not deployed')
 resource autoManageAccount_permissions_contributor 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
-  name: guid(autoManageAccountResourceGroupName, autoManageAccountName, contributor)
+  name: guid(autoManageAccountResourceGroupName, name, contributor)
   properties: {
     roleDefinitionId: contributor
     principalId: autoManageAccount.outputs.principalId
@@ -53,7 +53,7 @@ resource autoManageAccount_permissions_contributor 'Microsoft.Authorization/role
 }
 
 resource autoManageAccount_permissions_resourcePolicyContributor 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
-  name: guid(autoManageAccountResourceGroupName, autoManageAccountName, resourcePolicyContributor)
+  name: guid(autoManageAccountResourceGroupName, name, resourcePolicyContributor)
   properties: {
     roleDefinitionId: resourcePolicyContributor
     principalId: autoManageAccount.outputs.principalId
@@ -71,6 +71,11 @@ module configurationProfileAssignment '.bicep/nested_configurationProfileAssignm
   }
 }
 
+@description('The resource ID of the auto manage account')
 output autoManageAccountResourceId string = autoManageAccount.outputs.accountResourceId
+
+@description('The name of the auto manage account')
 output autoManageAccountName string = autoManageAccount.outputs.accountName
+
+@description('The resource group the auto manage account was deployed into')
 output autoManageAccountResourceGroup string = autoManageAccountResourceGroupName

--- a/arm/Microsoft.Automanage/accounts/readme.md
+++ b/arm/Microsoft.Automanage/accounts/readme.md
@@ -14,21 +14,21 @@ This module deploys an AutoManage account and associates VM with it.
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `autoManageAccountName` | string | `[format('{0}-AutoManage', replace(subscription().displayName, ' ', ''))]` |  | Optional. The name of automanage account |
 | `autoManageAccountResourceGroupName` | string | `[format('{0}_group', replace(subscription().displayName, ' ', ''))]` |  | Optional. The resource group name where automanage will be created |
 | `configurationProfile` | string | `Production` | `[Production, Dev/Test]` | Optional. The configuration profile of automanage |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered. |
 | `location` | string | `[deployment().location]` |  | Optional. The location of automanage |
+| `name` | string | `[format('{0}-AutoManage', replace(subscription().displayName, ' ', ''))]` |  | Optional. The name of automanage account |
 | `vmName` | string |  |  | Required. The name of the VM to be associated |
 | `vmResourceGroupName` | string |  |  | Required. The name of the VM resource group |
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `autoManageAccountName` | string |
-| `autoManageAccountResourceGroup` | string |
-| `autoManageAccountResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `autoManageAccountName` | string | The name of the auto manage account |
+| `autoManageAccountResourceGroup` | string | The resource group the auto manage account was deployed into |
+| `autoManageAccountResourceId` | string | The resource ID of the auto manage account |
 
 ## Template references
 


### PR DESCRIPTION
# Change

- Update AutoManage to use `name` input parameter
- Updated paramter file
- Updated docs

Pipeline reference
[![Automanage: Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.automanage.accounts.yml/badge.svg?branch=users%2Falsehr%2F547_automanage_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.automanage.accounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
