### PR TITLE
Added deleteOption to VM

### DIFF
--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.min.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.min.parameters.json
@@ -19,6 +19,7 @@
         "osDisk": {
             "value": {
                 "createOption": "fromImage",
+                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
@@ -27,6 +27,7 @@
         "osDisk": {
             "value": {
                 "createOption": "fromImage",
+                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"
@@ -51,6 +52,7 @@
             "value": [
                 {
                     "nicSuffix": "-nic-01",
+                    "deleteOption": "Delete",
                     "ipConfigurations": [
                         {
                             "name": "ipconfig01",

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.min.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.min.parameters.json
@@ -16,6 +16,7 @@
         "osDisk": {
             "value": {
                 "createOption": "fromImage",
+                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
@@ -19,6 +19,7 @@
         "osDisk": {
             "value": {
                 "createOption": "fromImage",
+                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"
@@ -40,6 +41,7 @@
             "value": [
                 {
                     "nicSuffix": "-nic-01",
+                    "deleteOption": "Delete",
                     "ipConfigurations": [
                         {
                             "name": "ipconfig01",

--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -343,6 +343,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
       osDisk: {
         name: '${name}-disk-os-01'
         createOption: osDisk.createOption
+        deleteOption: contains(osDisk, 'deleteOption') ? osDisk.deleteOption : 'Delete'
         diskSizeGB: osDisk.diskSizeGB
         managedDisk: {
           storageAccountType: osDisk.managedDisk.storageAccountType
@@ -353,6 +354,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
         name: '${name}-disk-data-${padLeft((index + 1), 2, '0')}'
         diskSizeGB: dataDisk.diskSizeGB
         createOption: dataDisk.createOption
+        deleteOption: contains(dataDisk, 'deleteOption') ? dataDisk.deleteOption : 'Delete'
         caching: dataDisk.caching
         managedDisk: {
           storageAccountType: dataDisk.managedDisk.storageAccountType
@@ -378,6 +380,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
     networkProfile: {
       networkInterfaces: [for (nicConfiguration, index) in nicConfigurations: {
         properties: {
+          deleteOption: contains(nicConfiguration, 'deleteOption') ? nicConfiguration.deleteOption : 'Delete'
           primary: index == 0 ? true : false
         }
         id: resourceId('Microsoft.Network/networkInterfaces', '${name}${nicConfiguration.nicSuffix}')

--- a/arm/Microsoft.Compute/virtualMachines/readme.md
+++ b/arm/Microsoft.Compute/virtualMachines/readme.md
@@ -126,6 +126,7 @@ This module deploys one Virtual Machine with one or multiple nics and optionally
  "osDisk": {
     "value": {
         "createOption": "fromImage",
+        "deleteOption": "Delete", // Optional. Can be 'Delete' or 'Detach'
         "diskSizeGB": "128",
         "managedDisk": {
             "storageAccountType": "Premium_LRS"
@@ -141,6 +142,7 @@ This module deploys one Virtual Machine with one or multiple nics and optionally
     "value": [{
         "caching": "ReadOnly",
         "createOption": "Empty",
+        "deleteOption": "Delete", // Optional. Can be 'Delete' or 'Detach'
         "diskSizeGB": "256",
         "managedDisk": {
             "storageAccountType": "Premium_LRS"
@@ -231,6 +233,7 @@ The field `nicSuffix` and `subnetId` are mandatory. If `enablePublicIP` is set t
   "value": [
     {
       "nicSuffix": "-nic-01",
+      "deleteOption": "Delete", // Optional. Can be 'Delete' or 'Detach'
       "ipConfigurations": [
         {
           "name": "ipconfig1",
@@ -512,11 +515,11 @@ You can specify multiple user assigned identities to a resource by providing add
 
 ## Template references
 
-- [Locks ](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks)
-- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-04-01-preview/roleAssignments)
-- [Virtualmachines](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2021-07-01/virtualMachines)
-- [Virtualmachines/Extensions](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2021-07-01/virtualMachines/extensions)
 - [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
+- [Locks](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks)
 - [Networkinterfaces](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/networkInterfaces)
 - [Publicipaddresses](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-03-01/publicIPAddresses)
+- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-04-01-preview/roleAssignments)
 - [Vaults/Backupfabrics/Protectioncontainers/Protecteditems](https://docs.microsoft.com/en-us/azure/templates/Microsoft.RecoveryServices/2021-06-01/vaults/backupFabrics/protectionContainers/protectedItems)
+- [Virtualmachines](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2021-07-01/virtualMachines)
+- [Virtualmachines/Extensions](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2021-07-01/virtualMachines/extensions)

--- a/docs/wiki/KnownIssues.md
+++ b/docs/wiki/KnownIssues.md
@@ -24,12 +24,6 @@ This section outlines known issues that currently affect our modules.
 
 This section outlines known issues that currently affect our testing.
 
-## Removal exceptions
-
-Not all modules are removed after their test deployment.
-
-In general, the current approach works for about 99% of the modules. There is one known exception, that is the `osDisk` removal for the virtual machine module, as Azure has difficulties finding it without using direct REST calls.
-
 ## Limited parameter file set
 
 We have yet to implement the full set of parameter files we need in order to test all possible scenarios. The most important first step will be a 'minimum-set' parameter file vs. a 'maximum-set' parameter file for each module, followed by parameter files for specific scenarios


### PR DESCRIPTION
# Change

- Added 'deleteOption' to virtual machine module's `dataDisk`, `osDisk` & `nicConfiguration`
- Successfully evaluated that e.g. the osDisk & NIC is removed
- Resolves our issue that osDisks are not properly removed

Pipeline reference:
[![Compute: VirtualMachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg?branch=users%2Falsehr%2F830_vmDeleteOption)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
