### PR TITLE
#443 Update child resources for insights/privateLinkScopes

### DIFF
--- a/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_privateEndpoint.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_privateEndpoint.bicep
@@ -14,7 +14,7 @@ var privateEndpoint_var = {
   customDnsConfigs: (contains(privateEndpointObj, 'customDnsConfigs') ? (empty(privateEndpointObj.customDnsConfigs) ? null : privateEndpointObj.customDnsConfigs) : null)
 }
 
-resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-05-01' = {
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-03-01' = {
   name: privateEndpoint_var.name
   location: privateEndpointVnetLocation
   tags: tags

--- a/arm/Microsoft.Insights/privateLinkScopes/.parameters/parameters.json
+++ b/arm/Microsoft.Insights/privateLinkScopes/.parameters/parameters.json
@@ -5,6 +5,14 @@
         "name": {
             "value": "sxx-az-pls-x-001"
         },
+        "scopedResources": {
+            "value": [
+                {
+                    "name": "scoped1",
+                    "linkedResourceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-la-x-001"
+                }
+            ]
+        },
         "roleAssignments": {
             "value": [
                 {

--- a/arm/Microsoft.Insights/privateLinkScopes/deploy.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/deploy.bicep
@@ -38,14 +38,16 @@ resource privateLinkScope 'Microsoft.Insights/privateLinkScopes@2019-10-17-previ
   location: location
   tags: tags
   properties: {}
-
-  resource privateLinkScope_scopedResources 'scopedresources@2019-10-17-preview' = [for (scopedResource, index) in scopedResources: {
-    name: 'scoped-${last(split(scopedResource.linkedResourceId, '/'))}-${guid(uniqueString(privateLinkScope.name, scopedResource.linkedResourceId))}'
-    properties: {
-      linkedResourceId: scopedResource.linkedResourceId
-    }
-  }]
 }
+
+module privateLinkScope_scopedResource 'scopedResources/deploy.bicep' = [for (scopedResource, index) in scopedResources: {
+  name: '${uniqueString(deployment().name, location)}-Insights-ScpdRes-${index}'
+  params: {
+    name: scopedResource.name
+    privateLinkScopeName: privateLinkScope.name
+    linkedResourceId: scopedResource.linkedResourceId
+  }
+}]
 
 resource privateLinkScope_lock 'Microsoft.Authorization/locks@2016-09-01' = if (lock != 'NotSpecified') {
   name: '${privateLinkScope.name}-${lock}-lock'
@@ -57,7 +59,7 @@ resource privateLinkScope_lock 'Microsoft.Authorization/locks@2016-09-01' = if (
 }
 
 module privateLinkScope_privateEndpoints '.bicep/nested_privateEndpoint.bicep' = [for (endpoint, index) in privateEndpoints: if (!empty(privateEndpoints)) {
-  name: '${uniqueString(deployment().name, location)}-Storage-PrivateEndpoints-${index}'
+  name: '${uniqueString(deployment().name, location)}-Insights-PvtEndPnt-${index}'
   params: {
     privateEndpointResourceId: privateLinkScope.id
     privateEndpointVnetLocation: (empty(privateEndpoints) ? 'dummy' : reference(split(endpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)

--- a/arm/Microsoft.Insights/privateLinkScopes/scopedResources/deploy.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/scopedResources/deploy.bicep
@@ -1,0 +1,29 @@
+@description('Required. Name of the private link scoped resource.')
+@minLength(1)
+param name string
+
+@description('Required. Name of the parent private link scope.')
+@minLength(1)
+param privateLinkScopeName string
+
+@description('Required. The resource id of the scoped Azure monitor resource.')
+param linkedResourceId string
+
+resource scopedResource 'Microsoft.Insights/privateLinkScopes/scopedResources@2021-07-01-preview' = {
+  name: '${privateLinkScopeName}/${name}'
+  properties: {
+    linkedResourceId: linkedResourceId
+  }
+}
+
+@description('The resource id of the parent private link scope')
+output privateLinkScopeResourceId string = resourceId('Microsoft.Insights/privateLinkScopes', privateLinkScopeName)
+
+@description('The name of the resource group where the resource has been deployed')
+output scopedResourceResourceGroup string = resourceGroup().name
+
+@description('The resource ID of the deployed scopedResource')
+output scopedResourceResourceId string = scopedResource.id
+
+@description('The full name of the deployed Scoped Resource')
+output scopedResourceName string = scopedResource.name

--- a/arm/Microsoft.Insights/privateLinkScopes/scopedResources/deploy.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/scopedResources/deploy.bicep
@@ -6,7 +6,7 @@ param name string
 @minLength(1)
 param privateLinkScopeName string
 
-@description('Required. The resource id of the scoped Azure monitor resource.')
+@description('Required. The resource ID of the scoped Azure monitor resource.')
 param linkedResourceId string
 
 resource scopedResource 'Microsoft.Insights/privateLinkScopes/scopedResources@2021-07-01-preview' = {
@@ -16,7 +16,7 @@ resource scopedResource 'Microsoft.Insights/privateLinkScopes/scopedResources@20
   }
 }
 
-@description('The resource id of the parent private link scope')
+@description('The resource ID of the parent private link scope')
 output privateLinkScopeResourceId string = resourceId('Microsoft.Insights/privateLinkScopes', privateLinkScopeName)
 
 @description('The name of the resource group where the resource has been deployed')

--- a/arm/Microsoft.Insights/privateLinkScopes/scopedResources/readme.md
+++ b/arm/Microsoft.Insights/privateLinkScopes/scopedResources/readme.md
@@ -1,0 +1,30 @@
+# Insights PrivateLinkScopes ScopedResources `[Microsoft.Insights/privateLinkScopes/scopedResources]`
+
+This module deploys Insights PrivateLinkScopes ScopedResources.
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Insights/privateLinkScopes/scopedResources` | 2021-07-01-preview |
+
+## Parameters
+
+| Parameter Name | Type | Default Value | Possible Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `name` | string |  |  | Required. Name of the private link scoped resource. |
+| `linkedResourceId` | string |  |  | Required. The resource id of the scoped Azure monitor resource. |
+| `privateLinkScopeName` | string |  |  | Required. Name of the parent private link scope. |
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `privateLinkScopeResourceId` | string | The resource id of the parent private link scope |
+| `scopedResourceName` | string | The full name of the deployed Scoped Resource |
+| `scopedResourceResourceGroup` | string | The name of the resource group where the resource has been deployed |
+| `scopedResourceResourceId` | string | The resource ID of the deployed scopedResource |
+
+## Template references
+
+- [Privatelinkscopes/Scopedresources](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-07-01-preview/privateLinkScopes/scopedResources)

--- a/arm/Microsoft.Insights/privateLinkScopes/scopedResources/readme.md
+++ b/arm/Microsoft.Insights/privateLinkScopes/scopedResources/readme.md
@@ -13,14 +13,14 @@ This module deploys Insights PrivateLinkScopes ScopedResources.
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `name` | string |  |  | Required. Name of the private link scoped resource. |
-| `linkedResourceId` | string |  |  | Required. The resource id of the scoped Azure monitor resource. |
+| `linkedResourceId` | string |  |  | Required. The resource ID of the scoped Azure monitor resource. |
 | `privateLinkScopeName` | string |  |  | Required. Name of the parent private link scope. |
 
 ## Outputs
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `privateLinkScopeResourceId` | string | The resource id of the parent private link scope |
+| `privateLinkScopeResourceId` | string | The resource ID of the parent private link scope |
 | `scopedResourceName` | string | The full name of the deployed Scoped Resource |
 | `scopedResourceResourceGroup` | string | The name of the resource group where the resource has been deployed |
 | `scopedResourceResourceId` | string | The resource ID of the deployed scopedResource |


### PR DESCRIPTION
# Change

Updated Microsoft.Insights/privateLinkScopes.
scopedResources becomes a child module

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
[![Insights: Privatelinkscopes](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml)

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
