### PR TITLE
Aligned serveral modules to use `name` parameter

### DIFF
--- a/arm/Microsoft.Automanage/accounts/deploy.bicep
+++ b/arm/Microsoft.Automanage/accounts/deploy.bicep
@@ -68,6 +68,9 @@ module configurationProfileAssignment '.bicep/nested_configurationProfileAssignm
     configurationProfile: configurationProfile
     autoManageAccountResourceId: autoManageAccount.outputs.accountResourceId
   }
+  dependsOn: [
+    autoManageAccount
+  ]
 }
 
 @description('The resource ID of the auto manage account')

--- a/arm/Microsoft.Automanage/accounts/deploy.bicep
+++ b/arm/Microsoft.Automanage/accounts/deploy.bicep
@@ -42,7 +42,6 @@ module autoManageAccount '.bicep/nested_autoManageAccount.bicep' = {
   }
 }
 
-//principalId: (createAutoManageAccount ? autoManageAccount.outputs.principalId : 'resource not deployed')
 resource autoManageAccount_permissions_contributor 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid(autoManageAccountResourceGroupName, name, contributor)
   properties: {

--- a/arm/Microsoft.Compute/availabilitySets/.parameters/parameters.json
+++ b/arm/Microsoft.Compute/availabilitySets/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "availabilitySetName": {
+        "name": {
             "value": "sxx-az-avs-x-001"
         },
         "roleAssignments": {

--- a/arm/Microsoft.Compute/availabilitySets/deploy.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the availability set that is being created.')
-param availabilitySetName string
+param name string
 
 @description('Optional. The number of fault domains to use.')
 param availabilitySetFaultDomain int = 2
@@ -39,7 +39,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource availabilitySet 'Microsoft.Compute/availabilitySets@2021-04-01' = {
-  name: availabilitySetName
+  name: name
   location: location
   tags: tags
   properties: {
@@ -75,5 +75,6 @@ output availabilitySetResourceName string = availabilitySet.name
 
 @description('The resource ID of the availability set')
 output availabilitySetResourceId string = availabilitySet.id
+
 @description('The name of the availability set')
 output availabilitySetResourceGroup string = resourceGroup().name

--- a/arm/Microsoft.Compute/availabilitySets/readme.md
+++ b/arm/Microsoft.Compute/availabilitySets/readme.md
@@ -15,12 +15,12 @@ This template deploys an Availability Set
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `availabilitySetFaultDomain` | int | `2` |  | Optional. The number of fault domains to use. |
-| `availabilitySetName` | string |  |  | Required. The name of the availability set that is being created. |
 | `availabilitySetSku` | string | `Aligned` |  | Optional. Sku of the availability set. Use 'Aligned' for virtual machines with managed disks and 'Classic' for virtual machines with unmanaged disks. |
 | `availabilitySetUpdateDomain` | int | `5` |  | Optional. The number of update domains to use. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Resource location. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
+| `name` | string |  |  | Required. The name of the availability set that is being created. |
 | `proximityPlacementGroupId` | string |  |  | Optional. Resource ID of a proximity placement group. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Optional. Tags of the availability set resource. |

--- a/arm/Microsoft.Compute/diskEncryptionSets/.parameters/parameters.json
+++ b/arm/Microsoft.Compute/diskEncryptionSets/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "diskEncryptionSetName": {
+        "name": {
             "value": "sxx-az-des-x-001"
         },
         "keyVaultId": {

--- a/arm/Microsoft.Compute/diskEncryptionSets/deploy.bicep
+++ b/arm/Microsoft.Compute/diskEncryptionSets/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the disk encryption set that is being created.')
-param diskEncryptionSetName string
+param name string
 
 @description('Optional. Resource location.')
 param location string = resourceGroup().location
@@ -46,7 +46,7 @@ resource keyVaultAccessPolicies 'Microsoft.KeyVault/vaults/accessPolicies@2019-0
 }
 
 resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2020-12-01' = {
-  name: diskEncryptionSetName
+  name: name
   location: location
   tags: tags
   identity: {
@@ -78,7 +78,7 @@ output diskEncryptionSetResourceId string = diskEncryptionSet.id
 output diskEncryptionSetName string = diskEncryptionSet.name
 
 @description('The principal ID of the disk encryption set')
-output principalId string = reference('Microsoft.Compute/diskEncryptionSets/${diskEncryptionSetName}', '2020-12-01', 'Full').identity.principalId
+output principalId string = diskEncryptionSet.identity.principalId
 
 @description('The name of the key vault with the disk encryption key')
 output keyVaultName string = last(split(keyVaultId, '/'))

--- a/arm/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/arm/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -15,10 +15,10 @@ This template deploys a Disk Encryption Set
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
-| `diskEncryptionSetName` | string |  |  | Required. The name of the disk encryption set that is being created. |
 | `keyUrl` | string |  |  | Required. Key URL (with version) pointing to a key or secret in KeyVault. |
 | `keyVaultId` | string |  |  | Required. Resource ID of the KeyVault containing the key or secret. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Resource location. |
+| `name` | string |  |  | Required. The name of the disk encryption set that is being created. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Optional. Tags of the Automation Account resource. |
 

--- a/arm/Microsoft.Compute/galleries/.parameters/images.parameters.json
+++ b/arm/Microsoft.Compute/galleries/.parameters/images.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "galleryName": {
+        "name": {
             "value": "sxxazsigweux002"
         },
         "images": {

--- a/arm/Microsoft.Compute/galleries/.parameters/parameters.json
+++ b/arm/Microsoft.Compute/galleries/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "galleryName": {
+        "name": {
             "value": "sxxazsigweux001"
         },
         "roleAssignments": {

--- a/arm/Microsoft.Compute/galleries/deploy.bicep
+++ b/arm/Microsoft.Compute/galleries/deploy.bicep
@@ -1,6 +1,6 @@
 @minLength(1)
 @description('Required. Name of the Azure Shared Image Gallery')
-param galleryName string
+param name string
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -34,7 +34,7 @@ module pidName '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource gallery 'Microsoft.Compute/galleries@2020-09-30' = {
-  name: galleryName
+  name: name
   location: location
   tags: tags
   properties: {
@@ -98,4 +98,4 @@ output galleryResourceId string = gallery.id
 output galleryResourceGroup string = resourceGroup().name
 
 @description('The name of the deployed image gallery')
-output galleryName string = galleryName
+output galleryName string = gallery.name

--- a/arm/Microsoft.Compute/galleries/images/deploy.bicep
+++ b/arm/Microsoft.Compute/galleries/images/deploy.bicep
@@ -99,8 +99,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
-resource galleryImage 'Microsoft.Compute/galleries/images@2020-09-30' = {
-  name: '${galleryName}/${name}'
+resource gallery 'Microsoft.Compute/galleries@2020-09-30' existing = {
+  name: galleryName
+}
+
+resource image 'Microsoft.Compute/galleries/images@2020-09-30' = {
+  name: name
+  parent: gallery
   location: location
   tags: tags
   properties: {
@@ -143,12 +148,15 @@ module galleryImage_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, inde
   params: {
     principalIds: roleAssignment.principalIds
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
-    resourceId: galleryImage.id
+    resourceId: image.id
   }
 }]
 
-output galleryResourceId string = resourceId('Microsoft.Compute/galleries', galleryName)
+@description('The resource group the image was deployed into')
 output galleryResourceGroup string = resourceGroup().name
-output galleryName string = galleryName
-output galleryImageResourceId string = galleryImage.id
-output galleryImageName string = galleryImage.name
+
+@description('The resource ID of the image')
+output galleryImageResourceId string = image.id
+
+@description('The name of the image')
+output galleryImageName string = image.name

--- a/arm/Microsoft.Compute/galleries/images/readme.md
+++ b/arm/Microsoft.Compute/galleries/images/readme.md
@@ -87,13 +87,11 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `galleryImageName` | string |
-| `galleryImageResourceId` | string |
-| `galleryName` | string |
-| `galleryResourceGroup` | string |
-| `galleryResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `galleryImageName` | string | The name of the image |
+| `galleryImageResourceId` | string | The resource ID of the image |
+| `galleryResourceGroup` | string | The resource group the image was deployed into |
 
 ## Template references
 

--- a/arm/Microsoft.Compute/galleries/readme.md
+++ b/arm/Microsoft.Compute/galleries/readme.md
@@ -17,10 +17,10 @@ This module deploys Share Image Gallery, with resource lock.
 | :-- | :-- | :-- | :-- | :-- |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `galleryDescription` | string |  |  | Optional. Description of the Azure Shared Image Gallery |
-| `galleryName` | string |  |  | Required. Name of the Azure Shared Image Gallery |
 | `images` | _[images](images/readme.md)_ array | `[]` |  | Optional. Images to create |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
+| `name` | string |  |  | Required. Name of the Azure Shared Image Gallery |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Optional. Tags for all resources. |
 

--- a/arm/Microsoft.Compute/proximityPlacementGroups/.parameters/parameters.json
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "proximityPlacementGroupName": {
+        "name": {
             "value": "sxx-az-ppg-x-001"
         },
         "roleAssignments": {

--- a/arm/Microsoft.Compute/proximityPlacementGroups/deploy.bicep
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. The name of the proximity placement group that is being created.')
-param proximityPlacementGroupName string = ''
+param name string = ''
 
 @description('Optional. Specifies the type of the proximity placement group.')
 @allowed([
@@ -34,7 +34,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource proximityPlacementGroup 'Microsoft.Compute/proximityPlacementGroups@2021-04-01' = {
-  name: proximityPlacementGroupName
+  name: name
   location: location
   tags: tags
   properties: {

--- a/arm/Microsoft.Compute/proximityPlacementGroups/readme.md
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/readme.md
@@ -17,7 +17,7 @@ This template deploys a Proximity Placement Group
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Resource location. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
-| `proximityPlacementGroupName` | string |  |  | Required. The name of the proximity placement group that is being created. |
+| `name` | string |  |  | Required. The name of the proximity placement group that is being created. |
 | `proximityPlacementGroupType` | string | `Standard` | `[Standard, Ultra]` | Optional. Specifies the type of the proximity placement group. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Optional. Tags of the proximity placement group resource. |

--- a/arm/Microsoft.Compute/virtualMachines/extensions/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/extensions/deploy.bicep
@@ -43,8 +43,13 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' existing = {
+  name: virtualMachineName
+}
+
 resource extension 'Microsoft.Compute/virtualMachines/extensions@2021-07-01' = {
-  name: '${virtualMachineName}/${name}'
+  name: name
+  parent: virtualMachine
   location: location
   properties: {
     publisher: publisher

--- a/arm/Microsoft.HealthBot/healthBots/.parameters/parameters.json
+++ b/arm/Microsoft.HealthBot/healthBots/.parameters/parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "azureHealthBotName": {
+        "name": {
             "value": "sxx-az-ahb-x-001"
         },
         "roleAssignments": {

--- a/arm/Microsoft.HealthBot/healthBots/deploy.bicep
+++ b/arm/Microsoft.HealthBot/healthBots/deploy.bicep
@@ -1,5 +1,5 @@
 @description('Required. Name of the resource')
-param azureHealthBotName string
+param name string
 
 @description('Optional. The resource model definition representing SKU.')
 param sku string = 'F0'
@@ -30,7 +30,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource azureHealthBot 'Microsoft.HealthBot/healthBots@2020-12-08' = {
-  name: azureHealthBotName
+  name: name
   location: location
   tags: tags
   sku: {
@@ -57,6 +57,11 @@ module healthBot_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   }
 }]
 
+@description('The resource group the health bot was deployed into')
 output azureHealthBotResourceGroup string = resourceGroup().name
+
+@description('The name of the health bot')
 output azureHealthBotName string = azureHealthBot.name
+
+@description('The resource ID of the health bot')
 output azureHealthBotResourceId string = azureHealthBot.id

--- a/arm/Microsoft.HealthBot/healthBots/readme.md
+++ b/arm/Microsoft.HealthBot/healthBots/readme.md
@@ -14,10 +14,10 @@ This module deploys an Azure Health Bot.
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `azureHealthBotName` | string |  |  | Required. Name of the resource |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
+| `name` | string |  |  | Required. Name of the resource |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `sku` | string | `F0` |  | Optional. The resource model definition representing SKU. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
@@ -63,11 +63,11 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `azureHealthBotName` | string |
-| `azureHealthBotResourceGroup` | string |
-| `azureHealthBotResourceId` | string |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `azureHealthBotName` | string | The name of the health bot |
+| `azureHealthBotResourceGroup` | string | The resource group the health bot was deployed into |
+| `azureHealthBotResourceId` | string | The resource ID of the health bot |
 
 ## Template references
 

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -84,7 +84,6 @@ var publicIPPrefix = {
   id: publicIPPrefixId
 }
 var azureFirewallSubnetId = '${vNetId}/subnets/AzureFirewallSubnet'
-var azureFirewallPipName_var = (empty(azureFirewallPipName) ? '${name}-pip' : azureFirewallPipName)
 var azureFirewallPipId = azureFirewallPip.id
 
 @description('Optional. The name of firewall logs that will be streamed.')
@@ -153,7 +152,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource azureFirewallPip 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
-  name: azureFirewallPipName_var
+  name: !empty(azureFirewallPipName) ? azureFirewallPipName : '${name}-pip'
   location: location
   tags: tags
   sku: {

--- a/arm/Microsoft.Network/bastionHosts/deploy.bicep
+++ b/arm/Microsoft.Network/bastionHosts/deploy.bicep
@@ -116,7 +116,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource azureBastionPip 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
-  name: empty(azureBastionPipName) ? '${name}-pip' : azureBastionPipName
+  name: !empty(azureBastionPipName) ? azureBastionPipName : '${name}-pip'
   location: location
   tags: tags
   sku: {

--- a/arm/Microsoft.Network/privateEndpoints/privateDnsZoneGroups/deploy.bicep
+++ b/arm/Microsoft.Network/privateEndpoints/privateDnsZoneGroups/deploy.bicep
@@ -4,8 +4,8 @@ param privateEndpointName string
 @description('Required. List of private DNS resource IDs')
 param privateDNSResourceIds array
 
-@description('The name of the private DNS Zone Group')
-param privateDnsZoneGroupName string = 'default'
+@description('Optional. The name of the private DNS Zone Group')
+param name string = 'default'
 
 var privateDnsZoneConfigs = [for privateDNSResourceId in privateDNSResourceIds: {
   name: privateEndpointName
@@ -19,7 +19,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-03-01' existin
 }
 
 resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2021-03-01' = {
-  name: privateDnsZoneGroupName
+  name: name
   parent: privateEndpoint
   properties: {
     privateDnsZoneConfigs: privateDnsZoneConfigs

--- a/arm/Microsoft.Network/privateEndpoints/privateDnsZoneGroups/readme.md
+++ b/arm/Microsoft.Network/privateEndpoints/privateDnsZoneGroups/readme.md
@@ -12,8 +12,8 @@ This module deploys a private endpoint private DNS zone group
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `name` | string | `default` |  | Optional. The name of the private DNS Zone Group |
 | `privateDNSResourceIds` | array |  |  | Required. List of private DNS resource IDs |
-| `privateDnsZoneGroupName` | string | `default` |  | The name of the private DNS Zone Group |
 | `privateEndpointName` | string |  |  | Required. The name of the private endpoint |
 
 ## Outputs

--- a/arm/Microsoft.Network/virtualWans/deploy.bicep
+++ b/arm/Microsoft.Network/virtualWans/deploy.bicep
@@ -67,7 +67,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   params: {}
 }
 
-resource virtualWan 'Microsoft.Network/virtualWans@2021-05-01' = {
+resource virtualWan 'Microsoft.Network/virtualWans@2021-03-01' = {
   name: name
   location: location
   tags: tags
@@ -85,7 +85,7 @@ resource virtualWan_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock !
   scope: virtualWan
 }
 
-resource virtualHub 'Microsoft.Network/virtualHubs@2021-05-01' = {
+resource virtualHub 'Microsoft.Network/virtualHubs@2021-03-01' = {
   name: virtualHubName
   location: location
   properties: {
@@ -105,7 +105,7 @@ resource virtualHub_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock !
   scope: virtualHub
 }
 
-resource vpnSite 'Microsoft.Network/vpnSites@2021-05-01' = {
+resource vpnSite 'Microsoft.Network/vpnSites@2021-03-01' = {
   name: vpnSiteName
   location: location
   properties: {
@@ -136,7 +136,7 @@ resource vpnSite_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock != '
   scope: vpnSite
 }
 
-resource vpnGateway 'Microsoft.Network/vpnGateways@2021-05-01' = {
+resource vpnGateway 'Microsoft.Network/vpnGateways@2021-03-01' = {
   name: vpnGatewayName
   location: location
   properties: {

--- a/arm/Microsoft.Network/virtualWans/readme.md
+++ b/arm/Microsoft.Network/virtualWans/readme.md
@@ -8,10 +8,10 @@ This template deploys Virtual Wan
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2016-09-01 |
 | `Microsoft.Authorization/roleAssignments` | 2020-04-01-preview |
-| `Microsoft.Network/virtualHubs` | 2021-05-01 |
-| `Microsoft.Network/virtualWans` | 2021-05-01 |
-| `Microsoft.Network/vpnGateways` | 2021-05-01 |
-| `Microsoft.Network/vpnSites` | 2021-05-01 |
+| `Microsoft.Network/virtualHubs` | 2021-03-01 |
+| `Microsoft.Network/virtualWans` | 2021-03-01 |
+| `Microsoft.Network/vpnGateways` | 2021-03-01 |
+| `Microsoft.Network/vpnSites` | 2021-03-01 |
 
 ## Parameters
 
@@ -93,7 +93,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 - [Locks](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2016-09-01/locks)
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-04-01-preview/roleAssignments)
-- [Virtualhubs](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/virtualHubs)
-- [Virtualwans](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/virtualWans)
-- [Vpngateways](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/vpnGateways)
-- [Vpnsites](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/vpnSites)
+- [Virtualhubs](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/virtualHubs)
+- [Virtualwans](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/virtualWans)
+- [Vpngateways](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/vpnGateways)
+- [Vpnsites](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/vpnSites)

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -122,7 +122,6 @@ var azureFilesIdentityBasedAuthentication_var = azureFilesIdentityBasedAuthentic
 var maxNameLength = 24
 var uniqueStoragenameUntrim = '${uniqueString('Storage Account${basetime}')}'
 var uniqueStoragename = length(uniqueStoragenameUntrim) > maxNameLength ? substring(uniqueStoragenameUntrim, 0, maxNameLength) : uniqueStoragenameUntrim
-var storageAccountName_var = empty(name) ? uniqueStoragename : name
 
 var saBaseProperties = {
   encryption: {
@@ -150,7 +149,7 @@ module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
 }
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
-  name: storageAccountName_var
+  name: !empty(name) ? name : uniqueStoragename
   location: location
   kind: storageAccountKind
   sku: {


### PR DESCRIPTION
# Change

- Aligned serveral modules to use `name` parameter
- Smaller improvements/cleanup to additional modules
- Fixed a bug of namespace module parameter passthru

Pipeline reference
[![Automanage: Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.automanage.accounts.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.automanage.accounts.yml)
[![Compute: Availabilitysets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml)
[![Compute: Diskencryptionsets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml)
[![Compute: Galleries](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.galleries.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.galleries.yml)
[![Compute: ProximityPlacementGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.proximityplacementgroups.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.proximityplacementgroups.yml)
[![Compute: Virtualmachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml)
[![HealthBot: Healthbots](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthbot.healthbots.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthbot.healthbots.yml)
[![Network: Azurefirewalls](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.azurefirewalls.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.azurefirewalls.yml)
[![Network: Bastionhosts](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml)
[![Network: Privateendpoints](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privateendpoints.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privateendpoints.yml)
[![ServiceBus: Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml/badge.svg?branch=users%2Falsehr%2F330_input_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
