### PR TITLE
Align Microsoft.KeyVault deployment names

### DIFF
--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -268,14 +268,14 @@ module keyVault_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   }
 }]
 
-@description('The Resource ID of the Key Vault.')
+@description('The resource ID of the key vault.')
 output keyVaultResourceId string = keyVault.id
 
-@description('The name of the Resource Group the Key Vault was created in.')
+@description('The name of the resource group the key vault was created in.')
 output keyVaultResourceGroup string = resourceGroup().name
 
-@description('The Name of the Key Vault.')
+@description('The name of the key vault.')
 output keyVaultName string = keyVault.name
 
-@description('The URL of the Key Vault.')
+@description('The URL of the key vault.')
 output keyVaultUrl string = keyVault.properties.vaultUri

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -210,7 +210,7 @@ resource keyVault_diagnosticSettings 'Microsoft.Insights/diagnosticsettings@2017
 }
 
 module keyVault_accessPolicies 'accessPolicies/deploy.bicep' = if (!empty(accessPolicies)) {
-  name: '${uniqueString(deployment().name, location)}-AccessPolicies'
+  name: '${uniqueString(deployment().name, location)}-KeyVault-AccessPolicies'
   params: {
     keyVaultName: keyVault.name
     accessPolicies: formattedAccessPolicies
@@ -218,7 +218,7 @@ module keyVault_accessPolicies 'accessPolicies/deploy.bicep' = if (!empty(access
 }
 
 module keyVault_secrets 'secrets/deploy.bicep' = [for (secret, index) in secrets: {
-  name: '${uniqueString(deployment().name, location)}-Secret-${index}'
+  name: '${uniqueString(deployment().name, location)}-KeyVault-Secret-${index}'
   params: {
     name: secret.name
     value: secret.value
@@ -233,7 +233,7 @@ module keyVault_secrets 'secrets/deploy.bicep' = [for (secret, index) in secrets
 }]
 
 module keyVault_keys 'keys/deploy.bicep' = [for (key, index) in keys: {
-  name: '${uniqueString(deployment().name, location)}-Key-${index}'
+  name: '${uniqueString(deployment().name, location)}-KeyVault-Key-${index}'
   params: {
     name: key.name
     keyVaultName: keyVault.name
@@ -250,7 +250,7 @@ module keyVault_keys 'keys/deploy.bicep' = [for (key, index) in keys: {
 }]
 
 module keyVault_privateEndpoints '.bicep/nested_privateEndpoint.bicep' = [for (privateEndpoint, index) in privateEndpoints: {
-  name: '${uniqueString(deployment().name, location)}-PrivateEndpoint-${index}'
+  name: '${uniqueString(deployment().name, location)}-KeyVault-PrivateEndpoint-${index}'
   params: {
     privateEndpointResourceId: keyVault.id
     privateEndpointVnetLocation: (empty(privateEndpoints) ? 'dummy' : reference(split(privateEndpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)
@@ -260,7 +260,7 @@ module keyVault_privateEndpoints '.bicep/nested_privateEndpoint.bicep' = [for (p
 }]
 
 module keyVault_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${deployment().name}-rbac-${index}'
+  name: '${uniqueString(deployment().name, location)}-KeyVault-Rbac-${index}'
   params: {
     principalIds: roleAssignment.principalIds
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
@@ -278,4 +278,4 @@ output keyVaultResourceGroup string = resourceGroup().name
 output keyVaultName string = keyVault.name
 
 @description('The URL of the Key Vault.')
-output keyVaultUrl string = reference(keyVault.id, '2016-10-01').vaultUri
+output keyVaultUrl string = keyVault.properties.vaultUri

--- a/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
@@ -82,7 +82,7 @@ resource key 'Microsoft.KeyVault/vaults/keys@2019-09-01' = {
 }
 
 module key_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${deployment().name}-rbac-${index}'
+  name: '${deployment().name}-Rbac-${index}'
   params: {
     principalIds: roleAssignment.principalIds
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -179,10 +179,10 @@ To use Private Endpoint the following dependencies must be deployed:
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `keyVaultName` | string | The Name of the Key Vault. |
-| `keyVaultResourceGroup` | string | The name of the Resource Group the Key Vault was created in. |
-| `keyVaultResourceId` | string | The Resource ID of the Key Vault. |
-| `keyVaultUrl` | string | The URL of the Key Vault. |
+| `keyVaultName` | string | The name of the key vault. |
+| `keyVaultResourceGroup` | string | The name of the resource group the key vault was created in. |
+| `keyVaultResourceId` | string | The resource ID of the key vault. |
+| `keyVaultUrl` | string | The URL of the key vault. |
 
 ## Template references
 

--- a/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
@@ -55,7 +55,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
 }
 
 module secret_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${deployment().name}-rbac-${index}'
+  name: '${deployment().name}-Rbac-${index}'
   params: {
     principalIds: roleAssignment.principalIds
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName


### PR DESCRIPTION
# Change

Aligning deployment names to naming convention for Microsoft.KeyVault resource provider
Fixed output to use dotted access instead of reference

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code