### PR TITLE
Added missing removal condition to avoid uncancelable pipeline

### DIFF
--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -268,7 +268,7 @@ jobs:
           #------------------
           - task: AzurePowerShell@5
             displayName: 'Remove deployed resources via [${{ parameters.serviceConnection }}]'
-            condition: and(eq( '${{ parameters.removeDeployment }}', 'true'), not(eq(variables['deploymentName'],'')))
+            condition: and(succeededOrFailed(), eq( '${{ parameters.removeDeployment }}', 'true'), not(eq(variables['deploymentName'],'')))
             inputs:
               azureSubscription: ${{ parameters.serviceConnection }}
               azurePowerShellVersion: ${{ parameters.azurePowerShellVersion }}


### PR DESCRIPTION
# Change

There was a condition for the ADO deployment pipeline template missing that essentially made it impossible to stop the removal step.

Tested both the cancellation as well as end2end execution in IaCS.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
