### PR TITLE
fix VM parameter file with additional parameter

### DIFF
--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
@@ -120,6 +120,9 @@
                 "enabled": true
             }
         },
+        "monitoringWorkspaceId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-law-x-001"
+        },
         "extensionDependencyAgentConfig": {
             "value": {
                 "enabled": true

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
@@ -137,6 +137,9 @@
                 "enabled": true
             }
         },
+        "monitoringWorkspaceId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-sxx-az-law-x-001"
+        },
         "extensionDependencyAgentConfig": {
             "value": {
                 "enabled": true

--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -162,7 +162,7 @@ param extensionMonitoringAgentConfig object = {
   enabled: false
 }
 
-@description('Optional. Resource ID of the monitoring log analytics workspace.')
+@description('Optional. Resource ID of the monitoring log analytics workspace. Must be set when extensionMonitoringAgentConfig is set to true.')
 param monitoringWorkspaceId string = ''
 
 @description('Optional. The configuration for the [Dependency Agent] extension. Must at least contain the ["enabled": true] property to be executed')

--- a/arm/Microsoft.Compute/virtualMachines/readme.md
+++ b/arm/Microsoft.Compute/virtualMachines/readme.md
@@ -59,7 +59,7 @@ This module deploys one Virtual Machine with one or multiple nics and optionally
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
 | `lock` | string | `NotSpecified` | `[CanNotDelete, NotSpecified, ReadOnly]` | Optional. Specify the type of lock. |
 | `maxPriceForLowPriorityVm` | string |  |  | Optional. Specifies the maximum price you are willing to pay for a low priority VM/VMSS. This price is in US Dollars. |
-| `monitoringWorkspaceId` | string |  |  | Optional. Resource ID of the monitoring log analytics workspace. |
+| `monitoringWorkspaceId` | string |  |  | Optional. Resource ID of the monitoring log analytics workspace. Must be set when extensionMonitoringAgentConfig is set to true. |
 | `name` | string | `[take(toLower(uniqueString(resourceGroup().name)), 10)]` |  | Optional. The name of the virtual machine to be created. You should use a unique prefix to reduce name collisions in Active Directory. If no value is provided, a 10 character long unique string will be generated based on the Resource Group's name. |
 | `nicConfigurations` | array |  |  | Required. Configures NICs and PIPs. |
 | `nicMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |


### PR DESCRIPTION
# Change

Because of refactoring, a new parameter was introduced. It is now set in the parameters files.

[![Compute: VirtualMachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
