### PR TITLE
Added dependency consideration for removal

### DIFF
--- a/utilities/pipelines/resourceRemoval/Remove-DeployedModule.ps1
+++ b/utilities/pipelines/resourceRemoval/Remove-DeployedModule.ps1
@@ -28,7 +28,7 @@
             Remove-vWan @inputObject -Verbose
         }
         'virtualMachines' {
-            Write-Verbose 'Run vWAN removal script' -Verbose
+            Write-Verbose 'Run virtual machine removal script' -Verbose
             # Load function
             . (Join-Path $PSScriptRoot 'helper' 'Remove-VirtualMachine.ps1')
 

--- a/utilities/pipelines/resourceRemoval/helper/Get-DependencyResourceNames.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Get-DependencyResourceNames.ps1
@@ -1,0 +1,40 @@
+﻿<#
+.SYNOPSIS
+Get a list of all dependency resources specified in the dependencies parameter files
+
+.DESCRIPTION
+Get a list of all dependency resources specified in the dependencies parameter files
+Note: It only considers resources that use the 'name' parameter
+
+.PARAMETER dependencyParameterPath
+Optional. The path the the dependency parameters parent folder. Defaults to 'utilities/pipelines/dependencies'
+
+.EXAMPLE
+Get-DependencyResourceNames
+
+Get the list of all dependency names from the current set of parameter files
+#>
+function Get-DependencyResourceNames {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string] $dependencyParameterPath = (Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'dependencies')
+    )
+
+    $parameterFolders = Get-ChildItem -Path $dependencyParameterPath -Recurse -Filter 'parameters' -Directory
+    $parameterFilePaths = [System.Collections.ArrayList]@()
+    foreach ($parameterFolderPath in $parameterFolders.FullName) {
+        $parameterFilePaths += Get-ChildItem -Path $parameterFolderPath -Recurse -Filter '*.json'
+    }
+
+    $dependencyResourceNames = [System.Collections.ArrayList]@()
+    foreach ($parameterFilePath in $parameterFilePaths) {
+        $paramFileContent = ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)
+        if ($nameParam = $paramFileContent.parameters.name.value) {
+            $dependencyResourceNames += $nameParam
+        }
+    }
+
+    return $dependencyResourceNames
+}

