### PR TITLE
(546) - Policy Definitions: Updated Module To Align with Other Resources

### DIFF
--- a/.github/workflows/ms.authorization.policydefinitions.yml
+++ b/.github/workflows/ms.authorization.policydefinitions.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parameterFilePaths: ['parameters.json']
+        parameterFilePaths: ['parameters.json', 'min.parameters.json']
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
@@ -1,30 +1,28 @@
 targetScope = 'managementGroup'
-param policyDefinitionName string
+param name string
 param displayName string = ''
-param policyDescription string = ''
+param description string = ''
 param mode string = 'All'
 param metadata object = {}
 param parameters object = {}
 param policyRule object
 param managementGroupId string
-param location string = deployment().location
 
-var policyDefinitionName_var = toLower(replace(policyDefinitionName, ' ', '-'))
+var name_var = toLower(replace(name, ' ', '-'))
 
-resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {
-  name: policyDefinitionName_var
-  location: location
+resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01' = {
+  name: name_var
   properties: {
     policyType: 'Custom'
     mode: mode
-    displayName: (empty(displayName) ? null : displayName)
-    description: (empty(policyDescription) ? null : policyDescription)
-    metadata: (empty(metadata) ? null : metadata)
-    parameters: (empty(parameters) ? null : parameters)
+    displayName: empty(displayName) ? null : displayName
+    description: empty(description) ? null : description
+    metadata: empty(metadata) ? null : metadata
+    parameters: empty(parameters) ? null : parameters
     policyRule: policyRule
   }
 }
 
-output policyDefinitionName string = policyDefinition.name
-output policyDefinitionId string = extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', managementGroupId), 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
+output PolicyDefinitionName string = policyDefinition.name
+output policyDefinitionResourceId string = extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', managementGroupId), 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
 output roleDefinitionIds array = (contains(policyDefinition.properties.policyRule.then, 'details') ? ((contains(policyDefinition.properties.policyRule.then.details, 'roleDefinitionIds') ? policyDefinition.properties.policyRule.then.details.roleDefinitionIds : [])) : [])

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
@@ -48,7 +48,7 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01'
 }
 
 @sys.description('Policy Definition Name')
-output PolicyDefinitionName string = policyDefinition.name
+output policyDefinitionName string = policyDefinition.name
 
 @sys.description('Policy Definition Resource ID')
 output policyDefinitionResourceId string = extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', managementGroupId), 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_mg.bicep
@@ -1,11 +1,35 @@
 targetScope = 'managementGroup'
+
+@sys.description('Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase')
+@maxLength(64)
 param name string
+
+@sys.description('Optional. The display name of the policy definition.')
 param displayName string = ''
+
+@sys.description('Optional. The policy definition description.')
 param description string = ''
+
+@sys.description('Optional. The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data.')
+@allowed([
+  'All'
+  'Indexed'
+  'Microsoft.KeyVault.Data'
+  'Microsoft.ContainerService.Data'
+  'Microsoft.Kubernetes.Data'
+])
 param mode string = 'All'
+
+@sys.description('Optional. The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs.')
 param metadata object = {}
+
+@sys.description('Optional. The policy definition parameters that can be used in policy definition references.')
 param parameters object = {}
+
+@sys.description('Required. The Policy Rule details for the Policy Definition')
 param policyRule object
+
+@sys.description('Required. The group ID of the Management Group')
 param managementGroupId string
 
 var name_var = toLower(replace(name, ' ', '-'))
@@ -23,6 +47,11 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01'
   }
 }
 
+@sys.description('Policy Definition Name')
 output PolicyDefinitionName string = policyDefinition.name
+
+@sys.description('Policy Definition Resource ID')
 output policyDefinitionResourceId string = extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', managementGroupId), 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
+
+@sys.description('Policy Definition Role Definition IDs')
 output roleDefinitionIds array = (contains(policyDefinition.properties.policyRule.then, 'details') ? ((contains(policyDefinition.properties.policyRule.then.details, 'roleDefinitionIds') ? policyDefinition.properties.policyRule.then.details.roleDefinitionIds : [])) : [])

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
@@ -48,7 +48,7 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01'
 }
 
 @sys.description('Policy Definition Name')
