### PR TITLE
Update Storage to use `existing`

### DIFF
--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/deploy.bicep
@@ -33,23 +33,24 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
 
     resource container 'containers@2019-06-01' existing = {
       name: containerName
-
-      resource immutabilityPolicy 'immutabilityPolicies@2019-06-01' = {
-        name: name
-        properties: {
-          immutabilityPeriodSinceCreationInDays: immutabilityPeriodSinceCreationInDays
-          allowProtectedAppendWrites: allowProtectedAppendWrites
-        }
-      }
     }
   }
 }
 
+resource immutabilityPolicy 'Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@2019-06-01' = {
+  name: name
+  parent: storageAccount::blobServices::container
+  properties: {
+    immutabilityPeriodSinceCreationInDays: immutabilityPeriodSinceCreationInDays
+    allowProtectedAppendWrites: allowProtectedAppendWrites
+  }
+}
+
 @description('The name of the deployed immutability policy.')
-output immutabilityPolicyName string = storageAccount::blobServices::container::immutabilityPolicy.name
+output immutabilityPolicyName string = immutabilityPolicy.name
 
 @description('The resource ID of the deployed immutability policy.')
-output immutabilityPolicyResourceId string = storageAccount::blobServices::container::immutabilityPolicy.id
+output immutabilityPolicyResourceId string = immutabilityPolicy.id
 
 @description('The resource group of the deployed immutability policy.')
 output immutabilityPolicyResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/deploy.bicep
@@ -27,16 +27,17 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
+}
 