--- a/utilities/pipelines/resourceRemoval/helper/Remove-GeneralModule.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-GeneralModule.ps1
@@ -233,7 +233,7 @@ function Remove-GeneralModule {
 
         # Remove resources
         # ----------------
-        if ($PSCmdlet.ShouldProcess(('[{0}] resources' -f $resourcesToRemove.Count), 'Remove')) {
+        if ($PSCmdlet.ShouldProcess(('[{0}] resources' -f (($resourcesToRemove -is [array]) ? $resourcesToRemove.Count : 1)), 'Remove')) {
             Remove-Resource -resourceToRemove $resourcesToRemove -Verbose
         }
     }

--- a/utilities/pipelines/resourceRemoval/helper/Remove-GeneralModule.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-GeneralModule.ps1
@@ -115,6 +115,7 @@ function Remove-GeneralModule {
 
         # Load helper
         . (Join-Path $PSScriptRoot 'Remove-Resource.ps1')
+        . (Join-Path $PSScriptRoot 'Get-DependencyResourceNames.ps1')
     }
 
     process {
@@ -225,6 +226,10 @@ function Remove-GeneralModule {
                 $resourcesToRemove = $resourcesToRemove | Where-Object { $_.ResourceId -notin $intermediateResources.resourceId }
             }
         }
+
+        # Filter all dependency resources
+        $dependencyResourceNames = Get-DependencyResourceNames
+        $resourcesToRemove = $resourcesToRemove | Where-Object { $_.Name -notin $dependencyResourceNames }
 
         # Remove resources
         # ----------------

--- a/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-Resource.ps1
@@ -79,7 +79,7 @@ function Remove-Resource {
     $resourcesToRetry = $resourceToRemove
 
     do {
-        if ($PSCmdlet.ShouldProcess(("[{0}] Resource(s) with a maximum of [$removalRetryLimit] attempts." -f $resourcesToRetry.Count), 'Remove')) {
+        if ($PSCmdlet.ShouldProcess(("[{0}] Resource(s) with a maximum of [$removalRetryLimit] attempts." -f (($resourcesToRetry -is [array]) ? $resourcesToRetry.Count : 1)), 'Remove')) {
             $resourcesToRetry = Remove-ResourceInner -resourceToRemove $resourcesToRetry -Verbose
         } else {
             Remove-ResourceInner -resourceToRemove $resourceToRemove -WhatIf

--- a/utilities/pipelines/resourceRemoval/helper/Remove-VirtualMachine.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-VirtualMachine.ps1
@@ -41,6 +41,7 @@ function Remove-VirtualMachine {
 
         # Load helper
         . (Join-Path $PSScriptRoot 'Remove-Resource.ps1')
+        . (Join-Path $PSScriptRoot 'Get-DependencyResourceNames.ps1')
     }
 
     process {
@@ -63,25 +64,48 @@ function Remove-VirtualMachine {
         }
 
         $unorderedResourceIds = $deployments.TargetResource | Where-Object { $_ -and $_ -notmatch '/deployments/' }
-        $vmName = ($unorderedResourceIds | Where-Object { $_ -match '/virtualMachines/' }).Split('/')[-1]
+        $resourcesToRemove = [System.Collections.ArrayList] @()
 
-        # Fetch all resources that match the VM
-        $allResources = Get-AzResource -ResourceGroupName $resourceGroupName -Name "$vmName*"
 
-        # Sort ascending as we need to remove the VM first
-        $orderedResourceIds = $allResources | Sort-Object -Property { $_.ResourceId.Split('/').Count }
-        $resourcesToRemove = $orderedResourceIds | ForEach-Object {
-            @{
-                resourceId = $_.ResourceId
-                name       = $_.Name
-                type       = $_.Type
+        # Handle VM resources
+        $vmIds = $unorderedResourceIds | Where-Object { $_ -match '/virtualMachines/' }
+        if ($vmIds.Count -gt 0) {
+            $vmName = ($unorderedResourceIds | Where-Object { $_ -match '/virtualMachines/' }).Split('/')[-1]
+
+            # Fetch all resources that match the VM
+            $allResources = Get-AzResource -ResourceGroupName $resourceGroupName -Name "$vmName*"
+
+            # Sort ascending as we need to remove the VM first
+            $orderedResourceIds = $allResources | Sort-Object -Property { $_.ResourceId.Split('/').Count }
+            $resourcesToRemove += $orderedResourceIds | ForEach-Object {
+                @{
+                    resourceId = $_.ResourceId
+                    name       = $_.Name
+                    type       = $_.Type
+                }
             }
         }
 
+        # Handle non-vm resources that are deployed with the VM
+        $otherIds = $unorderedResourceIds | Where-Object { $_ -notmatch '/virtualMachines/' }
+        foreach ($otherResourceId in $otherIds) {
+            $resourcesToRemove += @{
+                resourceId = $otherResourceId
+                name       = $otherResourceId.Split('/')[-1]
+                type       = $otherResourceId.Split('/')[6..7] -join '/'
+            }
+        }
+
+        # Filter all dependency resources
+        $dependencyResourceNames = Get-DependencyResourceNames
+        $resourcesToRemove = $resourcesToRemove | Where-Object { $_.Name -notin $dependencyResourceNames }
+
         # Remove resources
         # ----------------
-        if ($PSCmdlet.ShouldProcess(('[{0}] resources' -f $resourcesToRemove.Count), 'Remove')) {
-            Remove-Resource -resourceToRemove $resourcesToRemove -Verbose
+        if ($resourcesToRemove.count -gt 0) {
+            if ($PSCmdlet.ShouldProcess(('[{0}] resources' -f $resourcesToRemove.Count), 'Remove')) {
+                Remove-Resource -resourceToRemove $resourcesToRemove -Verbose
+            }
         }
     }
 


### PR DESCRIPTION
# Change

- To avoid the accidental deletion of dependency resources I implemented an initial version to filter out the resource-group level resources
- It's not perfect as I'm looking for the 'name' parameter in the paramter files and should be improved in the future
- However it will help us for the moment

Pipeline reference
[![Compute: VirtualMachineScaleSets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachinescalesets.yml/badge.svg?branch=users%2Falsehr%2FremovalImprovment)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachinescalesets.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