-output PolicyDefinitionName string = policyDefinition.name
+output policyDefinitionName string = policyDefinition.name
 
 @sys.description('Policy Definition Resource ID')
 output policyDefinitionResourceId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
@@ -1,30 +1,28 @@
 targetScope = 'subscription'
-param policyDefinitionName string
+param name string
 param displayName string = ''
-param policyDescription string = ''
+param description string = ''
 param mode string = 'All'
 param metadata object = {}
 param parameters object = {}
 param policyRule object
 param subscriptionId string = ''
-param location string = deployment().location
 
-var policyDefinitionName_var = toLower(replace(policyDefinitionName, ' ', '-'))
+var name_var = toLower(replace(name, ' ', '-'))
 
-resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {
-  name: policyDefinitionName_var
-  location: location
+resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01' = {
+  name: name_var
   properties: {
     policyType: 'Custom'
     mode: mode
-    displayName: (empty(displayName) ? null : displayName)
-    description: (empty(policyDescription) ? null : policyDescription)
-    metadata: (empty(metadata) ? null : metadata)
-    parameters: (empty(parameters) ? null : parameters)
+    displayName: empty(displayName) ? null : displayName
+    description: empty(description) ? null : description
+    metadata: empty(metadata) ? null : metadata
+    parameters: empty(parameters) ? null : parameters
     policyRule: policyRule
   }
 }
 
-output policyDefinitionName string = policyDefinition.name
-output policyDefinitionId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
+output PolicyDefinitionName string = policyDefinition.name
+output policyDefinitionResourceId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
 output roleDefinitionIds array = (contains(policyDefinition.properties.policyRule.then, 'details') ? ((contains(policyDefinition.properties.policyRule.then.details, 'roleDefinitionIds') ? policyDefinition.properties.policyRule.then.details.roleDefinitionIds : [])) : [])

--- a/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/.bicep/nested_policyDefinitions_sub.bicep
@@ -1,12 +1,36 @@
 targetScope = 'subscription'
+
+@sys.description('Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase')
+@maxLength(64)
 param name string
+
+@sys.description('Optional. The display name of the policy definition.')
 param displayName string = ''
+
+@sys.description('Optional. The policy definition description.')
 param description string = ''
+
+@sys.description('Optional. The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data.')
+@allowed([
+  'All'
+  'Indexed'
+  'Microsoft.KeyVault.Data'
+  'Microsoft.ContainerService.Data'
+  'Microsoft.Kubernetes.Data'
+])
 param mode string = 'All'
+
+@sys.description('Optional. The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs.')
 param metadata object = {}
+
+@sys.description('Optional. The policy definition parameters that can be used in policy definition references.')
 param parameters object = {}
+
+@sys.description('Required. The Policy Rule details for the Policy Definition')
 param policyRule object
-param subscriptionId string = ''
+
+@sys.description('Optional. The subscription ID of the subscription')
+param subscriptionId string = subscription().subscriptionId
 
 var name_var = toLower(replace(name, ' ', '-'))
 
@@ -23,6 +47,11 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01'
   }
 }
 
+@sys.description('Policy Definition Name')
 output PolicyDefinitionName string = policyDefinition.name
+
+@sys.description('Policy Definition Resource ID')
 output policyDefinitionResourceId string = subscriptionResourceId(subscriptionId, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
+
+@sys.description('Policy Definition Role Definition IDs')
 output roleDefinitionIds array = (contains(policyDefinition.properties.policyRule.then, 'details') ? ((contains(policyDefinition.properties.policyRule.then.details, 'roleDefinitionIds') ? policyDefinition.properties.policyRule.then.details.roleDefinitionIds : [])) : [])

--- a/arm/Microsoft.Authorization/policyDefinitions/.parameters/min.parameters.json
+++ b/arm/Microsoft.Authorization/policyDefinitions/.parameters/min.parameters.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "test-deny-keyvault-public-min"
+        },
+        "policyRule": {
+            "value": {
+                "if": {
+                    "allOf": [
+                        {
+                            "equals": "Microsoft.KeyVault/vaults",
+                            "field": "type"
+                        }
+                    ]
+                },
+                "then": {
+                    "effect": "[parameters('effect')]"
+                }
+            }
+        },
+        "parameters": {
+            "value": {
+                "effect": {
+                    "allowedValues": [
+                        "Audit"
+                    ],
+                    "defaultValue": "Audit",
+                    "type": "String"
+                }
+            }
+        },
+        "subscriptionId": {
+            "value": "<<subscriptionId>>"
+        }
+    }
+}

