### PR TITLE
Added improved error fetching for failed deployments

### DIFF
--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -327,7 +327,7 @@ output storageAccountName string = storageAccount.name
 output storageAccountResourceGroup string = resourceGroup().name
 
 @description('The primary blob endpoint reference if blob services are deployed.')
-output storageAccountPrimaryBlobEndpoint string = !empty(blobServices) && contains(blobServices, 'containers')) ? reference('Microsoft.Storage/storageAccounts/${storageAccount.name}', '2019-04-01').primaryEndpoints.blob : ''
+output storageAccountPrimaryBlobEndpoint string = !empty(blobServices) && contains(blobServices, 'containers') ? reference('Microsoft.Storage/storageAccounts/${storageAccount.name}', '2019-04-01').primaryEndpoints.blob : ''
 
 @description('The principal ID of the system assigned identity.')
 output systemAssignedPrincipalId string = systemAssignedIdentity && contains(storageAccount.identity, 'principalId') ? storageAccount.identity.principalId : ''


### PR DESCRIPTION
# Change

Added deployment error fetching based on deployment name if provisioning failed without an exception

Pipeline reference to show that it does not fail:
[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2F857_provisioningState)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
