### PR TITLE
Target NSGs in seperate resource group

### DIFF
--- a/arm/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -11,6 +11,10 @@ param addressPrefixes array
 @minLength(1)
 param subnets array
 
+@description('Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group.')
+@minLength(1)
+param nsgResourceGroup string = resourceGroup().name
+
 @description('Optional. DNS Servers associated to the Virtual Network.')
 param dnsServers array = []
 
@@ -116,7 +120,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
       name: item.name
       properties: {
         addressPrefix: item.addressPrefix
-        networkSecurityGroup: contains(item, 'networkSecurityGroupName') ? (empty(item.networkSecurityGroupName) ? null : json('{"id": "${resourceId('Microsoft.Network/networkSecurityGroups', item.networkSecurityGroupName)}"}')) : null
+        networkSecurityGroup: contains(item, 'networkSecurityGroupName') ? (empty(item.networkSecurityGroupName) ? null : json('{"id": "${resourceId(nsgResourceGroup, 'Microsoft.Network/networkSecurityGroups', item.networkSecurityGroupName)}"}')) : null
         routeTable: contains(item, 'routeTableName') ? (empty(item.routeTableName) ? null : json('{"id": "${resourceId('Microsoft.Network/routeTables', item.routeTableName)}"}')) : null
         serviceEndpoints: contains(item, 'serviceEndpoints') ? (empty(item.serviceEndpoints) ? null : item.serviceEndpoints) : null
         delegations: contains(item, 'delegations') ? (empty(item.delegations) ? null : item.delegations) : null

--- a/arm/Microsoft.Network/virtualNetworks/readme.md
+++ b/arm/Microsoft.Network/virtualNetworks/readme.md
@@ -31,6 +31,7 @@ This template deploys a virtual network (vNet).
 | `name` | string |  |  | Required. The Virtual Network (vNet) Name. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `subnets` | array |  |  | Required. An Array of subnets to deploy to the Virual Network. |
+| `nsgResourceGroup` | array |  |  | Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `virtualNetworkPeerings` | _[virtualNetworkPeerings](virtualNetworkPeerings/readme.md)_ array | `[]` |  | Optional. Virtual Network Peerings configurations |
 | `workspaceId` | string |  |  | Optional. Resource ID of log analytics. |

--- a/arm/Microsoft.Network/virtualNetworks/readme.md
+++ b/arm/Microsoft.Network/virtualNetworks/readme.md
@@ -31,7 +31,7 @@ This template deploys a virtual network (vNet).
 | `name` | string |  |  | Required. The Virtual Network (vNet) Name. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `subnets` | array |  |  | Required. An Array of subnets to deploy to the Virual Network. |
-| `nsgResourceGroup` | array |  |  | Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group. |
+| `nsgResourceGroup` | string |  |  | Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `virtualNetworkPeerings` | _[virtualNetworkPeerings](virtualNetworkPeerings/readme.md)_ array | `[]` |  | Optional. Virtual Network Peerings configurations |
 | `workspaceId` | string |  |  | Optional. Resource ID of log analytics. |

--- a/arm/Microsoft.Network/virtualNetworks/readme.md
+++ b/arm/Microsoft.Network/virtualNetworks/readme.md
@@ -31,7 +31,7 @@ This template deploys a virtual network (vNet).
 | `name` | string |  |  | Required. The Virtual Network (vNet) Name. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `subnets` | array |  |  | Required. An Array of subnets to deploy to the Virual Network. |
-| `nsgResourceGroup` | string |  |  | Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group. |
+| `nsgResourceGroup` | string | `[resourceGroup().name]` |  | Optional. Resource Group where NSGs are deployed, if different than VNET Resource Group. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `virtualNetworkPeerings` | _[virtualNetworkPeerings](virtualNetworkPeerings/readme.md)_ array | `[]` |  | Optional. Virtual Network Peerings configurations |
 | `workspaceId` | string |  |  | Optional. Resource ID of log analytics. |


### PR DESCRIPTION
In some scenarios, net sec teams are separate from network operations teams.

# Change

***Feel free to remove this sample text***
>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