-  resource blobServices 'blobServices@2021-06-01' = {
-    name: name
-    properties: {
-      deleteRetentionPolicy: {
-        enabled: deleteRetentionPolicy
-        days: deleteRetentionPolicyDays
-      }
-      automaticSnapshotPolicyEnabled: automaticSnapshotPolicyEnabled
+resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2021-06-01' = {
+  name: name
+  parent: storageAccount
+  properties: {
+    deleteRetentionPolicy: {
+      enabled: deleteRetentionPolicy
+      days: deleteRetentionPolicyDays
     }
+    automaticSnapshotPolicyEnabled: automaticSnapshotPolicyEnabled
   }
 }
 
@@ -44,7 +45,7 @@ module blobServices_container 'containers/deploy.bicep' = [for (container, index
   name: '${deployment().name}-Storage-Container-${index}'
   params: {
     storageAccountName: storageAccount.name
-    blobServicesName: storageAccount::blobServices.name
+    blobServicesName: blobServices.name
     name: container.name
     publicAccess: contains(container, 'publicAccess') ? container.publicAccess : 'None'
     roleAssignments: contains(container, 'roleAssignments') ? container.roleAssignments : []
@@ -53,10 +54,10 @@ module blobServices_container 'containers/deploy.bicep' = [for (container, index
 }]
 
 @description('The name of the deployed blob service')
-output blobServicesName string = storageAccount::blobServices.name
+output blobServicesName string = blobServices.name
 
 @description('The resource ID of the deployed blob service')
-output blobServicesResourceId string = storageAccount::blobServices.id
+output blobServicesResourceId string = blobServices.id
 
 @description('The name of the deployed blob service')
 output blobServicesResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
@@ -27,20 +27,22 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
+}
 
-  resource fileServices 'fileServices@2021-04-01' = {
-    name: name
-    properties: {
-      protocolSettings: protocolSettings
-      shareDeleteRetentionPolicy: shareDeleteRetentionPolicy
-    }
+resource fileServices 'Microsoft.Storage/storageAccounts/fileServices@2021-04-01' = {
+  name: name
+  parent: storageAccount
+  properties: {
+    protocolSettings: protocolSettings
+    shareDeleteRetentionPolicy: shareDeleteRetentionPolicy
   }
 }
+
 module fileServices_shares 'shares/deploy.bicep' = [for (share, index) in shares: {
   name: '${deployment().name}-Storage-File-${index}'
   params: {
     storageAccountName: storageAccount.name
-    fileServicesName: storageAccount::fileServices.name
+    fileServicesName: fileServices.name
     name: share.name
     sharedQuota: contains(share, 'sharedQuota') ? share.sharedQuota : 5120
     roleAssignments: contains(share, 'roleAssignments') ? share.roleAssignments : []
@@ -48,10 +50,10 @@ module fileServices_shares 'shares/deploy.bicep' = [for (share, index) in shares
 }]
 
 @description('The name of the deployed file share service')
-output fileServicesName string = storageAccount::fileServices.name
+output fileServicesName string = fileServices.name
 
 @description('The resource ID of the deployed file share service')
-output fileServicesResourceId string = storageAccount::fileServices.id
+output fileServicesResourceId string = fileServices.id
 
 @description('The resource group of the deployed file share service')
 output fileServicesResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/managementPolicies/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/managementPolicies/deploy.bicep
@@ -18,23 +18,24 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
+}
 
-  // lifecycle policy
-  resource managementPolicy 'managementPolicies@2019-06-01' = if (!empty(rules)) {
-    name: name
-    properties: {
-      policy: {
-        rules: rules
-      }
+// lifecycle policy
+resource managementPolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2019-06-01' = if (!empty(rules)) {
+  name: name
+  parent: storageAccount
+  properties: {
+    policy: {
+      rules: rules
     }
   }
 }
 
 @description('The resource ID of the deployed management policy')
-output managementPoliciesResourceId string = storageAccount::managementPolicy.name
+output managementPoliciesResourceId string = managementPolicy.name
 
 @description('The name of the deployed management policy')
-output managementPoliciesName string = storageAccount::managementPolicy.name
+output managementPoliciesName string = managementPolicy.name
 
 @description('The resource group of the deployed management policy')
 output managementPoliciesResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/deploy.bicep
@@ -18,18 +18,19 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
+}
 
-  resource queueServices 'queueServices@2021-04-01' = {
-    name: name
-    properties: {}
-  }
+resource queueServices 'Microsoft.Storage/storageAccounts/queueServices@2021-04-01' = {
+  name: name
+  parent: storageAccount
+  properties: {}
 }
 
 module queueServices_queues 'queues/deploy.bicep' = [for (queue, index) in queues: {
   name: '${deployment().name}-Storage-Queue-${index}'
   params: {
     storageAccountName: storageAccount.name
-    queueServicesName: storageAccount::queueServices.name
+    queueServicesName: queueServices.name
     name: queue.name
     metadata: contains(queue, 'metadata') ? queue.metadata : {}
     roleAssignments: contains(queue, 'roleAssignments') ? queue.roleAssignments : []
@@ -37,10 +38,10 @@ module queueServices_queues 'queues/deploy.bicep' = [for (queue, index) in queue
 }]
 
 @description('The name of the deployed file share service')
-output queueServicesName string = storageAccount::queueServices.name
+output queueServicesName string = queueServices.name
 
 @description('The resource ID of the deployed file share service')
-output queueServicesResourceId string = storageAccount::queueServices.id
+output queueServicesResourceId string = queueServices.id
 
 @description('The resource group of the deployed file share service')
 output queueServicesResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
@@ -27,13 +27,14 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
 
   resource queueServices 'queueServices@2021-06-01' existing = {
     name: queueServicesName
+  }
+}
 
-    resource queue 'queues@2019-06-01' = {
-      name: name
-      properties: {
-        metadata: metadata
-      }
-    }
+resource queue 'Microsoft.Storage/storageAccounts/queueServices/queues@2019-06-01' = {
+  name: name
+  parent: storageAccount::queueServices
+  properties: {
+    metadata: metadata
   }
 }
 
@@ -42,15 +43,15 @@ module queue_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   params: {
     principalIds: roleAssignment.principalIds
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
-    resourceId: '${storageAccount::queueServices::queue.id}'
+    resourceId: '${queue.id}'
   }
 }]
 
 @description('The name of the deployed queue')
-output queueName string = storageAccount::queueServices::queue.name
+output queueName string = queue.name
 
 @description('The resource ID of the deployed queue')
-output queueResourceId string = storageAccount::queueServices::queue.id
+output queueResourceId string = queue.id
 
 @description('The resource group of the deployed queue')
 output queueResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/tableServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/tableServices/deploy.bicep
@@ -18,27 +18,28 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
+}
 
-  resource tableServices 'tableServices@2021-04-01' = {
-    name: name
-    properties: {}
-  }
+resource tableServices 'Microsoft.Storage/storageAccounts/tableServices@2021-04-01' = {
+  name: name
+  parent: storageAccount
+  properties: {}
 }
 
 module tableServices_tables 'tables/deploy.bicep' = [for (tableName, index) in tables: {
   name: '${deployment().name}-Storage-Table-${index}'
   params: {
     storageAccountName: storageAccount.name
-    tableServicesName: storageAccount::tableServices.name
+    tableServicesName: tableServices.name
     name: tableName
   }
 }]
 
 @description('The name of the deployed table service')
-output tableServicesName string = storageAccount::tableServices.name
+output tableServicesName string = tableServices.name
 
 @description('The resource ID of the deployed table service')
-output tableServicesResourceId string = storageAccount::tableServices.id
+output tableServicesResourceId string = tableServices.id
 
 @description('The resource group of the deployed table service')
 output tableServicesResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Storage/storageAccounts/tableServices/tables/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/tableServices/tables/deploy.bicep
@@ -21,18 +21,19 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
 
   resource tableServices 'tableServices@2021-04-01' existing = {
     name: tableServicesName
-
-    resource table 'tables@2021-06-01' = {
-      name: name
-    }
   }
 }
 
+resource table 'Microsoft.Storage/storageAccounts/tableServices/tables@2021-06-01' = {
+  name: name
+  parent: storageAccount::tableServices
+}
+
 @description('The name of the deployed file share service')
-output tableName string = storageAccount::tableServices::table.name
+output tableName string = table.name
 
 @description('The resource ID of the deployed file share service')
-output tableResourceId string = storageAccount::tableServices::table.id
+output tableResourceId string = table.id
 
 @description('The resource group of the deployed file share service')
 output tableResourceGroup string = resourceGroup().name


### PR DESCRIPTION
# Change

- Update storage to use `existing` for parent resources

Pipeline reference
[![Storage: Storage Account](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2F579_storage_existing)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