--- a/arm/Microsoft.Authorization/policyDefinitions/.parameters/parameters.json
+++ b/arm/Microsoft.Authorization/policyDefinitions/.parameters/parameters.json
@@ -2,45 +2,61 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "policyDefinitionName": {
-            "value": "test-deny-keyvault-public-access"
+        "name": {
+            "value": "test-add-tag-to-sub-policy"
         },
         "displayName": {
-            "value": "[Test] This policy denies creation of Key Vaults with IP Firewall exposed to all public endpoints"
+            "value": "[Test] This policy adds tags to a subscription"
+        },
+        "description": {
+            "value": "This is the description of a policy that adds tags to a subscription"
         },
         "policyRule": {
             "value": {
                 "if": {
                     "allOf": [
                         {
-                            "equals": "Microsoft.KeyVault/vaults",
-                            "field": "type"
+                            "field": "type",
+                            "equals": "Microsoft.Resources/subscriptions"
                         },
                         {
-                            "field": "Microsoft.KeyVault/vaults/networkAcls.defaultAction",
-                            "notequals": "Deny"
+                            "field": "[concat('tags[', parameters('tagName'), ']')]",
+                            "exists": "false"
                         }
                     ]
                 },
                 "then": {
-                    "effect": "[parameters('effect')]"
+                    "effect": "modify",
+                    "details": {
+                        "roleDefinitionIds": [
+                            "/providers/microsoft.authorization/roleDefinitions/4a9ae827-6dc8-4573-8ac7-8239d42aa03f"
+                        ],
+                        "operations": [
+                            {
+                                "operation": "add",
+                                "field": "[concat('tags[', parameters('tagName'), ']')]",
+                                "value": "[parameters('tagValue')]"
+                            }
+                        ]
+                    }
                 }
             }
         },
         "parameters": {
             "value": {
-                "effect": {
-                    "allowedValues": [
-                        "Audit",
-                        "Deny",
-                        "Disabled"
-                    ],
-                    "defaultValue": "Deny",
+                "tagName": {
+                    "type": "String",
                     "metadata": {
-                        "description": "Enable or disable the execution of the policy",
-                        "displayName": "Effect"
-                    },
-                    "type": "String"
+                        "displayName": "Tag Name",
+                        "description": "Name of the tag, such as 'environment'"
+                    }
+                },
+                "tagValue": {
+                    "type": "String",
+                    "metadata": {
+                        "displayName": "Tag Value",
+                        "description": "Value of the tag, such as 'production'"
+                    }
                 }
             }
         },

--- a/arm/Microsoft.Authorization/policyDefinitions/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/deploy.bicep
@@ -1,16 +1,16 @@
 targetScope = 'managementGroup'
 
-@description('Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase')
+@sys.description('Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase')
 @maxLength(64)
-param policyDefinitionName string
+param name string
 
-@description('Optional. The display name of the policy definition.')
+@sys.description('Optional. The display name of the policy definition.')
 param displayName string = ''
 
-@description('Optional. The policy definition description.')
-param policyDescription string = ''
+@sys.description('Optional. The policy definition description.')
+param description string = ''
 
-@description('Optional. The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data.')
+@sys.description('Optional. The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data.')
 @allowed([
   'All'
   'Indexed'
@@ -20,58 +20,59 @@ param policyDescription string = ''
 ])
 param mode string = 'All'
 
-@description('Optional. The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs.')
+@sys.description('Optional. The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs.')
 param metadata object = {}
 
-@description('Optional. The policy definition parameters that can be used in policy definition references.')
+@sys.description('Optional. The policy definition parameters that can be used in policy definition references.')
 param parameters object = {}
 
-@description('Required. The Policy Rule details for the Policy Definition')
+@sys.description('Required. The Policy Rule details for the Policy Definition')
 param policyRule object
 
-@description('Optional. The group ID of the Management Group (Scope). Cannot be used with subscriptionId and does not support tenant level deployment (i.e. \'/\')')
+@sys.description('Optional. The group ID of the Management Group (Scope). Cannot be used with subscriptionId and does not support tenant level deployment (i.e. \'/\')')
 param managementGroupId string = ''
 
-@description('Optional. The subscription ID of the subscription (Scope). Cannot be used with managementGroupId')
+@sys.description('Optional. The subscription ID of the subscription (Scope). Cannot be used with managementGroupId')
 param subscriptionId string = ''
 
-@description('Optional. Location for all resources.')
+@sys.description('Optional. Location for all resources.')
 param location string = deployment().location
 
-var policyDefinitionName_var = toLower(replace(policyDefinitionName, ' ', '-'))
+var name_var = toLower(replace(name, ' ', '-'))
 
 module policyDefinition_mg '.bicep/nested_policyDefinitions_mg.bicep' = if (empty(subscriptionId) && !empty(managementGroupId)) {
-  name: '${policyDefinitionName_var}-mgDeployment'
+  name: '${uniqueString(deployment().name, location)}-policyDefinition-mg-Module'
   scope: managementGroup(managementGroupId)
   params: {
-    policyDefinitionName: policyDefinitionName_var
-    location: location
+    name: name_var
     managementGroupId: managementGroupId
     mode: mode
-    displayName: (empty(displayName) ? '' : displayName)
-    policyDescription: (empty(policyDescription) ? '' : policyDescription)
-    metadata: (empty(metadata) ? {} : metadata)
-    parameters: (empty(parameters) ? {} : parameters)
+    displayName: empty(displayName) ? '' : displayName
+    description: empty(description) ? '' : description
+    metadata: empty(metadata) ? {} : metadata
+    parameters: empty(parameters) ? {} : parameters
     policyRule: policyRule
   }
 }
 
 module policyDefinition_sub '.bicep/nested_policyDefinitions_sub.bicep' = if (empty(managementGroupId) && !empty(subscriptionId)) {
-  name: '${policyDefinitionName_var}-subDeployment'
+  name: '${uniqueString(deployment().name, location)}-policyDefinition-sub-Module'
   scope: subscription(subscriptionId)
   params: {
-    policyDefinitionName: policyDefinitionName_var
-    location: location
+    name: name_var
     subscriptionId: subscriptionId
     mode: mode
-    displayName: (empty(displayName) ? '' : displayName)
-    policyDescription: (empty(policyDescription) ? '' : policyDescription)
-    metadata: (empty(metadata) ? {} : metadata)
-    parameters: (empty(parameters) ? {} : parameters)
+    displayName: empty(displayName) ? '' : displayName
+    description: empty(description) ? '' : description
+    metadata: empty(metadata) ? {} : metadata
+    parameters: empty(parameters) ? {} : parameters
     policyRule: policyRule
   }
 }
 
-output policyDefinitionName string = !empty(managementGroupId) ? policyDefinition_mg.outputs.policyDefinitionName : policyDefinition_sub.outputs.policyDefinitionName
-output policyDefinitionId string = !empty(managementGroupId) ? policyDefinition_mg.outputs.policyDefinitionId : policyDefinition_sub.outputs.policyDefinitionId
+@sys.description('Policy Definition Name')
+output PolicyDefinitionName string = !empty(managementGroupId) ? policyDefinition_mg.outputs.PolicyDefinitionName : policyDefinition_sub.outputs.PolicyDefinitionName
+@sys.description('Policy Definition Resource ID')
+output policyDefinitionResourceId string = !empty(managementGroupId) ? policyDefinition_mg.outputs.policyDefinitionResourceId : policyDefinition_sub.outputs.policyDefinitionResourceId
+@sys.description('Policy Definition Role Definition IDs')
 output roleDefinitionIds array = !empty(managementGroupId) ? policyDefinition_mg.outputs.roleDefinitionIds : policyDefinition_sub.outputs.roleDefinitionIds

--- a/arm/Microsoft.Authorization/policyDefinitions/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyDefinitions/deploy.bicep
@@ -71,7 +71,7 @@ module policyDefinition_sub '.bicep/nested_policyDefinitions_sub.bicep' = if (em
 }
 
 @sys.description('Policy Definition Name')
-output PolicyDefinitionName string = !empty(managementGroupId) ? policyDefinition_mg.outputs.PolicyDefinitionName : policyDefinition_sub.outputs.PolicyDefinitionName
+output policyDefinitionName string = !empty(managementGroupId) ? policyDefinition_mg.outputs.policyDefinitionName : policyDefinition_sub.outputs.policyDefinitionName
 @sys.description('Policy Definition Resource ID')
 output policyDefinitionResourceId string = !empty(managementGroupId) ? policyDefinition_mg.outputs.policyDefinitionResourceId : policyDefinition_sub.outputs.policyDefinitionResourceId
 @sys.description('Policy Definition Role Definition IDs')

--- a/arm/Microsoft.Authorization/policyDefinitions/readme.md
+++ b/arm/Microsoft.Authorization/policyDefinitions/readme.md
@@ -4,20 +4,20 @@
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyDefinitions` | 2020-09-01 |
+| `Microsoft.Authorization/policyDefinitions` | 2021-06-01 |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `description` | string |  |  | Optional. The policy definition description. |
 | `displayName` | string |  |  | Optional. The display name of the policy definition. |
 | `location` | string | `[deployment().location]` |  | Optional. Location for all resources. |
 | `managementGroupId` | string |  |  | Optional. The group ID of the Management Group (Scope). Cannot be used with subscriptionId and does not support tenant level deployment (i.e. '/') |
 | `metadata` | object | `{object}` |  | Optional. The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `mode` | string | `All` | `[All, Indexed, Microsoft.KeyVault.Data, Microsoft.ContainerService.Data, Microsoft.Kubernetes.Data]` | Optional. The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
+| `name` | string |  |  | Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase |
 | `parameters` | object | `{object}` |  | Optional. The policy definition parameters that can be used in policy definition references. |
-| `policyDefinitionName` | string |  |  | Required. Specifies the name of the policy definition. Space characters will be replaced by (-) and converted to lowercase |
-| `policyDescription` | string |  |  | Optional. The policy definition description. |
 | `policyRule` | object |  |  | Required. The Policy Rule details for the Policy Definition |
 | `subscriptionId` | string |  |  | Optional. The subscription ID of the subscription (Scope). Cannot be used with managementGroupId |
 
@@ -45,12 +45,12 @@ To deploy resource to an Azure Subscription, provide the `subscriptionId` as an 
 
 ## Outputs
 
-| Output Name | Type |
-| :-- | :-- |
-| `policyDefinitionId` | string |
-| `policyDefinitionName` | string |
-| `roleDefinitionIds` | array |
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `PolicyDefinitionName` | string | Policy Definition Name |
+| `policyDefinitionResourceId` | string | Policy Definition Resource ID |
+| `roleDefinitionIds` | array | Policy Definition Role Definition IDs |
 
 ## Template references
 
-- [Policydefinitions](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-09-01/policyDefinitions)
+- [Policydefinitions](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2021-06-01/policyDefinitions)


### PR DESCRIPTION
# Change

- Aligned to the [ARM Documentation](https://docs.microsoft.com/en-us/azure/templates/microsoft.authorization/policydefinitions?tabs=bicep)
- Used `@sys.description` instead of `description` when creating a new parameter `description`.
- Added description to the outputs.
- Added a `min.parameters.json` so that it captures the minimum content for a policy definition
- Expanded the `parameters.json` to cater for most of parameters in the template.
- Output changed from `policyDefinitionId` to `policyDefinitionResourceId`
- Updated Readme documentation to cater for new changes.
- Aligned to other modules for module names within the deploy.bicep
- Removed the location from the resource for Policy Definitions as they are not pinned to locations.
- removed extra brackets 
- Updated API Version
- Added Parameters and Outputs description in nested modules

## Testing

[![Authorization: policyDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml/badge.svg?branch=users%2Fahmad%2FmsAuthzPolicyDef)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml)

- Testing has been performed on the nested modules locally. Did an nested_mg and nested_sub
- Testing has been performed on the main deploy.bicep targeting mg and sub


## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
