### PR TITLE
Adds Parameter to control publicNetworkAccess 

### DIFF
--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -49,7 +49,7 @@ param storageAccountAccessTier string = 'Hot'
   'Disabled'
 ])
 @description('Optional. Storage Account Public Network Access.')
-param publicNetworkAccess bool 
+param publicNetworkAccess bool = 'Enabled'
 
 @description('Optional. Provides the identity based authentication settings for Azure Files.')
 param azureFilesIdentityBasedAuthentication object = {}

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -173,7 +173,7 @@ var saBaseProperties = {
   minimumTlsVersion: minimumTlsVersion
   networkAcls: (empty(networkAcls) ? null : networkAcls_var)
   allowBlobPublicAccess: (storageAccountKind == 'true') ? null : allowBlobPublicAccess
-  publicNetworkAccess: (empty(publicNetworkAccess) ? null : publicNetworkAccess
+  publicNetworkAccess: !empty(publicNetworkAccess) ? publicNetworkAccess : null
 }
 var saOptIdBasedAuthProperties = {
   azureFilesIdentityBasedAuthentication: azureFilesIdentityBasedAuthentication_var

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -44,6 +44,13 @@ param storageAccountSku string = 'Standard_GRS'
 @description('Optional. Storage Account Access Tier.')
 param storageAccountAccessTier string = 'Hot'
 
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+@description('Optional. Storage Account Public Network Access.')
+param publicNetworkAccess bool 
+
 @description('Optional. Provides the identity based authentication settings for Azure Files.')
 param azureFilesIdentityBasedAuthentication object = {}
 
@@ -165,7 +172,8 @@ var saBaseProperties = {
   isHnsEnabled: ((!enableHierarchicalNamespace) ? null : enableHierarchicalNamespace)
   minimumTlsVersion: minimumTlsVersion
   networkAcls: (empty(networkAcls) ? null : networkAcls_var)
-  allowBlobPublicAccess: allowBlobPublicAccess
+  allowBlobPublicAccess: (storageAccountKind == 'true') ? null : allowBlobPublicAccess
+  publicNetworkAccess: (empty(publicNetworkAccess) ? null : publicNetworkAccess
 }
 var saOptIdBasedAuthProperties = {
   azureFilesIdentityBasedAuthentication: azureFilesIdentityBasedAuthentication_var

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -172,7 +172,7 @@ var saBaseProperties = {
   isHnsEnabled: ((!enableHierarchicalNamespace) ? null : enableHierarchicalNamespace)
   minimumTlsVersion: minimumTlsVersion
   networkAcls: (empty(networkAcls) ? null : networkAcls_var)
-  allowBlobPublicAccess: (storageAccountKind == 'true') ? null : allowBlobPublicAccess
+  allowBlobPublicAccess: allowBlobPublicAccess == 'true' ? allowBlobPublicAccess : null
   publicNetworkAccess: !empty(publicNetworkAccess) ? publicNetworkAccess : null
 }
 var saOptIdBasedAuthProperties = {

--- a/arm/Microsoft.Storage/storageAccounts/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/readme.md
@@ -27,6 +27,7 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `publicNetworkAccess ` | bool | `True` |  | Optional. Allow or disallow public network access to Storage Account. Value is optional but if passed in, must be 'Enabled' or 'Disabled'. |
 | `allowBlobPublicAccess` | bool | `True` |  | Optional. Indicates whether public access is enabled for all blobs or containers in the storage account. |
 | `azureFilesIdentityBasedAuthentication` | object | `{object}` |  | Optional. Provides the identity based authentication settings for Azure Files. |
 | `basetime` | string | `[utcNow('u')]` |  | Generated. Do not provide a value! This date value is used to generate a SAS token to access the modules. |


### PR DESCRIPTION
Adds Optional Parameter to control Public Network Access to Storage Accounts


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
