### PR TITLE
Dependency pipeline Replace msiPrincipalId at runtime

### DIFF
--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,7 +178,9 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
+                # Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
+                Write-Verbose "OtherCustomParameterFileTokens: '$(customParameterFileTokens)'" -Verbose
+
                 $OtherCustomParameterFileTokens = @()
                 # $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -179,7 +179,7 @@ jobs:
 
                 # Get additional Custom Parameter File Tokens from input
                 Write-Verbose "OtherCustomParameterFileTokens: '${{ parameters.customParameterFileTokens }}'" -Verbose
-                $OtherCustomParameterFileTokens = '${{ parameters.customParameterFileTokens }}' | ConvertFrom-Json
+                $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,7 +178,7 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose "OtherCustomParameterFileTokens: ${{  deploymentBlock.customParameterFileTokens }}" -Verbose
+                Write-Verbose 'OtherCustomParameterFileTokens: ${{  deploymentBlock.customParameterFileTokens }}' -Verbose
 
                 $OtherCustomParameterFileTokens = @()
                 # $OtherCustomParameterFileTokens2 = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -62,6 +62,7 @@ parameters:
   managementGroupId: '$(ARM_MGMTGROUP_ID)'
   parametersRepository: '$(Build.Repository.Name)'
   modulesRepository: '$(modulesRepository)'
+  customParameterFileTokens: ''
   # Azure PowerShell Version parameters
   azurePowerShellVersion: '$(azurePowerShellVersion)'
   preferredAzurePowerShellVersion: '$(preferredAzurePowerShellVersion)'
@@ -176,10 +177,14 @@ jobs:
                     @{ Name = "deploymentSpId";    Value = '$(DEPLOYMENT_SP_ID)' }
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
+                # Get additional Custom Parameter File Tokens from input
+                $OtherCustomParameterFileTokens = '${{ parameters.customParameterFileTokens }}' | ConvertFrom-Json
+
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{
                     ParameterFilePath                 = Join-Path '$(parametersRepoRoot)' '${{ deploymentBlock.path }}'
                     DefaultParameterFileTokens        = $DefaultParameterFileTokens
+                    OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
                     LocalCustomParameterFileTokens    = $Settings.parameterFileTokens.localTokens.tokens
                     TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
                     TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -179,7 +179,7 @@ jobs:
 
                 # Get additional Custom Parameter File Tokens from input
                 Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
-                Write-Verbose "OtherCustomParameterFileTokens: '$(customParameterFileTokens)'" -Verbose
+                # Write-Verbose "OtherCustomParameterFileTokens: '$(customParameterFileTokens)'" -Verbose
 
                 $OtherCustomParameterFileTokens = @()
                 # $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,7 +178,7 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                # Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
+                Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
                 Write-Verbose "OtherCustomParameterFileTokens: '$(customParameterFileTokens)'" -Verbose
 
                 $OtherCustomParameterFileTokens = @()

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -62,7 +62,6 @@ parameters:
   managementGroupId: '$(ARM_MGMTGROUP_ID)'
   parametersRepository: '$(Build.Repository.Name)'
   modulesRepository: '$(modulesRepository)'
-  customParameterFileTokens: ''
   # Azure PowerShell Version parameters
   azurePowerShellVersion: '$(azurePowerShellVersion)'
   preferredAzurePowerShellVersion: '$(preferredAzurePowerShellVersion)'

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,10 +178,10 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
+                Write-Verbose "OtherCustomParameterFileTokens: ${{  deploymentBlock.customParameterFileTokens }}" -Verbose
 
                 $OtherCustomParameterFileTokens = @()
-                # $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
+                # $OtherCustomParameterFileTokens2 = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,7 +178,7 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose 'OtherCustomParameterFileTokens: ${{  deploymentBlock.customParameterFileTokens }}' -Verbose
+                Write-Verbose 'OtherCustomParameterFileTokens: ${{ deploymentBlock.customParameterFileTokens }}' -Verbose
 
                 $OtherCustomParameterFileTokens = @()
                 # $OtherCustomParameterFileTokens2 = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,6 +178,7 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
+                Write-Verbose "OtherCustomParameterFileTokens: '${{ parameters.customParameterFileTokens }}'" -Verbose
                 $OtherCustomParameterFileTokens = '${{ parameters.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,9 +178,7 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose 'OtherCustomParameterFileTokens: ${{ deploymentBlock.customParameterFileTokens }}' -Verbose
-
-                # $OtherCustomParameterFileTokens = @()
+                Write-Verbose 'Additional Custom Parameter File Tokens: ${{ deploymentBlock.customParameterFileTokens }}' -Verbose
                 $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -180,8 +180,8 @@ jobs:
                 # Get additional Custom Parameter File Tokens from input
                 Write-Verbose 'OtherCustomParameterFileTokens: ${{ deploymentBlock.customParameterFileTokens }}' -Verbose
 
-                $OtherCustomParameterFileTokens = @()
-                # $OtherCustomParameterFileTokens2 = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
+                # $OtherCustomParameterFileTokens = @()
+                $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -179,7 +179,6 @@ jobs:
 
                 # Get additional Custom Parameter File Tokens from input
                 Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
-                # Write-Verbose "OtherCustomParameterFileTokens: '$(customParameterFileTokens)'" -Verbose
 
                 $OtherCustomParameterFileTokens = @()
                 # $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json

--- a/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+++ b/.azuredevops/pipelineTemplates/module.jobs.deploy.yml
@@ -178,8 +178,9 @@ jobs:
                 ) | ForEach-Object { [PSCustomObject]$PSItem }
 
                 # Get additional Custom Parameter File Tokens from input
-                Write-Verbose "OtherCustomParameterFileTokens: '${{ parameters.customParameterFileTokens }}'" -Verbose
-                $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
+                Write-Verbose "OtherCustomParameterFileTokens: '${{  deploymentBlock.customParameterFileTokens }}'" -Verbose
+                $OtherCustomParameterFileTokens = @()
+                # $OtherCustomParameterFileTokens = '${{  deploymentBlock.customParameterFileTokens }}' | ConvertFrom-Json
 
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -652,13 +652,13 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: $(msiPrincipalId)
+              # customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
-              # customParameterFileTokens: >
-              #   [
-              #   { "name": "msiPrincipalId",
-              #   "value": "$(msiPrincipalId)" }
-              #   ]
+              customParameterFileTokens: >
+                [
+                { "name": "msiPrincipalId",
+                "value": "msiPrincipalIdValue" }
+                ]
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -71,6 +71,7 @@ stages:
           deploymentOutput: $[ dependencies.job_deploy_msi.outputs['DeployModule.deploymentOutput'] ]
         steps:
           - task: PowerShell@2
+            name: print_msi_prinId
             inputs:
               targetType: inline
               pwsh: true
@@ -575,20 +576,57 @@ stages:
   #             templateFilePath: $(templateFilePath)
   #             displayName: Default Application Group
 
-  # - stage: deploy_rolea
-  #   displayName: Deploy role assignments
-  #   dependsOn:
-  #     - deploy_msi
-  #   variables:
-  #     resourceType: 'Microsoft.Authorization\roleAssignments'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: MSI Role Assignment
+  - stage: deploy_rolea
+    displayName: Deploy role assignments
+    dependsOn:
+      - deploy_msi
+    variables:
+      resourceType: 'Microsoft.Authorization\roleAssignments'
+      templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
+      varFromStageA: $[ stageDependencies.deploy_msi.default_msi_job.outputs['DeployModule.deploymentOutput'] ]
+    jobs:
+      - job:
+        displayName: Set msi principal ID output
+        pool:
+          ${{ if eq(variables['vmImage'], '') }}:
+            name: $(poolName)
+          ${{ if eq(variables['poolName'], '') }}:
+            vmImage: $(vmImage)
+        variables:
+          msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: inline
+              pwsh: true
+              script: |
+                # Load used functions
+                . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+
+                # Load Settings File
+                $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+
+                # Initialize Default Parameter File Tokens
+                $OtherCustomParameterFileTokens = @(
+                    @{ Name = 'msiPrincipalId'; Value = '$msiPrincipalId' }
+                )
+
+                # Construct Token Function Input
+                $ConvertTokensInputs = @{
+                    ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+                    OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+                    TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+                    TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+                }
+
+                # Invoke Token Replacement Functionality
+                $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: MSI Role Assignment
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -30,23 +30,23 @@ variables:
     value: 'validation-rg'
 
 stages:
-  - stage: deploy_rg
-    displayName: Deploy resource group
-    variables:
-      resourceType: 'Microsoft.Resources/resourceGroups'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/validation.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Validation Resource Group
+  # - stage: deploy_rg
+  #   displayName: Deploy resource group
+  #   variables:
+  #     resourceType: 'Microsoft.Resources/resourceGroups'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/validation.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Validation Resource Group
 
   - stage: deploy_msi
     displayName: Deploy user assigned identity
-    dependsOn:
-      - deploy_rg
+    # dependsOn:
+    #   - deploy_rg
     variables:
       resourceType: 'Microsoft.ManagedIdentity/userAssignedIdentities'
       templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
@@ -57,581 +57,603 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
-
-  - stage: deploy_pa
-    displayName: Deploy policy assignment
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Authorization/policyAssignments'
-      templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_policyAssignments_sub.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Policy assignment
-
-  - stage: deploy_evh
-    displayName: Deploy event hub
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.EventHub/namespaces'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: EventHub
-
-  - stage: deploy_law
-    displayName: Deploy log analytics workspace
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.OperationalInsights/workspaces'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default LAW
-            - path: $(dependencyPath)/$(resourceType)/parameters/appi.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: AppInsights LAW
-
-  - stage: deploy_sa
-    displayName: Deploy storage account
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Storage/storageAccounts'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default storage account
-              jobName: default_sa
-            - path: $(dependencyPath)/$(resourceType)/parameters/law.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: LAW storage account
-            - path: $(dependencyPath)/$(resourceType)/parameters/fa.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: FunctionApp storage account
+              jobName: job_deploy_msi
       - job:
-        displayName: Upload files to storage account
+        displayName: Set msi principal ID output
         dependsOn:
-          - default_sa
+          - job_deploy_msi
         pool:
           ${{ if eq(variables['vmImage'], '') }}:
             name: $(poolName)
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
+        variables:
+          deploymentOutput: $[ dependencies.job_deploy_msi.outputs['DeployModule.deploymentOutput'] ]
         steps:
           - task: PowerShell@2
-            displayName: 'Setup agent'
             inputs:
               targetType: inline
               pwsh: true
               script: |
-                # Load used functions
-                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+                $msiPrincipalId = (ConvertFrom-Json $deploymentOutput).msiPrincipalId
+                Write-Verbose "msiPrincipalId: $msiPrincipalId" -Verbose
+                Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'msiPrincipalId', $msiPrincipalId)
 
-                # Define PS modules to install on the runner
-                $Modules = @(
-                    @{ Name = 'Az.Storage' }
-                )
+  # - stage: deploy_pa
+  #   displayName: Deploy policy assignment
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Authorization/policyAssignments'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_policyAssignments_sub.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Policy assignment
 
-                # Set agent up
-                Set-EnvironmentOnAgent -PSModules $Modules
-          - task: AzurePowerShell@5
-            displayName: Upload files to storage account
-            inputs:
-              azureSubscription: $(serviceConnection)
-              ScriptType: 'InlineScript'
-              Inline: |
-                # Load used functions
-                . (Join-Path '$(Build.SourcesDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
+  # - stage: deploy_evh
+  #   displayName: Deploy event hub
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.EventHub/namespaces'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: EventHub
 
-                # Get storage account name
-                $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
-                $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
+  # - stage: deploy_law
+  #   displayName: Deploy log analytics workspace
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.OperationalInsights/workspaces'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default LAW
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/appi.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: AppInsights LAW
 
-                # Upload files to storage account
-                $functionInput = @{
-                  ResourceGroupName   = '$(defaultResourceGroupName)'
-                  StorageAccountName  = $storageAccountParameters.name.value
-                  contentDirectories  = Join-Path '$(Build.SourcesDirectory)' $(dependencyPath) '$(resourceType)' 'uploads'
-                  targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
-                }
+  # - stage: deploy_sa
+  #   displayName: Deploy storage account
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Storage/storageAccounts'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default storage account
+  #             jobName: default_sa
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/law.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: LAW storage account
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/fa.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: FunctionApp storage account
+  #     - job:
+  #       displayName: Upload files to storage account
+  #       dependsOn:
+  #         - default_sa
+  #       pool:
+  #         ${{ if eq(variables['vmImage'], '') }}:
+  #           name: $(poolName)
+  #         ${{ if eq(variables['poolName'], '') }}:
+  #           vmImage: $(vmImage)
+  #       steps:
+  #         - task: PowerShell@2
+  #           displayName: 'Setup agent'
+  #           inputs:
+  #             targetType: inline
+  #             pwsh: true
+  #             script: |
+  #               # Load used functions
+  #               . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-                Write-Verbose "Invoke task with" -Verbose
-                Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+  #               # Define PS modules to install on the runner
+  #               $Modules = @(
+  #                   @{ Name = 'Az.Storage' }
+  #               )
 
-                Export-ContentToBlob @functionInput -Verbose
-              azurePowerShellVersion: 'LatestVersion'
-              pwsh: true
+  #               # Set agent up
+  #               Set-EnvironmentOnAgent -PSModules $Modules
+  #         - task: AzurePowerShell@5
+  #           displayName: Upload files to storage account
+  #           inputs:
+  #             azureSubscription: $(serviceConnection)
+  #             ScriptType: 'InlineScript'
+  #             Inline: |
+  #               # Load used functions
+  #               . (Join-Path '$(Build.SourcesDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
 
-  - stage: deploy_sig
-    displayName: Deploy shared image gallery and definition
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Compute/galleries'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default SIG and SID
+  #               # Get storage account name
+  #               $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
+  #               $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
-  - stage: deploy_ag
-    displayName: Deploy action groups
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Insights/actionGroups'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Action Group
+  #               # Upload files to storage account
+  #               $functionInput = @{
+  #                 ResourceGroupName   = '$(defaultResourceGroupName)'
+  #                 StorageAccountName  = $storageAccountParameters.name.value
+  #                 contentDirectories  = Join-Path '$(Build.SourcesDirectory)' $(dependencyPath) '$(resourceType)' 'uploads'
+  #                 targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
+  #               }
 
-  - stage: deploy_asg
-    displayName: Deploy application security groups
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Network/applicationSecurityGroups'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Application Security Groups
+  #               Write-Verbose "Invoke task with" -Verbose
+  #               Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-  - stage: deploy_udr
-    displayName: Deploy route tables
-    dependsOn:
-      - deploy_rg
-    variables:
-      resourceType: 'Microsoft.Network/routeTables'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default User Defined Routes
-            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-                - path: $(dependencyPath)/$(resourceType)/parameters/sqlMi.parameters.json
-                  templateFilePath: $(templateFilePath)
-                  displayName: SQLMI User Defined Routes
+  #               Export-ContentToBlob @functionInput -Verbose
+  #             azurePowerShellVersion: 'LatestVersion'
+  #             pwsh: true
 
-  - stage: deploy_nsg
-    displayName: Deploy network security groups
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.Network/networkSecurityGroups'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default NSG
-            - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: App Gateway NSG
-            - path: $(dependencyPath)/$(resourceType)/parameters/ase.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: ASE NSG
-            - path: $(dependencyPath)/$(resourceType)/parameters/bastion.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Bastion NSG
-            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-                - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
-                  templateFilePath: $(templateFilePath)
-                  displayName: SQLMI NSG
+  # - stage: deploy_sig
+  #   displayName: Deploy shared image gallery and definition
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Compute/galleries'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default SIG and SID
 
-  - stage: deploy_pip
-    displayName: Deploy public IP addresses
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.Network\publicIPAddresses'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: App Gateway Public IP
-            - path: $(dependencyPath)/$(resourceType)/parameters/bas.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Bastion Public IP
-            - path: $(dependencyPath)/$(resourceType)/parameters/lb.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Load balancer Public IP
+  # - stage: deploy_ag
+  #   displayName: Deploy action groups
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Insights/actionGroups'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Action Group
 
-  - stage: deploy_appi
-    displayName: Deploy application insight
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.Insights/components'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Application Insights
+  # - stage: deploy_asg
+  #   displayName: Deploy application security groups
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Network/applicationSecurityGroups'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Application Security Groups
 
-  - stage: deploy_aut
-    displayName: Deploy automation account
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.Automation/automationAccounts'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Automation Account
+  # - stage: deploy_udr
+  #   displayName: Deploy route tables
+  #   dependsOn:
+  #     - deploy_rg
+  #   variables:
+  #     resourceType: 'Microsoft.Network/routeTables'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default User Defined Routes
+  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlMi.parameters.json
+  #                 templateFilePath: $(templateFilePath)
+  #                 displayName: SQLMI User Defined Routes
 
-  - stage: deploy_avdhp
-    displayName: Deploy AVD host pool
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.DesktopVirtualization/hostpools'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default AVD Host Pool
+  # - stage: deploy_nsg
+  #   displayName: Deploy network security groups
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.Network/networkSecurityGroups'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default NSG
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: App Gateway NSG
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/ase.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: ASE NSG
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/bastion.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Bastion NSG
+  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
+  #                 templateFilePath: $(templateFilePath)
+  #                 displayName: SQLMI NSG
 
-  - stage: deploy_rsv
-    displayName: Deploy recovery services vault
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.RecoveryServices/vaults'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default recovery services vault
+  # - stage: deploy_pip
+  #   displayName: Deploy public IP addresses
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.Network\publicIPAddresses'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: App Gateway Public IP
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/bas.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Bastion Public IP
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/lb.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Load balancer Public IP
 
-  - stage: deploy_kv
-    displayName: Deploy key vaults
-    dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
-    variables:
-      resourceType: 'Microsoft.KeyVault/vaults'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Key Vault
-              jobName: default_kv
-            - path: $(dependencyPath)/$(resourceType)/parameters/pe.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Private Endpoint Key Vault
-            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-                - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
-                  templateFilePath: $(templateFilePath)
-                  displayName: SQLMI key vault
-                  jobName: sqlmi_kv
-      - job:
-        displayName: Set key vault secrets keys and certificates
-        dependsOn:
-          - default_kv
-        pool:
-          ${{ if eq(variables['vmImage'], '') }}:
-            name: $(poolName)
-          ${{ if eq(variables['poolName'], '') }}:
-            vmImage: $(vmImage)
-        steps:
-          - task: PowerShell@2
-            displayName: 'Setup agent'
-            inputs:
-              targetType: inline
-              pwsh: true
-              script: |
-                # Load used functions
-                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  # - stage: deploy_appi
+  #   displayName: Deploy application insight
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.Insights/components'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Application Insights
 
-                # Define PS modules to install on the runner
-                $Modules = @(
-                    @{ Name = 'Az.KeyVault' }
-                )
+  # - stage: deploy_aut
+  #   displayName: Deploy automation account
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.Automation/automationAccounts'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Automation Account
 
-                # Set agent up
-                Set-EnvironmentOnAgent -PSModules $Modules
-          - task: AzurePowerShell@5
-            displayName: Set key vault secrets keys and certificates
-            inputs:
-              azureSubscription: $(serviceConnection)
-              ScriptType: 'InlineScript'
-              Inline: |
-                # Get key vault name
-                $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
-                $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-                $keyVaultName = $keyVaultParameters.name.value
+  # - stage: deploy_avdhp
+  #   displayName: Deploy AVD host pool
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.DesktopVirtualization/hostpools'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default AVD Host Pool
 
-                # Generate values
-                $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-                $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-                $passwordString = (New-Guid).Guid.SubString(0, 19)
-                $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
-                $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
-                $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
+  # - stage: deploy_rsv
+  #   displayName: Deploy recovery services vault
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.RecoveryServices/vaults'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default recovery services vault
 
-                # Set secrets
-                # -------
-                @(
-                  @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
-                  @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
-                  @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
-                  @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
-                  @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
-                  @{ name = 'apimClientId'; secretValue = $username } # API management
-                  @{ name = 'apimClientSecret'; secretValue = $password } # API management
-                ) | ForEach-Object {
-                  $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-                  Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-                }
+  # - stage: deploy_kv
+  #   displayName: Deploy key vaults
+  #   dependsOn:
+  #     - deploy_sa
+  #     - deploy_evh
+  #     - deploy_law
+  #   variables:
+  #     resourceType: 'Microsoft.KeyVault/vaults'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Key Vault
+  #             jobName: default_kv
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/pe.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Private Endpoint Key Vault
+  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
+  #                 templateFilePath: $(templateFilePath)
+  #                 displayName: SQLMI key vault
+  #                 jobName: sqlmi_kv
+  #     - job:
+  #       displayName: Set key vault secrets keys and certificates
+  #       dependsOn:
+  #         - default_kv
+  #       pool:
+  #         ${{ if eq(variables['vmImage'], '') }}:
+  #           name: $(poolName)
+  #         ${{ if eq(variables['poolName'], '') }}:
+  #           vmImage: $(vmImage)
+  #       steps:
+  #         - task: PowerShell@2
+  #           displayName: 'Setup agent'
+  #           inputs:
+  #             targetType: inline
+  #             pwsh: true
+  #             script: |
+  #               # Load used functions
+  #               . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-                # Certificats
-                # -----------
-                $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
-                @(
-                  @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
-                ) | ForEach-Object {
-                  $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
-                  Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-                }
+  #               # Define PS modules to install on the runner
+  #               $Modules = @(
+  #                   @{ Name = 'Az.KeyVault' }
+  #               )
 
-                # Set keys
-                # ----
-                @(
-                  @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
-                ) | ForEach-Object {
-                    $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-                    Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-                }
-              azurePowerShellVersion: 'LatestVersion'
-              pwsh: true
+  #               # Set agent up
+  #               Set-EnvironmentOnAgent -PSModules $Modules
+  #         - task: AzurePowerShell@5
+  #           displayName: Set key vault secrets keys and certificates
+  #           inputs:
+  #             azureSubscription: $(serviceConnection)
+  #             ScriptType: 'InlineScript'
+  #             Inline: |
+  #               # Get key vault name
+  #               $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
+  #               $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+  #               $keyVaultName = $keyVaultParameters.name.value
 
-      - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-          - job:
-            displayName: Set sqlmi key vault secrets and keys
-            condition: eq(${{ parameters.deploySqlMiDependencies }}, true)
-            dependsOn:
-              - sqlmi_kv
-            pool:
-              ${{ if eq(variables['vmImage'], '') }}:
-                name: $(poolName)
-              ${{ if eq(variables['poolName'], '') }}:
-                vmImage: $(vmImage)
-            steps:
-              - task: PowerShell@2
-                displayName: 'Setup agent'
-                inputs:
-                  targetType: inline
-                  pwsh: true
-                  script: |
-                    # Load used functions
-                    . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  #               # Generate values
+  #               $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+  #               $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+  #               $passwordString = (New-Guid).Guid.SubString(0, 19)
+  #               $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+  #               $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
+  #               $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
 
-                    # Define PS modules to install on the runner
-                    $Modules = @(
-                        @{ Name = 'Az.KeyVault' }
-                    )
+  #               # Set secrets
+  #               # -------
+  #               @(
+  #                 @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
+  #                 @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
+  #                 @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
+  #                 @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
+  #                 @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
+  #                 @{ name = 'apimClientId'; secretValue = $username } # API management
+  #                 @{ name = 'apimClientSecret'; secretValue = $password } # API management
+  #               ) | ForEach-Object {
+  #                 $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+  #                 Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #               }
 
-                    # Set agent up
-                    Set-EnvironmentOnAgent -PSModules $Modules
-              - task: AzurePowerShell@5
-                displayName: Set sqlmi key vault secrets and keys
-                inputs:
-                  azureSubscription: $(serviceConnection)
-                  ScriptType: 'InlineScript'
-                  Inline: |
-                    # Get key vault name
-                    $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'sqlmi.parameters.json'
-                    $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-                    $keyVaultName = $keyVaultParameters.name.value
+  #               # Certificats
+  #               # -----------
+  #               $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
+  #               @(
+  #                 @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
+  #               ) | ForEach-Object {
+  #                 $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
+  #                 Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #               }
 
-                    # Generate values
-                    $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-                    $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-                    $passwordString = (New-Guid).Guid.SubString(0, 19)
-                    $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+  #               # Set keys
+  #               # ----
+  #               @(
+  #                 @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
+  #               ) | ForEach-Object {
+  #                   $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+  #                   Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #               }
+  #             azurePowerShellVersion: 'LatestVersion'
+  #             pwsh: true
 
-                    # Set secrets
-                    # -------
-                    @(
-                      @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
-                      @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
-                    ) | ForEach-Object {
-                      $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-                      Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-                    }
+  #     - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #         - job:
+  #           displayName: Set sqlmi key vault secrets and keys
+  #           condition: eq(${{ parameters.deploySqlMiDependencies }}, true)
+  #           dependsOn:
+  #             - sqlmi_kv
+  #           pool:
+  #             ${{ if eq(variables['vmImage'], '') }}:
+  #               name: $(poolName)
+  #             ${{ if eq(variables['poolName'], '') }}:
+  #               vmImage: $(vmImage)
+  #           steps:
+  #             - task: PowerShell@2
+  #               displayName: 'Setup agent'
+  #               inputs:
+  #                 targetType: inline
+  #                 pwsh: true
+  #                 script: |
+  #                   # Load used functions
+  #                   . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-                    # Set keys
-                    # ----
-                    @(
-                      @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
-                    ) | ForEach-Object {
-                        $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-                        Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-                    }
-                  azurePowerShellVersion: 'LatestVersion'
-                  pwsh: true
+  #                   # Define PS modules to install on the runner
+  #                   $Modules = @(
+  #                       @{ Name = 'Az.KeyVault' }
+  #                   )
 
-  - stage: deploy_avdag
-    displayName: Deploy AVD application group
-    dependsOn:
-      - deploy_avdhp
-    variables:
-      resourceType: 'Microsoft.DesktopVirtualization/applicationgroups'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Application Group
+  #                   # Set agent up
+  #                   Set-EnvironmentOnAgent -PSModules $Modules
+  #             - task: AzurePowerShell@5
+  #               displayName: Set sqlmi key vault secrets and keys
+  #               inputs:
+  #                 azureSubscription: $(serviceConnection)
+  #                 ScriptType: 'InlineScript'
+  #                 Inline: |
+  #                   # Get key vault name
+  #                   $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'sqlmi.parameters.json'
+  #                   $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+  #                   $keyVaultName = $keyVaultParameters.name.value
 
-  - stage: deploy_rolea
-    displayName: Deploy role assignments
-    dependsOn:
-      - deploy_msi
-    variables:
-      resourceType: 'Microsoft.Authorization\roleAssignments'
-      templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: MSI Role Assignment
+  #                   # Generate values
+  #                   $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+  #                   $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+  #                   $passwordString = (New-Guid).Guid.SubString(0, 19)
+  #                   $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
 
-  - stage: deploy_vnet
-    displayName: Deploy virtual networks
-    dependsOn:
-      - deploy_nsg
-      - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-          - deploy_udr
-    variables:
-      resourceType: 'Microsoft.Network/virtualNetworks'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Virtual Network
-            - path: $(dependencyPath)/$(resourceType)/parameters/1.bastion.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Bastion Virtual Network
-            - path: $(dependencyPath)/$(resourceType)/parameters/2.vnetpeer01.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: VNET PEering 1 Virtual Network
-            - path: $(dependencyPath)/$(resourceType)/parameters/3.vnetpeer02.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: VNET Peering 2 Virtual Network
-            - path: $(dependencyPath)/$(resourceType)/parameters/4.azfw.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Azure Firewall Virtual Network
-            - path: $(dependencyPath)/$(resourceType)/parameters/5.aks.parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: AKS Virtual Network
-            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-                - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
-                  templateFilePath: $(templateFilePath)
-                  displayName: SQL MI Virtual Network
+  #                   # Set secrets
+  #                   # -------
+  #                   @(
+  #                     @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
+  #                     @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
+  #                   ) | ForEach-Object {
+  #                     $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+  #                     Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #                   }
 
-  - stage: deploy_dnszone
-    displayName: Deploy private DNS zones
-    dependsOn:
-      - deploy_vnet
-    variables:
-      resourceType: 'Microsoft.Network/privateDnsZones'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Private DNS Zones
+  #                   # Set keys
+  #                   # ----
+  #                   @(
+  #                     @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
+  #                   ) | ForEach-Object {
+  #                       $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+  #                       Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #                   }
+  #                 azurePowerShellVersion: 'LatestVersion'
+  #                 pwsh: true
 
-  - stage: deploy_vm
-    displayName: Deploy virtual machines
-    dependsOn:
-      - deploy_vnet
-      - deploy_rsv
-      - deploy_kv
-    variables:
-      resourceType: 'Microsoft.Compute/virtualMachines'
-      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-    jobs:
-      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        parameters:
-          deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-              templateFilePath: $(templateFilePath)
-              displayName: Default Virtual Machine
+  # - stage: deploy_avdag
+  #   displayName: Deploy AVD application group
+  #   dependsOn:
+  #     - deploy_avdhp
+  #   variables:
+  #     resourceType: 'Microsoft.DesktopVirtualization/applicationgroups'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Application Group
+
+  # - stage: deploy_rolea
+  #   displayName: Deploy role assignments
+  #   dependsOn:
+  #     - deploy_msi
+  #   variables:
+  #     resourceType: 'Microsoft.Authorization\roleAssignments'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: MSI Role Assignment
+
+
+  # - stage: deploy_vnet
+  #   displayName: Deploy virtual networks
+  #   dependsOn:
+  #     - deploy_nsg
+  #     - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #         - deploy_udr
+  #   variables:
+  #     resourceType: 'Microsoft.Network/virtualNetworks'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Virtual Network
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/1.bastion.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Bastion Virtual Network
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/2.vnetpeer01.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: VNET PEering 1 Virtual Network
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/3.vnetpeer02.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: VNET Peering 2 Virtual Network
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/4.azfw.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Azure Firewall Virtual Network
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/5.aks.parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: AKS Virtual Network
+  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+  #               - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
+  #                 templateFilePath: $(templateFilePath)
+  #                 displayName: SQL MI Virtual Network
+
+  # - stage: deploy_dnszone
+  #   displayName: Deploy private DNS zones
+  #   dependsOn:
+  #     - deploy_vnet
+  #   variables:
+  #     resourceType: 'Microsoft.Network/privateDnsZones'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Private DNS Zones
+
+  # - stage: deploy_vm
+  #   displayName: Deploy virtual machines
+  #   dependsOn:
+  #     - deploy_vnet
+  #     - deploy_rsv
+  #     - deploy_kv
+  #   variables:
+  #     resourceType: 'Microsoft.Compute/virtualMachines'
+  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+  #   jobs:
+  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+  #       parameters:
+  #         deploymentBlocks:
+  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+  #             templateFilePath: $(templateFilePath)
+  #             displayName: Default Virtual Machine

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -595,6 +595,8 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
+      msiPrincipalId: $[ dependencies.deploy_msi.outputs['job_set_msi_id.print_msi_prinId.msiPrincipalId'] ]
+      # dependencies.STAGE.outputs['JOB.TASK.VARIABLE']
     jobs:
       - job: job_get_msi_id
         displayName: Get msi principal ID output
@@ -603,8 +605,8 @@ stages:
             name: $(poolName)
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
-        variables:
-          msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+        # variables:
+        #   msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
         steps:
           - task: PowerShell@2
             name: print_custom_token
@@ -650,7 +652,8 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
               # customParameterFileTokens: '$(msiPrincipalId)'
-              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
+              # customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
+              customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -581,7 +581,7 @@ stages:
     dependsOn:
       - deploy_msi
     variables:
-      resourceType: 'Microsoft.Authorization\roleAssignments'
+      resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
       varFromStageA: $[ stageDependencies.deploy_msi.default_msi_job.outputs['DeployModule.deploymentOutput'] ]
     jobs:
@@ -613,7 +613,7 @@ stages:
 
                 # Construct Token Function Input
                 $ConvertTokensInputs = @{
-                    ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+                    ParameterFilePath                 = Join-Path '$(System.DefaultWorkingDirectory)' '$(dependencyPath)/$(resourceType)/parameters/parameters.json'
                     OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
                     TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
                     TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -644,8 +644,6 @@ stages:
                 Write-Verbose "customParameterFileTokens: $customParameterFileTokens" -Verbose
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'customParameterFileTokens', $customParameterFileTokens)
       - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-        variables:
-          customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
         parameters:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,8 +58,6 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-              # customParameterFileTokens: "[{\"name\":\"value\"}]"
-              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(templateFilePath)"}]'
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:
@@ -655,7 +653,7 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: $(msiPrincipalId)
+              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
               # customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: \[\{"name":"msiPrincipalId","value":"msiPrincipalIdddd"\}\]
               # customParameterFileTokens: >

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -626,7 +626,7 @@ stages:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
-              displayName: Default Role Assignment
+              displayName: Default MSI Role Assignment
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -649,7 +649,7 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: $(msiPrincipalId)
+              customParameterFileTokens: '$(msiPrincipalId)'
               # customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -644,9 +644,9 @@ stages:
                 Write-Verbose "customParameterFileTokens: $customParameterFileTokens" -Verbose
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'customParameterFileTokens', $customParameterFileTokens)
       - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        variables:
+          customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
         parameters:
-          variables:
-            customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -620,6 +620,7 @@ stages:
 
                 # # Invoke Token Replacement Functionality
 
+                Write-Verbose "msiPrincipalId: $(msiPrincipalId)" -Verbose
                 # Initialize Additional Custom Parameter File Tokens for Token Replacement Functionality
                 $otherCustomParameterFileTokens = @(
                     @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,7 +58,7 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-              customParameterFileTokens: [{"name":"value"}]
+              customParameterFileTokens: '[{"name":"value"}]'
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,7 +58,7 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-              customParameterFileTokens: '[{"name":"value"}]'
+              customParameterFileTokens: '[{\"name\":\"value\"}]'
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -634,8 +634,8 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              # customParameterFileTokens: '$(customParameterFileTokens)'
-              customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
+              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
+              # customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -649,7 +649,7 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
+              customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -652,13 +652,14 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
+              customParameterFileTokens: \[\]
               # customParameterFileTokens: $(msiPrincipalId)
-              # customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
-              customParameterFileTokens: >
-                [
-                { "name": "msiPrincipalId",
-                "value": "msiPrincipalIdValue" }
-                ]
+              # customParameterFileTokens: \[\{"name":"msiPrincipalId","value":"msiPrincipalIdddd"\}\]
+              # customParameterFileTokens: >
+              #   [
+              #   { "name": "msiPrincipalId",
+              #   "value": "msiPrincipalIdValue" }
+              #   ]
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -601,14 +601,14 @@ stages:
               pwsh: true
               script: |
                 # Load used functions
-                . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
                 # Load Settings File
                 $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
                 # Initialize Default Parameter File Tokens
                 $OtherCustomParameterFileTokens = @(
-                    @{ Name = 'msiPrincipalId'; Value = '$msiPrincipalId' }
+                    @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
                 )
 
                 # Construct Token Function Input

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -595,7 +595,8 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-      msiPrincipalId: $[ dependencies.deploy_msi.outputs['job_set_msi_id.print_msi_prinId.msiPrincipalId'] ]
+      # msiPrincipalId: $[ dependencies.deploy_msi.outputs['job_set_msi_id.print_msi_prinId.msiPrincipalId'] ]
+      msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
       # dependencies.STAGE.outputs['JOB.TASK.VARIABLE']
     jobs:
       - job: job_get_msi_id

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -622,10 +622,11 @@ stages:
 
                 # # Invoke Token Replacement Functionality
 
-                Write-Verbose "msiPrincipalId: $(msiPrincipalId)" -Verbose
+                Write-Verbose "msiPrincipalId: '$(msiPrincipalId)'" -Verbose
+                $msiPrincipalId = '$(msiPrincipalId)'
                 # Initialize Additional Custom Parameter File Tokens for Token Replacement Functionality
                 $otherCustomParameterFileTokens = @(
-                    @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
+                    @{ Name = 'msiPrincipalId'; Value = $msiPrincipalId }
                 )
 
                 $customParameterFileTokens = $otherCustomParameterFileTokens | ConvertTo-Json

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -75,7 +75,8 @@ stages:
               targetType: inline
               pwsh: true
               script: |
-                $msiPrincipalId = (ConvertFrom-Json $deploymentOutput).msiPrincipalId
+                # Write-Verbose $(deploymentOutput) -Verbose
+                $msiPrincipalId = (ConvertFrom-Json $(deploymentOutput)).msiPrincipalId
                 Write-Verbose "msiPrincipalId: $msiPrincipalId" -Verbose
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'msiPrincipalId', $msiPrincipalId)
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -76,7 +76,7 @@ stages:
               pwsh: true
               script: |
                 # Write-Verbose $(deploymentOutput) -Verbose
-                $msiPrincipalId = (ConvertFrom-Json $(deploymentOutput)).msiPrincipalId
+                $msiPrincipalId = (ConvertFrom-Json '$(deploymentOutput)').msiPrincipalId
                 Write-Verbose "msiPrincipalId: $msiPrincipalId" -Verbose
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'msiPrincipalId', $msiPrincipalId)
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -626,7 +626,7 @@ stages:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
-              displayName: MSI Role Assignment
+              displayName: Default Role Assignment
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -598,7 +598,7 @@ stages:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
-              displayName: Default MSI Role Assignment
+              displayName: MSI Role Assignment
               customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
 
   - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -583,7 +583,7 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-      msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
+
     jobs:
       - job: job_get_msi
         displayName: Get msi principal ID output
@@ -592,6 +592,8 @@ stages:
             name: $(poolName)
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
+        variables:
+          msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
         steps:
           - task: PowerShell@2
             name: print_custom_token

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -30,23 +30,23 @@ variables:
     value: 'validation-rg'
 
 stages:
-  # - stage: deploy_rg
-  #   displayName: Deploy resource group
-  #   variables:
-  #     resourceType: 'Microsoft.Resources/resourceGroups'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/validation.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Validation Resource Group
+  - stage: deploy_rg
+    displayName: Deploy resource group
+    variables:
+      resourceType: 'Microsoft.Resources/resourceGroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/validation.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Validation Resource Group
 
   - stage: deploy_msi
     displayName: Deploy user assigned identity
-    # dependsOn:
-    #   - deploy_rg
+    dependsOn:
+      - deploy_rg
     variables:
       resourceType: 'Microsoft.ManagedIdentity/userAssignedIdentities'
       templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
@@ -81,303 +81,303 @@ stages:
                 Write-Verbose "msiPrincipalId: $msiPrincipalId" -Verbose
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'msiPrincipalId', $msiPrincipalId)
 
-  # - stage: deploy_pa
-  #   displayName: Deploy policy assignment
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Authorization/policyAssignments'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_policyAssignments_sub.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Policy assignment
+  - stage: deploy_pa
+    displayName: Deploy policy assignment
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Authorization/policyAssignments'
+      templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_policyAssignments_sub.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Policy assignment
 
-  # - stage: deploy_evh
-  #   displayName: Deploy event hub
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.EventHub/namespaces'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: EventHub
+  - stage: deploy_evh
+    displayName: Deploy event hub
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.EventHub/namespaces'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: EventHub
 
-  # - stage: deploy_law
-  #   displayName: Deploy log analytics workspace
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.OperationalInsights/workspaces'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default LAW
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/appi.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: AppInsights LAW
+  - stage: deploy_law
+    displayName: Deploy log analytics workspace
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.OperationalInsights/workspaces'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default LAW
+            - path: $(dependencyPath)/$(resourceType)/parameters/appi.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: AppInsights LAW
 
-  # - stage: deploy_sa
-  #   displayName: Deploy storage account
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Storage/storageAccounts'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default storage account
-  #             jobName: default_sa
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/law.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: LAW storage account
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/fa.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: FunctionApp storage account
-  #     - job:
-  #       displayName: Upload files to storage account
-  #       dependsOn:
-  #         - default_sa
-  #       pool:
-  #         ${{ if eq(variables['vmImage'], '') }}:
-  #           name: $(poolName)
-  #         ${{ if eq(variables['poolName'], '') }}:
-  #           vmImage: $(vmImage)
-  #       steps:
-  #         - task: PowerShell@2
-  #           displayName: 'Setup agent'
-  #           inputs:
-  #             targetType: inline
-  #             pwsh: true
-  #             script: |
-  #               # Load used functions
-  #               . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  - stage: deploy_sa
+    displayName: Deploy storage account
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Storage/storageAccounts'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default storage account
+              jobName: default_sa
+            - path: $(dependencyPath)/$(resourceType)/parameters/law.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: LAW storage account
+            - path: $(dependencyPath)/$(resourceType)/parameters/fa.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: FunctionApp storage account
+      - job:
+        displayName: Upload files to storage account
+        dependsOn:
+          - default_sa
+        pool:
+          ${{ if eq(variables['vmImage'], '') }}:
+            name: $(poolName)
+          ${{ if eq(variables['poolName'], '') }}:
+            vmImage: $(vmImage)
+        steps:
+          - task: PowerShell@2
+            displayName: 'Setup agent'
+            inputs:
+              targetType: inline
+              pwsh: true
+              script: |
+                # Load used functions
+                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #               # Define PS modules to install on the runner
-  #               $Modules = @(
-  #                   @{ Name = 'Az.Storage' }
-  #               )
+                # Define PS modules to install on the runner
+                $Modules = @(
+                    @{ Name = 'Az.Storage' }
+                )
 
-  #               # Set agent up
-  #               Set-EnvironmentOnAgent -PSModules $Modules
-  #         - task: AzurePowerShell@5
-  #           displayName: Upload files to storage account
-  #           inputs:
-  #             azureSubscription: $(serviceConnection)
-  #             ScriptType: 'InlineScript'
-  #             Inline: |
-  #               # Load used functions
-  #               . (Join-Path '$(Build.SourcesDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
+                # Set agent up
+                Set-EnvironmentOnAgent -PSModules $Modules
+          - task: AzurePowerShell@5
+            displayName: Upload files to storage account
+            inputs:
+              azureSubscription: $(serviceConnection)
+              ScriptType: 'InlineScript'
+              Inline: |
+                # Load used functions
+                . (Join-Path '$(Build.SourcesDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
 
-  #               # Get storage account name
-  #               $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
-  #               $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
+                # Get storage account name
+                $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
+                $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
-  #               # Upload files to storage account
-  #               $functionInput = @{
-  #                 ResourceGroupName   = '$(defaultResourceGroupName)'
-  #                 StorageAccountName  = $storageAccountParameters.name.value
-  #                 contentDirectories  = Join-Path '$(Build.SourcesDirectory)' $(dependencyPath) '$(resourceType)' 'uploads'
-  #                 targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
-  #               }
+                # Upload files to storage account
+                $functionInput = @{
+                  ResourceGroupName   = '$(defaultResourceGroupName)'
+                  StorageAccountName  = $storageAccountParameters.name.value
+                  contentDirectories  = Join-Path '$(Build.SourcesDirectory)' $(dependencyPath) '$(resourceType)' 'uploads'
+                  targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
+                }
 
-  #               Write-Verbose "Invoke task with" -Verbose
-  #               Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+                Write-Verbose "Invoke task with" -Verbose
+                Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-  #               Export-ContentToBlob @functionInput -Verbose
-  #             azurePowerShellVersion: 'LatestVersion'
-  #             pwsh: true
+                Export-ContentToBlob @functionInput -Verbose
+              azurePowerShellVersion: 'LatestVersion'
+              pwsh: true
 
-  # - stage: deploy_sig
-  #   displayName: Deploy shared image gallery and definition
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Compute/galleries'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default SIG and SID
+  - stage: deploy_sig
+    displayName: Deploy shared image gallery and definition
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Compute/galleries'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default SIG and SID
 
-  # - stage: deploy_ag
-  #   displayName: Deploy action groups
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Insights/actionGroups'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Action Group
+  - stage: deploy_ag
+    displayName: Deploy action groups
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Insights/actionGroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Action Group
 
-  # - stage: deploy_asg
-  #   displayName: Deploy application security groups
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Network/applicationSecurityGroups'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Application Security Groups
+  - stage: deploy_asg
+    displayName: Deploy application security groups
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Network/applicationSecurityGroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Application Security Groups
 
-  # - stage: deploy_udr
-  #   displayName: Deploy route tables
-  #   dependsOn:
-  #     - deploy_rg
-  #   variables:
-  #     resourceType: 'Microsoft.Network/routeTables'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default User Defined Routes
-  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlMi.parameters.json
-  #                 templateFilePath: $(templateFilePath)
-  #                 displayName: SQLMI User Defined Routes
+  - stage: deploy_udr
+    displayName: Deploy route tables
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Network/routeTables'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default User Defined Routes
+            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+                - path: $(dependencyPath)/$(resourceType)/parameters/sqlMi.parameters.json
+                  templateFilePath: $(templateFilePath)
+                  displayName: SQLMI User Defined Routes
 
-  # - stage: deploy_nsg
-  #   displayName: Deploy network security groups
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.Network/networkSecurityGroups'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default NSG
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: App Gateway NSG
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/ase.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: ASE NSG
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/bastion.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Bastion NSG
-  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
-  #                 templateFilePath: $(templateFilePath)
-  #                 displayName: SQLMI NSG
+  - stage: deploy_nsg
+    displayName: Deploy network security groups
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+    variables:
+      resourceType: 'Microsoft.Network/networkSecurityGroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default NSG
+            - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: App Gateway NSG
+            - path: $(dependencyPath)/$(resourceType)/parameters/ase.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: ASE NSG
+            - path: $(dependencyPath)/$(resourceType)/parameters/bastion.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Bastion NSG
+            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+                - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
+                  templateFilePath: $(templateFilePath)
+                  displayName: SQLMI NSG
 
-  # - stage: deploy_pip
-  #   displayName: Deploy public IP addresses
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.Network\publicIPAddresses'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: App Gateway Public IP
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/bas.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Bastion Public IP
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/lb.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Load balancer Public IP
+  - stage: deploy_pip
+    displayName: Deploy public IP addresses
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+    variables:
+      resourceType: 'Microsoft.Network\publicIPAddresses'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/apgw.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: App Gateway Public IP
+            - path: $(dependencyPath)/$(resourceType)/parameters/bas.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Bastion Public IP
+            - path: $(dependencyPath)/$(resourceType)/parameters/lb.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Load balancer Public IP
 
-  # - stage: deploy_appi
-  #   displayName: Deploy application insight
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.Insights/components'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Application Insights
+  - stage: deploy_appi
+    displayName: Deploy application insight
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+    variables:
+      resourceType: 'Microsoft.Insights/components'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Application Insights
 
-  # - stage: deploy_aut
-  #   displayName: Deploy automation account
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.Automation/automationAccounts'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Automation Account
+  - stage: deploy_aut
+    displayName: Deploy automation account
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+    variables:
+      resourceType: 'Microsoft.Automation/automationAccounts'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Automation Account
 
-  # - stage: deploy_avdhp
-  #   displayName: Deploy AVD host pool
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.DesktopVirtualization/hostpools'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default AVD Host Pool
+  - stage: deploy_avdhp
+    displayName: Deploy AVD host pool
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+    variables:
+      resourceType: 'Microsoft.DesktopVirtualization/hostpools'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default AVD Host Pool
 
   - stage: deploy_rsv
     displayName: Deploy recovery services vault
     dependsOn:
-      # - deploy_sa
-      # - deploy_evh
-      # - deploy_law
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
       - deploy_msi
     variables:
       resourceType: 'Microsoft.RecoveryServices/vaults'
@@ -395,9 +395,9 @@ stages:
   - stage: deploy_kv
     displayName: Deploy key vaults
     dependsOn:
-      # - deploy_sa
-      # - deploy_evh
-      # - deploy_law
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
       - deploy_msi
     variables:
       resourceType: 'Microsoft.KeyVault/vaults'
@@ -422,167 +422,167 @@ stages:
                   displayName: SQLMI key vault
                   jobName: sqlmi_kv
                   customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
-  #     - job:
-  #       displayName: Set key vault secrets keys and certificates
-  #       dependsOn:
-  #         - default_kv
-  #       pool:
-  #         ${{ if eq(variables['vmImage'], '') }}:
-  #           name: $(poolName)
-  #         ${{ if eq(variables['poolName'], '') }}:
-  #           vmImage: $(vmImage)
-  #       steps:
-  #         - task: PowerShell@2
-  #           displayName: 'Setup agent'
-  #           inputs:
-  #             targetType: inline
-  #             pwsh: true
-  #             script: |
-  #               # Load used functions
-  #               . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+      - job:
+        displayName: Set key vault secrets keys and certificates
+        dependsOn:
+          - default_kv
+        pool:
+          ${{ if eq(variables['vmImage'], '') }}:
+            name: $(poolName)
+          ${{ if eq(variables['poolName'], '') }}:
+            vmImage: $(vmImage)
+        steps:
+          - task: PowerShell@2
+            displayName: 'Setup agent'
+            inputs:
+              targetType: inline
+              pwsh: true
+              script: |
+                # Load used functions
+                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #               # Define PS modules to install on the runner
-  #               $Modules = @(
-  #                   @{ Name = 'Az.KeyVault' }
-  #               )
+                # Define PS modules to install on the runner
+                $Modules = @(
+                    @{ Name = 'Az.KeyVault' }
+                )
 
-  #               # Set agent up
-  #               Set-EnvironmentOnAgent -PSModules $Modules
-  #         - task: AzurePowerShell@5
-  #           displayName: Set key vault secrets keys and certificates
-  #           inputs:
-  #             azureSubscription: $(serviceConnection)
-  #             ScriptType: 'InlineScript'
-  #             Inline: |
-  #               # Get key vault name
-  #               $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
-  #               $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #               $keyVaultName = $keyVaultParameters.name.value
+                # Set agent up
+                Set-EnvironmentOnAgent -PSModules $Modules
+          - task: AzurePowerShell@5
+            displayName: Set key vault secrets keys and certificates
+            inputs:
+              azureSubscription: $(serviceConnection)
+              ScriptType: 'InlineScript'
+              Inline: |
+                # Get key vault name
+                $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'parameters.json'
+                $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+                $keyVaultName = $keyVaultParameters.name.value
 
-  #               # Generate values
-  #               $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #               $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #               $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #               $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
-  #               $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
-  #               $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
+                # Generate values
+                $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+                $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+                $passwordString = (New-Guid).Guid.SubString(0, 19)
+                $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+                $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
+                $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
 
-  #               # Set secrets
-  #               # -------
-  #               @(
-  #                 @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
-  #                 @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
-  #                 @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
-  #                 @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
-  #                 @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
-  #                 @{ name = 'apimClientId'; secretValue = $username } # API management
-  #                 @{ name = 'apimClientSecret'; secretValue = $password } # API management
-  #               ) | ForEach-Object {
-  #                 $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #                 Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #               }
+                # Set secrets
+                # -------
+                @(
+                  @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
+                  @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
+                  @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
+                  @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
+                  @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
+                  @{ name = 'apimClientId'; secretValue = $username } # API management
+                  @{ name = 'apimClientSecret'; secretValue = $password } # API management
+                ) | ForEach-Object {
+                  $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+                  Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+                }
 
-  #               # Certificats
-  #               # -----------
-  #               $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
-  #               @(
-  #                 @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
-  #               ) | ForEach-Object {
-  #                 $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
-  #                 Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #               }
+                # Certificats
+                # -----------
+                $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
+                @(
+                  @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
+                ) | ForEach-Object {
+                  $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
+                  Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+                }
 
-  #               # Set keys
-  #               # ----
-  #               @(
-  #                 @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
-  #               ) | ForEach-Object {
-  #                   $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #                   Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #               }
-  #             azurePowerShellVersion: 'LatestVersion'
-  #             pwsh: true
+                # Set keys
+                # ----
+                @(
+                  @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
+                ) | ForEach-Object {
+                    $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                    Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+                }
+              azurePowerShellVersion: 'LatestVersion'
+              pwsh: true
 
-  #     - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #         - job:
-  #           displayName: Set sqlmi key vault secrets and keys
-  #           condition: eq(${{ parameters.deploySqlMiDependencies }}, true)
-  #           dependsOn:
-  #             - sqlmi_kv
-  #           pool:
-  #             ${{ if eq(variables['vmImage'], '') }}:
-  #               name: $(poolName)
-  #             ${{ if eq(variables['poolName'], '') }}:
-  #               vmImage: $(vmImage)
-  #           steps:
-  #             - task: PowerShell@2
-  #               displayName: 'Setup agent'
-  #               inputs:
-  #                 targetType: inline
-  #                 pwsh: true
-  #                 script: |
-  #                   # Load used functions
-  #                   . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+      - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+          - job:
+            displayName: Set sqlmi key vault secrets and keys
+            condition: eq(${{ parameters.deploySqlMiDependencies }}, true)
+            dependsOn:
+              - sqlmi_kv
+            pool:
+              ${{ if eq(variables['vmImage'], '') }}:
+                name: $(poolName)
+              ${{ if eq(variables['poolName'], '') }}:
+                vmImage: $(vmImage)
+            steps:
+              - task: PowerShell@2
+                displayName: 'Setup agent'
+                inputs:
+                  targetType: inline
+                  pwsh: true
+                  script: |
+                    # Load used functions
+                    . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #                   # Define PS modules to install on the runner
-  #                   $Modules = @(
-  #                       @{ Name = 'Az.KeyVault' }
-  #                   )
+                    # Define PS modules to install on the runner
+                    $Modules = @(
+                        @{ Name = 'Az.KeyVault' }
+                    )
 
-  #                   # Set agent up
-  #                   Set-EnvironmentOnAgent -PSModules $Modules
-  #             - task: AzurePowerShell@5
-  #               displayName: Set sqlmi key vault secrets and keys
-  #               inputs:
-  #                 azureSubscription: $(serviceConnection)
-  #                 ScriptType: 'InlineScript'
-  #                 Inline: |
-  #                   # Get key vault name
-  #                   $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'sqlmi.parameters.json'
-  #                   $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #                   $keyVaultName = $keyVaultParameters.name.value
+                    # Set agent up
+                    Set-EnvironmentOnAgent -PSModules $Modules
+              - task: AzurePowerShell@5
+                displayName: Set sqlmi key vault secrets and keys
+                inputs:
+                  azureSubscription: $(serviceConnection)
+                  ScriptType: 'InlineScript'
+                  Inline: |
+                    # Get key vault name
+                    $parameterFilePath = Join-Path '$(Build.SourcesDirectory)' '$(dependencyPath)' '$(resourceType)' 'parameters' 'sqlmi.parameters.json'
+                    $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+                    $keyVaultName = $keyVaultParameters.name.value
 
-  #                   # Generate values
-  #                   $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #                   $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #                   $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #                   $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+                    # Generate values
+                    $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+                    $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+                    $passwordString = (New-Guid).Guid.SubString(0, 19)
+                    $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
 
-  #                   # Set secrets
-  #                   # -------
-  #                   @(
-  #                     @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
-  #                     @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
-  #                   ) | ForEach-Object {
-  #                     $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #                     Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #                   }
+                    # Set secrets
+                    # -------
+                    @(
+                      @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
+                      @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
+                    ) | ForEach-Object {
+                      $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+                      Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+                    }
 
-  #                   # Set keys
-  #                   # ----
-  #                   @(
-  #                     @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
-  #                   ) | ForEach-Object {
-  #                       $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #                       Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #                   }
-  #                 azurePowerShellVersion: 'LatestVersion'
-  #                 pwsh: true
+                    # Set keys
+                    # ----
+                    @(
+                      @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
+                    ) | ForEach-Object {
+                        $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                        Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+                    }
+                  azurePowerShellVersion: 'LatestVersion'
+                  pwsh: true
 
-  # - stage: deploy_avdag
-  #   displayName: Deploy AVD application group
-  #   dependsOn:
-  #     - deploy_avdhp
-  #   variables:
-  #     resourceType: 'Microsoft.DesktopVirtualization/applicationgroups'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Application Group
+  - stage: deploy_avdag
+    displayName: Deploy AVD application group
+    dependsOn:
+      - deploy_avdhp
+    variables:
+      resourceType: 'Microsoft.DesktopVirtualization/applicationgroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Application Group
 
   - stage: deploy_rolea
     displayName: Deploy role assignments
@@ -601,71 +601,70 @@ stages:
               displayName: Default MSI Role Assignment
               customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
 
+  - stage: deploy_vnet
+    displayName: Deploy virtual networks
+    dependsOn:
+      - deploy_nsg
+      - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+          - deploy_udr
+    variables:
+      resourceType: 'Microsoft.Network/virtualNetworks'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/1.bastion.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Bastion Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/2.vnetpeer01.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: VNET PEering 1 Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/3.vnetpeer02.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: VNET Peering 2 Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/4.azfw.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Azure Firewall Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/5.aks.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: AKS Virtual Network
+            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+                - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
+                  templateFilePath: $(templateFilePath)
+                  displayName: SQL MI Virtual Network
 
-  # - stage: deploy_vnet
-  #   displayName: Deploy virtual networks
-  #   dependsOn:
-  #     - deploy_nsg
-  #     - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #         - deploy_udr
-  #   variables:
-  #     resourceType: 'Microsoft.Network/virtualNetworks'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Virtual Network
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/1.bastion.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Bastion Virtual Network
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/2.vnetpeer01.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: VNET PEering 1 Virtual Network
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/3.vnetpeer02.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: VNET Peering 2 Virtual Network
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/4.azfw.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Azure Firewall Virtual Network
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/5.aks.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: AKS Virtual Network
-  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #               - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
-  #                 templateFilePath: $(templateFilePath)
-  #                 displayName: SQL MI Virtual Network
+  - stage: deploy_dnszone
+    displayName: Deploy private DNS zones
+    dependsOn:
+      - deploy_vnet
+    variables:
+      resourceType: 'Microsoft.Network/privateDnsZones'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Private DNS Zones
 
-  # - stage: deploy_dnszone
-  #   displayName: Deploy private DNS zones
-  #   dependsOn:
-  #     - deploy_vnet
-  #   variables:
-  #     resourceType: 'Microsoft.Network/privateDnsZones'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Private DNS Zones
-
-  # - stage: deploy_vm
-  #   displayName: Deploy virtual machines
-  #   dependsOn:
-  #     - deploy_vnet
-  #     - deploy_rsv
-  #     - deploy_kv
-  #   variables:
-  #     resourceType: 'Microsoft.Compute/virtualMachines'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Virtual Machine
+  - stage: deploy_vm
+    displayName: Deploy virtual machines
+    dependsOn:
+      - deploy_vnet
+      - deploy_rsv
+      - deploy_kv
+    variables:
+      resourceType: 'Microsoft.Compute/virtualMachines'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Virtual Machine

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -583,18 +583,18 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
+      msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
     jobs:
-      - job:
-        displayName: Set msi principal ID output
+      - job: job_get_msi
+        displayName: Get msi principal ID output
         pool:
           ${{ if eq(variables['vmImage'], '') }}:
             name: $(poolName)
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
-        variables:
-          msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
         steps:
           - task: PowerShell@2
+            name: print_custom_token
             inputs:
               targetType: inline
               pwsh: true
@@ -620,7 +620,7 @@ stages:
 
                 # # Invoke Token Replacement Functionality
 
-                # Initialize Additional Custom Parameter File Tokens
+                # Initialize Additional Custom Parameter File Tokens for Token Replacement Functionality
                 $otherCustomParameterFileTokens = @(
                     @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
                 )
@@ -634,7 +634,8 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: '$(customParameterFileTokens)'
+              # customParameterFileTokens: '$(customParameterFileTokens)'
+              customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -372,48 +372,56 @@ stages:
   #             templateFilePath: $(templateFilePath)
   #             displayName: Default AVD Host Pool
 
-  # - stage: deploy_rsv
-  #   displayName: Deploy recovery services vault
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.RecoveryServices/vaults'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default recovery services vault
+  - stage: deploy_rsv
+    displayName: Deploy recovery services vault
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+      - deploy_msi
+    variables:
+      resourceType: 'Microsoft.RecoveryServices/vaults'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+      msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default recovery services vault
+              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
 
-  # - stage: deploy_kv
-  #   displayName: Deploy key vaults
-  #   dependsOn:
-  #     - deploy_sa
-  #     - deploy_evh
-  #     - deploy_law
-  #   variables:
-  #     resourceType: 'Microsoft.KeyVault/vaults'
-  #     templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
-  #   jobs:
-  #     - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
-  #       parameters:
-  #         deploymentBlocks:
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Default Key Vault
-  #             jobName: default_kv
-  #           - path: $(dependencyPath)/$(resourceType)/parameters/pe.parameters.json
-  #             templateFilePath: $(templateFilePath)
-  #             displayName: Private Endpoint Key Vault
-  #           - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
-  #               - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
-  #                 templateFilePath: $(templateFilePath)
-  #                 displayName: SQLMI key vault
-  #                 jobName: sqlmi_kv
+  - stage: deploy_kv
+    displayName: Deploy key vaults
+    dependsOn:
+      - deploy_sa
+      - deploy_evh
+      - deploy_law
+      - deploy_msi
+    variables:
+      resourceType: 'Microsoft.KeyVault/vaults'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+      msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Default Key Vault
+              jobName: default_kv
+              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
+            - path: $(dependencyPath)/$(resourceType)/parameters/pe.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Private Endpoint Key Vault
+              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
+            - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
+                - path: $(dependencyPath)/$(resourceType)/parameters/sqlmi.parameters.json
+                  templateFilePath: $(templateFilePath)
+                  displayName: SQLMI key vault
+                  jobName: sqlmi_kv
+                  customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
   #     - job:
   #       displayName: Set key vault secrets keys and certificates
   #       dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -576,18 +576,6 @@ stages:
   #             templateFilePath: $(templateFilePath)
   #             displayName: Default Application Group
 
-  - stage: print_msi
-    dependsOn: deploy_msi
-    jobs:
-    - job: print_msi_job
-      variables:
-        varFromStageA: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
-      steps:
-      - checkout: none
-      - script: |
-          echo "This Job will print value from deploy_msi stage"
-          echo $(varFromStageA)
-
   - stage: deploy_rolea
     displayName: Deploy role assignments
     dependsOn:
@@ -595,58 +583,8 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-      # msiPrincipalId: $[ dependencies.deploy_msi.outputs['job_set_msi_id.print_msi_prinId.msiPrincipalId'] ]
       msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
-      # dependencies.STAGE.outputs['JOB.TASK.VARIABLE']
     jobs:
-      - job: job_get_msi_id
-        displayName: Get msi principal ID output
-        pool:
-          ${{ if eq(variables['vmImage'], '') }}:
-            name: $(poolName)
-          ${{ if eq(variables['poolName'], '') }}:
-            vmImage: $(vmImage)
-        variables:
-          # msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
-          msiPrincipalId: $(msiPrincipalId)
-        steps:
-          - task: PowerShell@2
-            name: print_custom_token
-            inputs:
-              targetType: inline
-              pwsh: true
-              script: |
-                # # Load used functions
-                # . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
-
-                # # Load Settings File
-                # $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
-
-                # # Initialize Default Parameter File Tokens
-                # $OtherCustomParameterFileTokens = @(
-                #     @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
-                # )
-
-                # # Construct Token Function Input
-                # $ConvertTokensInputs = @{
-                #     ParameterFilePath                 = Join-Path '$(System.DefaultWorkingDirectory)' '$(dependencyPath)/$(resourceType)/parameters/parameters.json'
-                #     OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-                #     TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-                #     TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-                # }
-
-                # # Invoke Token Replacement Functionality
-
-                # Write-Verbose "msiPrincipalId: '$(msiPrincipalId)'" -Verbose
-                # $msiPrincipalId = '$(msiPrincipalId)'
-                # Initialize Additional Custom Parameter File Tokens for Token Replacement Functionality
-                $otherCustomParameterFileTokens = @(
-                    @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
-                )
-
-                $customParameterFileTokens = $otherCustomParameterFileTokens | ConvertTo-Json
-                Write-Verbose "customParameterFileTokens: $customParameterFileTokens" -Verbose
-                Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'customParameterFileTokens', $customParameterFileTokens)
       - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
         parameters:
           deploymentBlocks:
@@ -654,14 +592,6 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
               customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(msiPrincipalId)"}]'
-              # customParameterFileTokens: $(msiPrincipalId)
-              # customParameterFileTokens: \[\{"name":"msiPrincipalId","value":"msiPrincipalIdddd"\}\]
-              # customParameterFileTokens: >
-              #   [
-              #   { "name": "msiPrincipalId",
-              #   "value": "msiPrincipalIdValue" }
-              #   ]
-          # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -634,8 +634,9 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
-              # customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
+              customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
+              # customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
+          # customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -583,7 +583,6 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-      varFromStageA: $[ stageDependencies.deploy_msi.default_msi_job.outputs['DeployModule.deploymentOutput'] ]
     jobs:
       - job:
         displayName: Set msi principal ID output
@@ -600,33 +599,42 @@ stages:
               targetType: inline
               pwsh: true
               script: |
-                # Load used functions
-                . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+                # # Load used functions
+                # . (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-                # Load Settings File
-                $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+                # # Load Settings File
+                # $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-                # Initialize Default Parameter File Tokens
-                $OtherCustomParameterFileTokens = @(
+                # # Initialize Default Parameter File Tokens
+                # $OtherCustomParameterFileTokens = @(
+                #     @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
+                # )
+
+                # # Construct Token Function Input
+                # $ConvertTokensInputs = @{
+                #     ParameterFilePath                 = Join-Path '$(System.DefaultWorkingDirectory)' '$(dependencyPath)/$(resourceType)/parameters/parameters.json'
+                #     OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+                #     TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+                #     TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+                # }
+
+                # # Invoke Token Replacement Functionality
+
+                # Initialize Additional Custom Parameter File Tokens
+                $otherCustomParameterFileTokens = @(
                     @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
                 )
 
-                # Construct Token Function Input
-                $ConvertTokensInputs = @{
-                    ParameterFilePath                 = Join-Path '$(System.DefaultWorkingDirectory)' '$(dependencyPath)/$(resourceType)/parameters/parameters.json'
-                    OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-                    TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-                    TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-                }
-
-                # Invoke Token Replacement Functionality
-                $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+                $customParameterFileTokens = $otherCustomParameterFileTokens | ConvertTo-Json
+                Write-Verbose "customParameterFileTokens: $customParameterFileTokens" -Verbose
+                Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'customParameterFileTokens', $customParameterFileTokens)
       - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
         parameters:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
+              customParameterFileTokens: '$(customParameterFileTokens)'
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -59,7 +59,7 @@ stages:
               displayName: User Assigned Identity
               jobName: job_deploy_msi
               # customParameterFileTokens: "[{\"name\":\"value\"}]"
-              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdValue"}]'
+              customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"$(templateFilePath)"}]'
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -375,9 +375,9 @@ stages:
   - stage: deploy_rsv
     displayName: Deploy recovery services vault
     dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
+      # - deploy_sa
+      # - deploy_evh
+      # - deploy_law
       - deploy_msi
     variables:
       resourceType: 'Microsoft.RecoveryServices/vaults'
@@ -395,9 +395,9 @@ stages:
   - stage: deploy_kv
     displayName: Deploy key vaults
     dependsOn:
-      - deploy_sa
-      - deploy_evh
-      - deploy_law
+      # - deploy_sa
+      # - deploy_evh
+      # - deploy_law
       - deploy_msi
     variables:
       resourceType: 'Microsoft.KeyVault/vaults'

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,6 +58,7 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
+              customParameterFileTokens: [{"name":"value"}]
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:
@@ -653,7 +654,7 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: \[\]
+              customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: \[\{"name":"msiPrincipalId","value":"msiPrincipalIdddd"\}\]
               # customParameterFileTokens: >

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,7 +58,7 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-      - job:
+      - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:
           - job_deploy_msi
@@ -576,6 +576,18 @@ stages:
   #             templateFilePath: $(templateFilePath)
   #             displayName: Default Application Group
 
+  - stage: print_msi
+    dependsOn: deploy_msi
+    jobs:
+    - job: print_msi_job
+      variables:
+        varFromStageA: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+      steps:
+      - checkout: none
+      - script: |
+          echo "This Job will print value from deploy_msi stage"
+          echo $(varFromStageA)
+
   - stage: deploy_rolea
     displayName: Deploy role assignments
     dependsOn:
@@ -583,9 +595,8 @@ stages:
     variables:
       resourceType: 'Microsoft.Authorization/roleAssignments'
       templateFilePath: $(modulesPath)/$(resourceType)/.bicep/nested_rbac_sub.bicep
-
     jobs:
-      - job: job_get_msi
+      - job: job_get_msi_id
         displayName: Get msi principal ID output
         pool:
           ${{ if eq(variables['vmImage'], '') }}:
@@ -593,7 +604,7 @@ stages:
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
         variables:
-          msiPrincipalId: $[ stageDependencies.deploy_msi.job_deploy_msi.outputs['print_msi_prinId.msiPrincipalId'] ]
+          msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
         steps:
           - task: PowerShell@2
             name: print_custom_token
@@ -622,11 +633,11 @@ stages:
 
                 # # Invoke Token Replacement Functionality
 
-                Write-Verbose "msiPrincipalId: '$(msiPrincipalId)'" -Verbose
-                $msiPrincipalId = '$(msiPrincipalId)'
+                # Write-Verbose "msiPrincipalId: '$(msiPrincipalId)'" -Verbose
+                # $msiPrincipalId = '$(msiPrincipalId)'
                 # Initialize Additional Custom Parameter File Tokens for Token Replacement Functionality
                 $otherCustomParameterFileTokens = @(
-                    @{ Name = 'msiPrincipalId'; Value = $msiPrincipalId }
+                    @{ Name = 'msiPrincipalId'; Value = '$(msiPrincipalId)' }
                 )
 
                 $customParameterFileTokens = $otherCustomParameterFileTokens | ConvertTo-Json
@@ -638,9 +649,9 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
+              customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
               # customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
-          # customParameterFileTokens: $[ dependencies.job_get_msi.outputs['print_custom_token.customParameterFileTokens'] ]
+          # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 
   # - stage: deploy_vnet

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -653,7 +653,11 @@ stages:
               displayName: Default MSI Role Assignment
               # customParameterFileTokens: '$(msiPrincipalId)'
               # customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
-              customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
+              customParameterFileTokens: >
+                [
+                { "name": "msiPrincipalId",
+                "value": "$(msiPrincipalId)" }
+                ]
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -605,8 +605,9 @@ stages:
             name: $(poolName)
           ${{ if eq(variables['poolName'], '') }}:
             vmImage: $(vmImage)
-        # variables:
-        #   msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+        variables:
+          # msiPrincipalId: $[ stageDependencies.deploy_msi.job_set_msi_id.outputs['print_msi_prinId.msiPrincipalId'] ]
+          msiPrincipalId: $(msiPrincipalId)
         steps:
           - task: PowerShell@2
             name: print_custom_token
@@ -651,13 +652,13 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              # customParameterFileTokens: '$(msiPrincipalId)'
+              customParameterFileTokens: $(msiPrincipalId)
               # customParameterFileTokens: '[{\"name\":\"msiPrincipalId\",\"value\":\"msiPrincipalIdddd\"}]'
-              customParameterFileTokens: >
-                [
-                { "name": "msiPrincipalId",
-                "value": "$(msiPrincipalId)" }
-                ]
+              # customParameterFileTokens: >
+              #   [
+              #   { "name": "msiPrincipalId",
+              #   "value": "$(msiPrincipalId)" }
+              #   ]
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,7 +58,8 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-              customParameterFileTokens: "[{\"name\":\"value\"}]"
+              # customParameterFileTokens: "[{\"name\":\"value\"}]"
+              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdValue"}]'
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -58,7 +58,7 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: User Assigned Identity
               jobName: job_deploy_msi
-              customParameterFileTokens: '[{\"name\":\"value\"}]'
+              customParameterFileTokens: "[{\"name\":\"value\"}]"
       - job: job_set_msi_id
         displayName: Set msi principal ID output
         dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -645,12 +645,14 @@ stages:
                 Write-Output ('##vso[task.setvariable variable={0};isOutput=true]{1}' -f 'customParameterFileTokens', $customParameterFileTokens)
       - template: /.azuredevops/pipelineTemplates/module.jobs.deploy.yml
         parameters:
+          variables:
+            customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Default MSI Role Assignment
-              customParameterFileTokens: '$(msiPrincipalId)'
-              # customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
+              # customParameterFileTokens: '$(msiPrincipalId)'
+              customParameterFileTokens: '[{"name":"msiPrincipalId","value":"msiPrincipalIdddd"}]'
           # customParameterFileTokens: $[ dependencies.job_get_msi_id.outputs['print_custom_token.customParameterFileTokens'] ]
 
 

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -20,6 +20,9 @@ inputs:
   managementGroupId:
     description: 'The managementGroupId to deploy to'
     required: false
+  customParameterFileTokens:
+    description: 'Additional parameter file token pairs in json format. e.g. [{"Name":"tokenName","Value":"tokenValue"}]'
+    required: false
   removeDeployment:
     description: 'Set "true" to set module up for removal'
     default: 'true'
@@ -84,14 +87,17 @@ runs:
             @{ Name = 'managementGroupId'; Value = '${{ inputs.managementGroupId }}' }
             @{ Name = "tenantId"; Value = '${{ env.ARM_TENANT_ID }}' }
             @{ Name = "deploymentSpId"; Value = '${{ env.DEPLOYMENT_SP_ID }}' }
-        )
+        ) | ForEach-Object { [PSCustomObject]$PSItem }
 
-        $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
+        # Get additional Custom Parameter File Tokens from input
+        Write-Verbose 'Additional Custom Parameter File Tokens: ${{ inputs.customParameterFileTokens }}' -Verbose
+        $OtherCustomParameterFileTokens = '${{  inputs.customParameterFileTokens }}' | ConvertFrom-Json
 
         # Construct Token Function Input
         $ConvertTokensInputs = @{
             ParameterFilePath                 = '${{ inputs.parameterFilePath }}'
             DefaultParameterFileTokens        = $DefaultParameterFileTokens
+            OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
             LocalCustomParameterFileTokens    = $Settings.parameterFileTokens.localTokens.tokens
             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -576,34 +576,59 @@ jobs:
   #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
   #         removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_rsv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy recovery services vault'
-  #   env:
-  #     namespace: 'Microsoft.RecoveryServices\vaults'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_rsv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy recovery services vault'
+    env:
+      namespace: 'Microsoft.RecoveryServices\vaults'
+    needs:
+      - job_deploy_msi
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Get msi principal ID and replace token in parameter file'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+
+          # Load Settings File
+          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+
+          # Initialize Default Parameter File Tokens
+          $OtherCustomParameterFileTokens = @(
+              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+          )
+
+          # Construct Token Function Input
+          $ConvertTokensInputs = @{
+              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+          }
+
+          # Invoke Token Replacement Functionality
+          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_kv:
     runs-on: ubuntu-20.04
@@ -741,35 +766,60 @@ jobs:
   #           }
   #         azPSVersion: 'latest'
 
-  # job_deploy_sqlmi_kv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi key vault'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_kv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi key vault'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      - job_deploy_msi
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Get msi principal ID and replace token in parameter file'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+
+          # Load Settings File
+          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+
+          # Initialize Default Parameter File Tokens
+          $OtherCustomParameterFileTokens = @(
+              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+          )
+
+          # Construct Token Function Input
+          $ConvertTokensInputs = @{
+              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+          }
+
+          # Invoke Token Replacement Functionality
+          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   # job_deploy_sqlmi_kv_secrets:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -30,38 +30,38 @@ env:
   DEPLOYMENT_SP_ID: '${{ secrets.DEPLOYMENT_SP_ID }}'
 
 jobs:
-  # job_deploy_rg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy resource group'
-  #   env:
-  #     namespace: 'Microsoft.Resources\resourceGroups'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['validation.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_rg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy resource group'
+    env:
+      namespace: 'Microsoft.Resources\resourceGroups'
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['validation.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_msi:
     runs-on: ubuntu-20.04
     name: 'Deploy user assigned identity'
     env:
       namespace: 'Microsoft.ManagedIdentity\userAssignedIdentities'
-    # needs:
-    #   - job_deploy_rg
+    needs:
+      - job_deploy_rg
     outputs:
       msiPrincipalId: ${{ steps.print_msi_prinId.outputs.msiPrincipalId }}
     strategy:
@@ -94,487 +94,487 @@ jobs:
             Write-Output ('::set-output name=msiPrincipalId::{0}' -f $msiPrincipalId)
           azPSVersion: 'latest'
 
-  # job_deploy_pa:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy policy assignment'
-  #   env:
-  #     namespace: 'Microsoft.Authorization\policyAssignments'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_pa:
+    runs-on: ubuntu-20.04
+    name: 'Deploy policy assignment'
+    env:
+      namespace: 'Microsoft.Authorization\policyAssignments'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_evh:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy eventhub'
-  #   env:
-  #     namespace: 'Microsoft.EventHub\namespaces'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_evh:
+    runs-on: ubuntu-20.04
+    name: 'Deploy eventhub'
+    env:
+      namespace: 'Microsoft.EventHub\namespaces'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_law:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy log analytics workspace'
-  #   env:
-  #     namespace: 'Microsoft.OperationalInsights\workspaces'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['appi.parameters.json', 'parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_law:
+    runs-on: ubuntu-20.04
+    name: 'Deploy log analytics workspace'
+    env:
+      namespace: 'Microsoft.OperationalInsights\workspaces'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['appi.parameters.json', 'parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sa:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy storage account'
-  #   env:
-  #     namespace: 'Microsoft.Storage\storageAccounts'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sa:
+    runs-on: ubuntu-20.04
+    name: 'Deploy storage account'
+    env:
+      namespace: 'Microsoft.Storage\storageAccounts'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_sa_upload_storage_files:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Upload files to storage account'
-  #   env:
-  #     namespace: 'Microsoft.Storage\storageAccounts'
-  #   needs:
-  #     - job_deploy_sa
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_sa_upload_storage_files:
+    runs-on: ubuntu-20.04
+    name: 'Upload files to storage account'
+    env:
+      namespace: 'Microsoft.Storage\storageAccounts'
+    needs:
+      - job_deploy_sa
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.Storage' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.Storage' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: Run PowerShell
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Load used functions
-  #           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: Run PowerShell
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Load used functions
+            . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
 
-  #           # Get storage account name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
-  #           $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
+            # Get storage account name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
+            $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
-  #           # Upload files to storage account
-  #           $functionInput = @{
-  #             ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
-  #             StorageAccountName  = $storageAccountParameters.name.value
-  #             contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
-  #             targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
-  #           }
+            # Upload files to storage account
+            $functionInput = @{
+              ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
+              StorageAccountName  = $storageAccountParameters.name.value
+              contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
+              targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
+            }
 
-  #           Write-Verbose "Invoke task with" -Verbose
-  #           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+            Write-Verbose "Invoke task with" -Verbose
+            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-  #           Export-ContentToBlob @functionInput -Verbose
-  #         azPSVersion: 'latest'
+            Export-ContentToBlob @functionInput -Verbose
+          azPSVersion: 'latest'
 
-  # job_deploy_sig:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy shared image gallery and definition'
-  #   env:
-  #     namespace: 'Microsoft.Compute\galleries'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sig:
+    runs-on: ubuntu-20.04
+    name: 'Deploy shared image gallery and definition'
+    env:
+      namespace: 'Microsoft.Compute\galleries'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_ag:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy action groups'
-  #   env:
-  #     namespace: 'Microsoft.Insights\actionGroups'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_ag:
+    runs-on: ubuntu-20.04
+    name: 'Deploy action groups'
+    env:
+      namespace: 'Microsoft.Insights\actionGroups'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_asg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy application security groups'
-  #   env:
-  #     namespace: 'Microsoft.Network\applicationSecurityGroups'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_asg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy application security groups'
+    env:
+      namespace: 'Microsoft.Network\applicationSecurityGroups'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_udr:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy route tables'
-  #   env:
-  #     namespace: 'Microsoft.Network\routeTables'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_udr:
+    runs-on: ubuntu-20.04
+    name: 'Deploy route tables'
+    env:
+      namespace: 'Microsoft.Network\routeTables'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_udr:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi route tables'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\routeTables'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlMi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_udr:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi route tables'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\routeTables'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlMi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_nsg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy network security groups'
-  #   env:
-  #     namespace: 'Microsoft.Network\networkSecurityGroups'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         [
-  #           'apgw.parameters.json',
-  #           'ase.parameters.json',
-  #           'bastion.parameters.json',
-  #           'parameters.json',
-  #         ]
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_nsg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy network security groups'
+    env:
+      namespace: 'Microsoft.Network\networkSecurityGroups'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          [
+            'apgw.parameters.json',
+            'ase.parameters.json',
+            'bastion.parameters.json',
+            'parameters.json',
+          ]
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_nsg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi network security group'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\networkSecurityGroups'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_nsg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi network security group'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\networkSecurityGroups'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_pip:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy public IP addresses'
-  #   env:
-  #     namespace: 'Microsoft.Network\publicIPAddresses'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_pip:
+    runs-on: ubuntu-20.04
+    name: 'Deploy public IP addresses'
+    env:
+      namespace: 'Microsoft.Network\publicIPAddresses'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_appi:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy application insight'
-  #   env:
-  #     namespace: 'Microsoft.Insights\components'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_appi:
+    runs-on: ubuntu-20.04
+    name: 'Deploy application insight'
+    env:
+      namespace: 'Microsoft.Insights\components'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_aut:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy automation account'
-  #   env:
-  #     namespace: 'Microsoft.Automation\automationAccounts'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_aut:
+    runs-on: ubuntu-20.04
+    name: 'Deploy automation account'
+    env:
+      namespace: 'Microsoft.Automation\automationAccounts'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_avdhp:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy AVD host pool'
-  #   env:
-  #     namespace: 'Microsoft.DesktopVirtualization\hostpools'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_avdhp:
+    runs-on: ubuntu-20.04
+    name: 'Deploy AVD host pool'
+    env:
+      namespace: 'Microsoft.DesktopVirtualization\hostpools'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_rsv:
     runs-on: ubuntu-20.04
@@ -582,9 +582,9 @@ jobs:
     env:
       namespace: 'Microsoft.RecoveryServices\vaults'
     needs:
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
       - job_deploy_msi
     strategy:
       fail-fast: false
@@ -613,9 +613,9 @@ jobs:
     env:
       namespace: 'Microsoft.KeyVault\vaults'
     needs:
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
       - job_deploy_msi
     strategy:
       fail-fast: false
@@ -638,87 +638,87 @@ jobs:
           removeDeployment: '${{ env.removeDeployment }}'
           customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
-  # job_deploy_kv_secrets:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Set key vault secrets keys and certificates'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_kv
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_deploy_kv_secrets:
+    runs-on: ubuntu-20.04
+    name: 'Set key vault secrets keys and certificates'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      - job_deploy_kv
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.KeyVault' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.KeyVault' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: 'Set key vault secrets keys and certificates'
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Get key vault name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
-  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #           $keyVaultName = $keyVaultParameters.name.value
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: 'Set key vault secrets keys and certificates'
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Get key vault name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
+            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+            $keyVaultName = $keyVaultParameters.name.value
 
-  #           # Generate values
-  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
-  #           $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
-  #           $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
+            # Generate values
+            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+            $passwordString = (New-Guid).Guid.SubString(0, 19)
+            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+            $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
+            $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
 
-  #           # Set secrets
-  #           # -------
-  #           @(
-  #             @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
-  #             @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
-  #             @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
-  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
-  #             @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
-  #             @{ name = 'apimClientId'; secretValue = $username } # API management
-  #             @{ name = 'apimClientSecret'; secretValue = $password } # API management
-  #           ) | ForEach-Object {
-  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set secrets
+            # -------
+            @(
+              @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
+              @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
+              @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
+              @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
+              @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
+              @{ name = 'apimClientId'; secretValue = $username } # API management
+              @{ name = 'apimClientSecret'; secretValue = $password } # API management
+            ) | ForEach-Object {
+              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set certificates
-  #           # -----------
-  #           $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
-  #           @(
-  #             @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
-  #           ) | ForEach-Object {
-  #             $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
-  #             Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set certificates
+            # -----------
+            $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
+            @(
+              @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
+            ) | ForEach-Object {
+              $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
+              Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set keys
-  #           # ----
-  #           @(
-  #             @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
-  #           ) | ForEach-Object {
-  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
-  #         azPSVersion: 'latest'
+            # Set keys
+            # ----
+            @(
+              @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
+            ) | ForEach-Object {
+                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
+          azPSVersion: 'latest'
 
   job_deploy_sqlmi_kv:
     runs-on: ubuntu-20.04
@@ -727,9 +727,9 @@ jobs:
     env:
       namespace: 'Microsoft.KeyVault\vaults'
     needs:
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
       - job_deploy_msi
     strategy:
       fail-fast: false
@@ -752,98 +752,98 @@ jobs:
           removeDeployment: '${{ env.removeDeployment }}'
           customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
-  # job_deploy_sqlmi_kv_secrets:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Set sqlmi key vault secrets and keys'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   needs:
-  #     - job_deploy_sqlmi_kv
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_deploy_sqlmi_kv_secrets:
+    runs-on: ubuntu-20.04
+    name: 'Set sqlmi key vault secrets and keys'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    needs:
+      - job_deploy_sqlmi_kv
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.KeyVault' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.KeyVault' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: 'Set sqlmi key vault secrets and keys'
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Get key vault name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
-  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #           $keyVaultName = $keyVaultParameters.name.value
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: 'Set sqlmi key vault secrets and keys'
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Get key vault name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
+            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+            $keyVaultName = $keyVaultParameters.name.value
 
-  #           # Generate values
-  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+            # Generate values
+            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+            $passwordString = (New-Guid).Guid.SubString(0, 19)
+            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
 
-  #           # Set secrets
-  #           # -------
-  #           @(
-  #             @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
-  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
-  #           ) | ForEach-Object {
-  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set secrets
+            # -------
+            @(
+              @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
+              @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
+            ) | ForEach-Object {
+              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set keys
-  #           # ----
-  #           @(
-  #             @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
-  #           ) | ForEach-Object {
-  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
-  #         azPSVersion: 'latest'
+            # Set keys
+            # ----
+            @(
+              @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
+            ) | ForEach-Object {
+                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
+          azPSVersion: 'latest'
 
-  # job_deploy_avdag:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy AVD application group'
-  #   env:
-  #     namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
-  #   needs:
-  #     - job_deploy_avdhp
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_avdag:
+    runs-on: ubuntu-20.04
+    name: 'Deploy AVD application group'
+    env:
+      namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
+    needs:
+      - job_deploy_avdhp
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_rolea:
     runs-on: ubuntu-20.04
@@ -873,173 +873,122 @@ jobs:
           removeDeployment: '${{ env.removeDeployment }}'
           customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
-  # job_deploy_rolea:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy role assignments'
-  #   env:
-  #     namespace: 'Microsoft.Authorization\roleAssignments'
-  #   needs:
-  #     - job_deploy_msi
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Get msi principal ID and replace token in parameter file'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+  job_deploy_vnet:
+    runs-on: ubuntu-20.04
+    name: 'Deploy virtual networks'
+    env:
+      namespace: 'Microsoft.Network\virtualNetworks'
+    needs:
+      - job_deploy_nsg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          [
+            '1.bastion.parameters.json',
+            '2.vnetpeer01.parameters.json',
+            '3.vnetpeer02.parameters.json',
+            '4.azfw.parameters.json',
+            '5.aks.parameters.json',
+            'parameters.json',
+          ]
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  #         # Load Settings File
-  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+  job_deploy_sqlmi_vnet:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi virtual network'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\virtualNetworks'
+    needs:
+      - job_deploy_sqlmi_udr
+      - job_deploy_sqlmi_nsg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['6.sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  #         # Initialize Default Parameter File Tokens
-  #         $OtherCustomParameterFileTokens = @(
-  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-  #         )
+  job_deploy_dnszone:
+    runs-on: ubuntu-20.04
+    name: 'Deploy private DNS zones'
+    env:
+      namespace: 'Microsoft.Network\privateDnsZones'
+    needs:
+      - job_deploy_vnet
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  #         # Construct Token Function Input
-  #         $ConvertTokensInputs = @{
-  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-  #         }
-
-  #         # Invoke Token Replacement Functionality
-  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_rbac_sub.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
-
-  # job_deploy_vnet:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy virtual networks'
-  #   env:
-  #     namespace: 'Microsoft.Network\virtualNetworks'
-  #   needs:
-  #     - job_deploy_nsg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         [
-  #           '1.bastion.parameters.json',
-  #           '2.vnetpeer01.parameters.json',
-  #           '3.vnetpeer02.parameters.json',
-  #           '4.azfw.parameters.json',
-  #           '5.aks.parameters.json',
-  #           'parameters.json',
-  #         ]
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
-
-  # job_deploy_sqlmi_vnet:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi virtual network'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\virtualNetworks'
-  #   needs:
-  #     - job_deploy_sqlmi_udr
-  #     - job_deploy_sqlmi_nsg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['6.sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
-
-  # job_deploy_dnszone:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy private DNS zones'
-  #   env:
-  #     namespace: 'Microsoft.Network\privateDnsZones'
-  #   needs:
-  #     - job_deploy_vnet
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
-
-  # job_deploy_vm:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy virtual machines'
-  #   env:
-  #     namespace: 'Microsoft.Compute\virtualMachines'
-  #   needs:
-  #     - job_deploy_kv_secrets
-  #     - job_deploy_vnet
-  #     - job_deploy_rsv
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_vm:
+    runs-on: ubuntu-20.04
+    name: 'Deploy virtual machines'
+    env:
+      namespace: 'Microsoft.Compute\virtualMachines'
+    needs:
+      - job_deploy_kv_secrets
+      - job_deploy_vnet
+      - job_deploy_rsv
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -30,38 +30,38 @@ env:
   DEPLOYMENT_SP_ID: '${{ secrets.DEPLOYMENT_SP_ID }}'
 
 jobs:
-  # job_deploy_rg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy resource group'
-  #   env:
-  #     namespace: 'Microsoft.Resources\resourceGroups'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['validation.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_rg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy resource group'
+    env:
+      namespace: 'Microsoft.Resources\resourceGroups'
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['validation.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_msi:
     runs-on: ubuntu-20.04
     name: 'Deploy user assigned identity'
     env:
       namespace: 'Microsoft.ManagedIdentity\userAssignedIdentities'
-    # needs:
-    #   - job_deploy_rg
+    needs:
+      - job_deploy_rg
     outputs:
       msiPrincipalId: ${{ steps.deploy-msi-out.outputs.msiPrincipalId }}
     strategy:
@@ -94,487 +94,487 @@ jobs:
             Write-Output ('::set-output name=msiPrincipalId::{0}' -f $msiPrincipalId)
           azPSVersion: 'latest'
 
-  # job_deploy_pa:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy policy assignment'
-  #   env:
-  #     namespace: 'Microsoft.Authorization\policyAssignments'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_pa:
+    runs-on: ubuntu-20.04
+    name: 'Deploy policy assignment'
+    env:
+      namespace: 'Microsoft.Authorization\policyAssignments'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_evh:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy eventhub'
-  #   env:
-  #     namespace: 'Microsoft.EventHub\namespaces'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_evh:
+    runs-on: ubuntu-20.04
+    name: 'Deploy eventhub'
+    env:
+      namespace: 'Microsoft.EventHub\namespaces'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_law:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy log analytics workspace'
-  #   env:
-  #     namespace: 'Microsoft.OperationalInsights\workspaces'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['appi.parameters.json', 'parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_law:
+    runs-on: ubuntu-20.04
+    name: 'Deploy log analytics workspace'
+    env:
+      namespace: 'Microsoft.OperationalInsights\workspaces'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['appi.parameters.json', 'parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sa:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy storage account'
-  #   env:
-  #     namespace: 'Microsoft.Storage\storageAccounts'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sa:
+    runs-on: ubuntu-20.04
+    name: 'Deploy storage account'
+    env:
+      namespace: 'Microsoft.Storage\storageAccounts'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_sa_upload_storage_files:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Upload files to storage account'
-  #   env:
-  #     namespace: 'Microsoft.Storage\storageAccounts'
-  #   needs:
-  #     - job_deploy_sa
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_sa_upload_storage_files:
+    runs-on: ubuntu-20.04
+    name: 'Upload files to storage account'
+    env:
+      namespace: 'Microsoft.Storage\storageAccounts'
+    needs:
+      - job_deploy_sa
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.Storage' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.Storage' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: Run PowerShell
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Load used functions
-  #           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: Run PowerShell
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Load used functions
+            . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
 
-  #           # Get storage account name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
-  #           $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
+            # Get storage account name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
+            $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
-  #           # Upload files to storage account
-  #           $functionInput = @{
-  #             ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
-  #             StorageAccountName  = $storageAccountParameters.name.value
-  #             contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
-  #             targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
-  #           }
+            # Upload files to storage account
+            $functionInput = @{
+              ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
+              StorageAccountName  = $storageAccountParameters.name.value
+              contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
+              targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
+            }
 
-  #           Write-Verbose "Invoke task with" -Verbose
-  #           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+            Write-Verbose "Invoke task with" -Verbose
+            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-  #           Export-ContentToBlob @functionInput -Verbose
-  #         azPSVersion: 'latest'
+            Export-ContentToBlob @functionInput -Verbose
+          azPSVersion: 'latest'
 
-  # job_deploy_sig:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy shared image gallery and definition'
-  #   env:
-  #     namespace: 'Microsoft.Compute\galleries'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sig:
+    runs-on: ubuntu-20.04
+    name: 'Deploy shared image gallery and definition'
+    env:
+      namespace: 'Microsoft.Compute\galleries'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_ag:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy action groups'
-  #   env:
-  #     namespace: 'Microsoft.Insights\actionGroups'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_ag:
+    runs-on: ubuntu-20.04
+    name: 'Deploy action groups'
+    env:
+      namespace: 'Microsoft.Insights\actionGroups'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_asg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy application security groups'
-  #   env:
-  #     namespace: 'Microsoft.Network\applicationSecurityGroups'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_asg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy application security groups'
+    env:
+      namespace: 'Microsoft.Network\applicationSecurityGroups'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_udr:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy route tables'
-  #   env:
-  #     namespace: 'Microsoft.Network\routeTables'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_udr:
+    runs-on: ubuntu-20.04
+    name: 'Deploy route tables'
+    env:
+      namespace: 'Microsoft.Network\routeTables'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_udr:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi route tables'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\routeTables'
-  #   needs:
-  #     - job_deploy_rg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlMi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_udr:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi route tables'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\routeTables'
+    needs:
+      - job_deploy_rg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlMi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_nsg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy network security groups'
-  #   env:
-  #     namespace: 'Microsoft.Network\networkSecurityGroups'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         [
-  #           'apgw.parameters.json',
-  #           'ase.parameters.json',
-  #           'bastion.parameters.json',
-  #           'parameters.json',
-  #         ]
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_nsg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy network security groups'
+    env:
+      namespace: 'Microsoft.Network\networkSecurityGroups'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          [
+            'apgw.parameters.json',
+            'ase.parameters.json',
+            'bastion.parameters.json',
+            'parameters.json',
+          ]
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_nsg:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi network security group'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\networkSecurityGroups'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_nsg:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi network security group'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\networkSecurityGroups'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_pip:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy public IP addresses'
-  #   env:
-  #     namespace: 'Microsoft.Network\publicIPAddresses'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_pip:
+    runs-on: ubuntu-20.04
+    name: 'Deploy public IP addresses'
+    env:
+      namespace: 'Microsoft.Network\publicIPAddresses'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_appi:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy application insight'
-  #   env:
-  #     namespace: 'Microsoft.Insights\components'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_appi:
+    runs-on: ubuntu-20.04
+    name: 'Deploy application insight'
+    env:
+      namespace: 'Microsoft.Insights\components'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_aut:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy automation account'
-  #   env:
-  #     namespace: 'Microsoft.Automation\automationAccounts'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_aut:
+    runs-on: ubuntu-20.04
+    name: 'Deploy automation account'
+    env:
+      namespace: 'Microsoft.Automation\automationAccounts'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_avdhp:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy AVD host pool'
-  #   env:
-  #     namespace: 'Microsoft.DesktopVirtualization\hostpools'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_avdhp:
+    runs-on: ubuntu-20.04
+    name: 'Deploy AVD host pool'
+    env:
+      namespace: 'Microsoft.DesktopVirtualization\hostpools'
+    needs:
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_rsv:
     runs-on: ubuntu-20.04
@@ -583,9 +583,9 @@ jobs:
       namespace: 'Microsoft.RecoveryServices\vaults'
     needs:
       - job_deploy_msi
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
     strategy:
       fail-fast: false
       matrix:
@@ -637,9 +637,9 @@ jobs:
       namespace: 'Microsoft.KeyVault\vaults'
     needs:
       - job_deploy_msi
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
     strategy:
       fail-fast: false
       matrix:
@@ -684,87 +684,87 @@ jobs:
           managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
           removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_kv_secrets:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Set key vault secrets keys and certificates'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_kv
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_deploy_kv_secrets:
+    runs-on: ubuntu-20.04
+    name: 'Set key vault secrets keys and certificates'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      - job_deploy_kv
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.KeyVault' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.KeyVault' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: 'Set key vault secrets keys and certificates'
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Get key vault name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
-  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #           $keyVaultName = $keyVaultParameters.name.value
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: 'Set key vault secrets keys and certificates'
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Get key vault name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
+            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+            $keyVaultName = $keyVaultParameters.name.value
 
-  #           # Generate values
-  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
-  #           $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
-  #           $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
+            # Generate values
+            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+            $passwordString = (New-Guid).Guid.SubString(0, 19)
+            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+            $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
+            $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
 
-  #           # Set secrets
-  #           # -------
-  #           @(
-  #             @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
-  #             @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
-  #             @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
-  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
-  #             @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
-  #             @{ name = 'apimClientId'; secretValue = $username } # API management
-  #             @{ name = 'apimClientSecret'; secretValue = $password } # API management
-  #           ) | ForEach-Object {
-  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set secrets
+            # -------
+            @(
+              @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
+              @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
+              @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
+              @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
+              @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
+              @{ name = 'apimClientId'; secretValue = $username } # API management
+              @{ name = 'apimClientSecret'; secretValue = $password } # API management
+            ) | ForEach-Object {
+              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set certificates
-  #           # -----------
-  #           $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
-  #           @(
-  #             @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
-  #           ) | ForEach-Object {
-  #             $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
-  #             Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set certificates
+            # -----------
+            $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
+            @(
+              @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
+            ) | ForEach-Object {
+              $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
+              Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set keys
-  #           # ----
-  #           @(
-  #             @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
-  #           ) | ForEach-Object {
-  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
-  #         azPSVersion: 'latest'
+            # Set keys
+            # ----
+            @(
+              @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
+            ) | ForEach-Object {
+                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
+          azPSVersion: 'latest'
 
   job_deploy_sqlmi_kv:
     runs-on: ubuntu-20.04
@@ -774,9 +774,9 @@ jobs:
       namespace: 'Microsoft.KeyVault\vaults'
     needs:
       - job_deploy_msi
-      # - job_deploy_sa
-      # - job_deploy_evh
-      # - job_deploy_law
+      - job_deploy_sa
+      - job_deploy_evh
+      - job_deploy_law
     strategy:
       fail-fast: false
       matrix:
@@ -821,98 +821,98 @@ jobs:
           managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
           removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_kv_secrets:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Set sqlmi key vault secrets and keys'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   needs:
-  #     - job_deploy_sqlmi_kv
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Setup agent'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  job_deploy_sqlmi_kv_secrets:
+    runs-on: ubuntu-20.04
+    name: 'Set sqlmi key vault secrets and keys'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    needs:
+      - job_deploy_sqlmi_kv
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Setup agent'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-  #         # Define PS modules to install on the runner
-  #         $Modules = @(
-  #             @{ Name = 'Az.KeyVault' }
-  #         )
+          # Define PS modules to install on the runner
+          $Modules = @(
+              @{ Name = 'Az.KeyVault' }
+          )
 
-  #         # Set agent up
-  #         Set-EnvironmentOnAgent -PSModules $Modules
-  #     - name: Azure Login
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-  #         enable-AzPSSession: true
-  #     - name: 'Set sqlmi key vault secrets and keys'
-  #       uses: azure/powershell@v1
-  #       with:
-  #         inlineScript: |
-  #           # Get key vault name
-  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
-  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-  #           $keyVaultName = $keyVaultParameters.name.value
+          # Set agent up
+          Set-EnvironmentOnAgent -PSModules $Modules
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: 'Set sqlmi key vault secrets and keys'
+        uses: azure/powershell@v1
+        with:
+          inlineScript: |
+            # Get key vault name
+            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
+            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+            $keyVaultName = $keyVaultParameters.name.value
 
-  #           # Generate values
-  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
-  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+            # Generate values
+            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+            $passwordString = (New-Guid).Guid.SubString(0, 19)
+            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
 
-  #           # Set secrets
-  #           # -------
-  #           @(
-  #             @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
-  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
-  #           ) | ForEach-Object {
-  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
+            # Set secrets
+            # -------
+            @(
+              @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
+              @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
+            ) | ForEach-Object {
+              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
 
-  #           # Set keys
-  #           # ----
-  #           @(
-  #             @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
-  #           ) | ForEach-Object {
-  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-  #           }
-  #         azPSVersion: 'latest'
+            # Set keys
+            # ----
+            @(
+              @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
+            ) | ForEach-Object {
+                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+            }
+          azPSVersion: 'latest'
 
-  # job_deploy_avdag:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy AVD application group'
-  #   env:
-  #     namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
-  #   needs:
-  #     - job_deploy_avdhp
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_avdag:
+    runs-on: ubuntu-20.04
+    name: 'Deploy AVD application group'
+    env:
+      namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
+    needs:
+      - job_deploy_avdhp
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_rolea:
     runs-on: ubuntu-20.04
@@ -933,18 +933,18 @@ jobs:
       - name: 'Get msi principal ID and replace token in parameter file'
         shell: pwsh
         run: |
-          # Load used functions
+          Load used functions
           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-          # Load Settings File
+          Load Settings File
           $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-          # Initialize Default Parameter File Tokens
+          Initialize Default Parameter File Tokens
           $OtherCustomParameterFileTokens = @(
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
           )
 
-          # Construct Token Function Input
+          Construct Token Function Input
           $ConvertTokensInputs = @{
               ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
               OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
@@ -952,7 +952,7 @@ jobs:
               TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
           }
 
-          # Invoke Token Replacement Functionality
+          Invoke Token Replacement Functionality
           $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
       - name: 'Deploy module'
         uses: ./.github/actions/templates/validateModuleDeployment
@@ -965,122 +965,122 @@ jobs:
           managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
           removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_vnet:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy virtual networks'
-  #   env:
-  #     namespace: 'Microsoft.Network\virtualNetworks'
-  #   needs:
-  #     - job_deploy_nsg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths:
-  #         [
-  #           '1.bastion.parameters.json',
-  #           '2.vnetpeer01.parameters.json',
-  #           '3.vnetpeer02.parameters.json',
-  #           '4.azfw.parameters.json',
-  #           '5.aks.parameters.json',
-  #           'parameters.json',
-  #         ]
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_vnet:
+    runs-on: ubuntu-20.04
+    name: 'Deploy virtual networks'
+    env:
+      namespace: 'Microsoft.Network\virtualNetworks'
+    needs:
+      - job_deploy_nsg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths:
+          [
+            '1.bastion.parameters.json',
+            '2.vnetpeer01.parameters.json',
+            '3.vnetpeer02.parameters.json',
+            '4.azfw.parameters.json',
+            '5.aks.parameters.json',
+            'parameters.json',
+          ]
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_sqlmi_vnet:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi virtual network'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.Network\virtualNetworks'
-  #   needs:
-  #     - job_deploy_sqlmi_udr
-  #     - job_deploy_sqlmi_nsg
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['6.sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_vnet:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi virtual network'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.Network\virtualNetworks'
+    needs:
+      - job_deploy_sqlmi_udr
+      - job_deploy_sqlmi_nsg
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['6.sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_dnszone:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy private DNS zones'
-  #   env:
-  #     namespace: 'Microsoft.Network\privateDnsZones'
-  #   needs:
-  #     - job_deploy_vnet
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_dnszone:
+    runs-on: ubuntu-20.04
+    name: 'Deploy private DNS zones'
+    env:
+      namespace: 'Microsoft.Network\privateDnsZones'
+    needs:
+      - job_deploy_vnet
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_vm:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy virtual machines'
-  #   env:
-  #     namespace: 'Microsoft.Compute\virtualMachines'
-  #   needs:
-  #     - job_deploy_kv_secrets
-  #     - job_deploy_vnet
-  #     - job_deploy_rsv
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_vm:
+    runs-on: ubuntu-20.04
+    name: 'Deploy virtual machines'
+    env:
+      namespace: 'Microsoft.Compute\virtualMachines'
+    needs:
+      - job_deploy_kv_secrets
+      - job_deploy_vnet
+      - job_deploy_rsv
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -855,7 +855,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: 'Replace msi principal ID in parameter file'
+      - name: 'Get msi principal ID and replace token in parameter file'
         shell: pwsh
         run: |
           # Load used functions
@@ -875,7 +875,6 @@ jobs:
           $ConvertTokensInputs = @{
               ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
               DefaultParameterFileTokens        = $DefaultParameterFileTokens
-              LocalCustomParameterFileTokens    = $Settings.parameterFileTokens.localTokens.tokens
               TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
               TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
           }

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -30,38 +30,38 @@ env:
   DEPLOYMENT_SP_ID: '${{ secrets.DEPLOYMENT_SP_ID }}'
 
 jobs:
-  job_deploy_rg:
-    runs-on: ubuntu-20.04
-    name: 'Deploy resource group'
-    env:
-      namespace: 'Microsoft.Resources\resourceGroups'
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['validation.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_rg:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy resource group'
+  #   env:
+  #     namespace: 'Microsoft.Resources\resourceGroups'
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['validation.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_msi:
     runs-on: ubuntu-20.04
     name: 'Deploy user assigned identity'
     env:
       namespace: 'Microsoft.ManagedIdentity\userAssignedIdentities'
-    needs:
-      - job_deploy_rg
+    # needs:
+    #   - job_deploy_rg
     outputs:
       msiPrincipalId: ${{ steps.print_msi_prinId.outputs.msiPrincipalId }}
     strategy:
@@ -94,825 +94,825 @@ jobs:
             Write-Output ('::set-output name=msiPrincipalId::{0}' -f $msiPrincipalId)
           azPSVersion: 'latest'
 
-  job_deploy_pa:
-    runs-on: ubuntu-20.04
-    name: 'Deploy policy assignment'
-    env:
-      namespace: 'Microsoft.Authorization\policyAssignments'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_pa:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy policy assignment'
+  #   env:
+  #     namespace: 'Microsoft.Authorization\policyAssignments'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_policyAssignments_sub.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_evh:
-    runs-on: ubuntu-20.04
-    name: 'Deploy eventhub'
-    env:
-      namespace: 'Microsoft.EventHub\namespaces'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_evh:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy eventhub'
+  #   env:
+  #     namespace: 'Microsoft.EventHub\namespaces'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_law:
-    runs-on: ubuntu-20.04
-    name: 'Deploy log analytics workspace'
-    env:
-      namespace: 'Microsoft.OperationalInsights\workspaces'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['appi.parameters.json', 'parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_law:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy log analytics workspace'
+  #   env:
+  #     namespace: 'Microsoft.OperationalInsights\workspaces'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['appi.parameters.json', 'parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_sa:
-    runs-on: ubuntu-20.04
-    name: 'Deploy storage account'
-    env:
-      namespace: 'Microsoft.Storage\storageAccounts'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths:
-          ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_sa:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy storage account'
+  #   env:
+  #     namespace: 'Microsoft.Storage\storageAccounts'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths:
+  #         ['fa.parameters.json', 'law.parameters.json', 'parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_sa_upload_storage_files:
-    runs-on: ubuntu-20.04
-    name: 'Upload files to storage account'
-    env:
-      namespace: 'Microsoft.Storage\storageAccounts'
-    needs:
-      - job_deploy_sa
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Setup agent'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  # job_sa_upload_storage_files:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Upload files to storage account'
+  #   env:
+  #     namespace: 'Microsoft.Storage\storageAccounts'
+  #   needs:
+  #     - job_deploy_sa
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Setup agent'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-          # Define PS modules to install on the runner
-          $Modules = @(
-              @{ Name = 'Az.Storage' }
-          )
+  #         # Define PS modules to install on the runner
+  #         $Modules = @(
+  #             @{ Name = 'Az.Storage' }
+  #         )
 
-          # Set agent up
-          Set-EnvironmentOnAgent -PSModules $Modules
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          enable-AzPSSession: true
-      - name: Run PowerShell
-        uses: azure/powershell@v1
-        with:
-          inlineScript: |
-            # Load used functions
-            . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
+  #         # Set agent up
+  #         Set-EnvironmentOnAgent -PSModules $Modules
+  #     - name: Azure Login
+  #       uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #         enable-AzPSSession: true
+  #     - name: Run PowerShell
+  #       uses: azure/powershell@v1
+  #       with:
+  #         inlineScript: |
+  #           # Load used functions
+  #           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Export-ContentToBlob.ps1')
 
-            # Get storage account name
-            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
-            $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
+  #           # Get storage account name
+  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'parameters' 'parameters.json'
+  #           $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
-            # Upload files to storage account
-            $functionInput = @{
-              ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
-              StorageAccountName  = $storageAccountParameters.name.value
-              contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
-              targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
-            }
+  #           # Upload files to storage account
+  #           $functionInput = @{
+  #             ResourceGroupName   = '${{ env.defaultResourceGroupName }}'
+  #             StorageAccountName  = $storageAccountParameters.name.value
+  #             contentDirectories  = Join-Path $env:GITHUB_WORKSPACE '${{ env.dependencyPath }}' '${{ env.namespace }}' 'uploads'
+  #             targetContainer     = $storageAccountParameters.blobServices.value.containers[0].name
+  #           }
 
-            Write-Verbose "Invoke task with" -Verbose
-            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+  #           Write-Verbose "Invoke task with" -Verbose
+  #           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-            Export-ContentToBlob @functionInput -Verbose
-          azPSVersion: 'latest'
+  #           Export-ContentToBlob @functionInput -Verbose
+  #         azPSVersion: 'latest'
 
-  job_deploy_sig:
-    runs-on: ubuntu-20.04
-    name: 'Deploy shared image gallery and definition'
-    env:
-      namespace: 'Microsoft.Compute\galleries'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_sig:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy shared image gallery and definition'
+  #   env:
+  #     namespace: 'Microsoft.Compute\galleries'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_ag:
-    runs-on: ubuntu-20.04
-    name: 'Deploy action groups'
-    env:
-      namespace: 'Microsoft.Insights\actionGroups'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_ag:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy action groups'
+  #   env:
+  #     namespace: 'Microsoft.Insights\actionGroups'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_asg:
-    runs-on: ubuntu-20.04
-    name: 'Deploy application security groups'
-    env:
-      namespace: 'Microsoft.Network\applicationSecurityGroups'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_asg:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy application security groups'
+  #   env:
+  #     namespace: 'Microsoft.Network\applicationSecurityGroups'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_udr:
-    runs-on: ubuntu-20.04
-    name: 'Deploy route tables'
-    env:
-      namespace: 'Microsoft.Network\routeTables'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_udr:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy route tables'
+  #   env:
+  #     namespace: 'Microsoft.Network\routeTables'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_sqlmi_udr:
-    runs-on: ubuntu-20.04
-    name: 'Deploy sqlmi route tables'
-    if: github.event.inputs.deploySqlMiDependencies == 'true'
-    env:
-      namespace: 'Microsoft.Network\routeTables'
-    needs:
-      - job_deploy_rg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['sqlMi.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_sqlmi_udr:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy sqlmi route tables'
+  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
+  #   env:
+  #     namespace: 'Microsoft.Network\routeTables'
+  #   needs:
+  #     - job_deploy_rg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['sqlMi.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_nsg:
-    runs-on: ubuntu-20.04
-    name: 'Deploy network security groups'
-    env:
-      namespace: 'Microsoft.Network\networkSecurityGroups'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths:
-          [
-            'apgw.parameters.json',
-            'ase.parameters.json',
-            'bastion.parameters.json',
-            'parameters.json',
-          ]
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_nsg:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy network security groups'
+  #   env:
+  #     namespace: 'Microsoft.Network\networkSecurityGroups'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths:
+  #         [
+  #           'apgw.parameters.json',
+  #           'ase.parameters.json',
+  #           'bastion.parameters.json',
+  #           'parameters.json',
+  #         ]
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_sqlmi_nsg:
-    runs-on: ubuntu-20.04
-    name: 'Deploy sqlmi network security group'
-    if: github.event.inputs.deploySqlMiDependencies == 'true'
-    env:
-      namespace: 'Microsoft.Network\networkSecurityGroups'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['sqlmi.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_sqlmi_nsg:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy sqlmi network security group'
+  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
+  #   env:
+  #     namespace: 'Microsoft.Network\networkSecurityGroups'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['sqlmi.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_pip:
-    runs-on: ubuntu-20.04
-    name: 'Deploy public IP addresses'
-    env:
-      namespace: 'Microsoft.Network\publicIPAddresses'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths:
-          ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_pip:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy public IP addresses'
+  #   env:
+  #     namespace: 'Microsoft.Network\publicIPAddresses'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths:
+  #         ['apgw.parameters.json', 'bas.parameters.json', 'lb.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_appi:
-    runs-on: ubuntu-20.04
-    name: 'Deploy application insight'
-    env:
-      namespace: 'Microsoft.Insights\components'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_appi:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy application insight'
+  #   env:
+  #     namespace: 'Microsoft.Insights\components'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_aut:
-    runs-on: ubuntu-20.04
-    name: 'Deploy automation account'
-    env:
-      namespace: 'Microsoft.Automation\automationAccounts'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_aut:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy automation account'
+  #   env:
+  #     namespace: 'Microsoft.Automation\automationAccounts'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_avdhp:
-    runs-on: ubuntu-20.04
-    name: 'Deploy AVD host pool'
-    env:
-      namespace: 'Microsoft.DesktopVirtualization\hostpools'
-    needs:
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_avdhp:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy AVD host pool'
+  #   env:
+  #     namespace: 'Microsoft.DesktopVirtualization\hostpools'
+  #   needs:
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_rsv:
-    runs-on: ubuntu-20.04
-    name: 'Deploy recovery services vault'
-    env:
-      namespace: 'Microsoft.RecoveryServices\vaults'
-    needs:
-      - job_deploy_msi
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Get msi principal ID and replace token in parameter file'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+  # job_deploy_rsv:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy recovery services vault'
+  #   env:
+  #     namespace: 'Microsoft.RecoveryServices\vaults'
+  #   needs:
+  #     - job_deploy_msi
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Get msi principal ID and replace token in parameter file'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-          # Load Settings File
-          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+  #         # Load Settings File
+  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-          # Initialize Default Parameter File Tokens
-          $OtherCustomParameterFileTokens = @(
-              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-          )
+  #         # Initialize Default Parameter File Tokens
+  #         $OtherCustomParameterFileTokens = @(
+  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+  #         )
 
-          # Construct Token Function Input
-          $ConvertTokensInputs = @{
-              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-          }
+  #         # Construct Token Function Input
+  #         $ConvertTokensInputs = @{
+  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+  #         }
 
-          # Invoke Token Replacement Functionality
-          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Invoke Token Replacement Functionality
+  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_kv:
-    runs-on: ubuntu-20.04
-    name: 'Deploy key vaults'
-    env:
-      namespace: 'Microsoft.KeyVault\vaults'
-    needs:
-      - job_deploy_msi
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json', 'pe.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Get msi principal ID and replace token in parameter file'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+  # job_deploy_kv:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy key vaults'
+  #   env:
+  #     namespace: 'Microsoft.KeyVault\vaults'
+  #   needs:
+  #     - job_deploy_msi
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json', 'pe.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Get msi principal ID and replace token in parameter file'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-          # Load Settings File
-          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+  #         # Load Settings File
+  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-          # Initialize Default Parameter File Tokens
-          $OtherCustomParameterFileTokens = @(
-              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-          )
+  #         # Initialize Default Parameter File Tokens
+  #         $OtherCustomParameterFileTokens = @(
+  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+  #         )
 
-          # Construct Token Function Input
-          $ConvertTokensInputs = @{
-              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-          }
+  #         # Construct Token Function Input
+  #         $ConvertTokensInputs = @{
+  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+  #         }
 
-          # Invoke Token Replacement Functionality
-          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Invoke Token Replacement Functionality
+  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_kv_secrets:
-    runs-on: ubuntu-20.04
-    name: 'Set key vault secrets keys and certificates'
-    env:
-      namespace: 'Microsoft.KeyVault\vaults'
-    needs:
-      - job_deploy_kv
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Setup agent'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  # job_deploy_kv_secrets:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Set key vault secrets keys and certificates'
+  #   env:
+  #     namespace: 'Microsoft.KeyVault\vaults'
+  #   needs:
+  #     - job_deploy_kv
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Setup agent'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-          # Define PS modules to install on the runner
-          $Modules = @(
-              @{ Name = 'Az.KeyVault' }
-          )
+  #         # Define PS modules to install on the runner
+  #         $Modules = @(
+  #             @{ Name = 'Az.KeyVault' }
+  #         )
 
-          # Set agent up
-          Set-EnvironmentOnAgent -PSModules $Modules
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          enable-AzPSSession: true
-      - name: 'Set key vault secrets keys and certificates'
-        uses: azure/powershell@v1
-        with:
-          inlineScript: |
-            # Get key vault name
-            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
-            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-            $keyVaultName = $keyVaultParameters.name.value
+  #         # Set agent up
+  #         Set-EnvironmentOnAgent -PSModules $Modules
+  #     - name: Azure Login
+  #       uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #         enable-AzPSSession: true
+  #     - name: 'Set key vault secrets keys and certificates'
+  #       uses: azure/powershell@v1
+  #       with:
+  #         inlineScript: |
+  #           # Get key vault name
+  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'parameters.json'
+  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+  #           $keyVaultName = $keyVaultParameters.name.value
 
-            # Generate values
-            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-            $passwordString = (New-Guid).Guid.SubString(0, 19)
-            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
-            $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
-            $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
+  #           # Generate values
+  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
+  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+  #           $vpnSharedKeyString = (New-Guid).Guid.SubString(0, 32)
+  #           $vpnSharedKey = ConvertTo-SecureString -String $vpnSharedKeyString -AsPlainText -Force
 
-            # Set secrets
-            # -------
-            @(
-              @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
-              @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
-              @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
-              @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
-              @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
-              @{ name = 'apimClientId'; secretValue = $username } # API management
-              @{ name = 'apimClientSecret'; secretValue = $password } # API management
-            ) | ForEach-Object {
-              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-            }
+  #           # Set secrets
+  #           # -------
+  #           @(
+  #             @{ name = 'adminUsername'; secretValue = $username } # VirtualMachines and VMSS
+  #             @{ name = 'adminPassword'; secretValue = $password } # VirtualMachines and VMSS
+  #             @{ name = 'administratorLogin'; secretValue = $username } # Azure SQLServer
+  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # Azure SQLServer
+  #             @{ name = 'vpnSharedKey'; secretValue = $vpnSharedKey } # VirtualNetworkGateway
+  #             @{ name = 'apimClientId'; secretValue = $username } # API management
+  #             @{ name = 'apimClientSecret'; secretValue = $password } # API management
+  #           ) | ForEach-Object {
+  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #           }
 
-            # Set certificates
-            # -----------
-            $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
-            @(
-              @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
-            ) | ForEach-Object {
-              $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
-              Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-            }
+  #           # Set certificates
+  #           # -----------
+  #           $certPolicy = New-AzKeyVaultCertificatePolicy -SecretContentType 'application/x-pkcs12' -SubjectName 'CN=fabrikam.com' -IssuerName 'Self' -ValidityInMonths 12 -ReuseKeyOnRenewal
+  #           @(
+  #             @{ name = 'applicationGatewaySslCertificate'; CertificatePolicy = $certPolicy } # ApplicationGateway
+  #           ) | ForEach-Object {
+  #             $null = Add-AzKeyVaultCertificate -VaultName $keyVaultName -Name $_.name -CertificatePolicy $_.CertificatePolicy
+  #             Write-Verbose ('Added certificate [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #           }
 
-            # Set keys
-            # ----
-            @(
-              @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
-            ) | ForEach-Object {
-                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-            }
-          azPSVersion: 'latest'
+  #           # Set keys
+  #           # ----
+  #           @(
+  #             @{ name = 'keyEncryptionKey'; Destination = 'Software' } # DiskEncryptionSet, VirtualMachines and VMSS
+  #           ) | ForEach-Object {
+  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #           }
+  #         azPSVersion: 'latest'
 
-  job_deploy_sqlmi_kv:
-    runs-on: ubuntu-20.04
-    name: 'Deploy sqlmi key vault'
-    if: github.event.inputs.deploySqlMiDependencies == 'true'
-    env:
-      namespace: 'Microsoft.KeyVault\vaults'
-    needs:
-      - job_deploy_msi
-      - job_deploy_sa
-      - job_deploy_evh
-      - job_deploy_law
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['sqlmi.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Get msi principal ID and replace token in parameter file'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+  # job_deploy_sqlmi_kv:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy sqlmi key vault'
+  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
+  #   env:
+  #     namespace: 'Microsoft.KeyVault\vaults'
+  #   needs:
+  #     - job_deploy_msi
+  #     - job_deploy_sa
+  #     - job_deploy_evh
+  #     - job_deploy_law
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['sqlmi.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Get msi principal ID and replace token in parameter file'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-          # Load Settings File
-          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+  #         # Load Settings File
+  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-          # Initialize Default Parameter File Tokens
-          $OtherCustomParameterFileTokens = @(
-              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-          )
+  #         # Initialize Default Parameter File Tokens
+  #         $OtherCustomParameterFileTokens = @(
+  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+  #         )
 
-          # Construct Token Function Input
-          $ConvertTokensInputs = @{
-              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-          }
+  #         # Construct Token Function Input
+  #         $ConvertTokensInputs = @{
+  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+  #         }
 
-          # Invoke Token Replacement Functionality
-          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Invoke Token Replacement Functionality
+  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
-  job_deploy_sqlmi_kv_secrets:
-    runs-on: ubuntu-20.04
-    name: 'Set sqlmi key vault secrets and keys'
-    if: github.event.inputs.deploySqlMiDependencies == 'true'
-    needs:
-      - job_deploy_sqlmi_kv
-    env:
-      namespace: 'Microsoft.KeyVault\vaults'
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Setup agent'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
+  # job_deploy_sqlmi_kv_secrets:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Set sqlmi key vault secrets and keys'
+  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
+  #   needs:
+  #     - job_deploy_sqlmi_kv
+  #   env:
+  #     namespace: 'Microsoft.KeyVault\vaults'
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Setup agent'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Set-EnvironmentOnAgent.ps1')
 
-          # Define PS modules to install on the runner
-          $Modules = @(
-              @{ Name = 'Az.KeyVault' }
-          )
+  #         # Define PS modules to install on the runner
+  #         $Modules = @(
+  #             @{ Name = 'Az.KeyVault' }
+  #         )
 
-          # Set agent up
-          Set-EnvironmentOnAgent -PSModules $Modules
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          enable-AzPSSession: true
-      - name: 'Set sqlmi key vault secrets and keys'
-        uses: azure/powershell@v1
-        with:
-          inlineScript: |
-            # Get key vault name
-            $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
-            $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
-            $keyVaultName = $keyVaultParameters.name.value
+  #         # Set agent up
+  #         Set-EnvironmentOnAgent -PSModules $Modules
+  #     - name: Azure Login
+  #       uses: azure/login@v1
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #         enable-AzPSSession: true
+  #     - name: 'Set sqlmi key vault secrets and keys'
+  #       uses: azure/powershell@v1
+  #       with:
+  #         inlineScript: |
+  #           # Get key vault name
+  #           $parameterFilePath = Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies' '${{ env.namespace }}' 'parameters' 'sqlmi.parameters.json'
+  #           $keyVaultParameters = (ConvertFrom-Json (Get-Content -Path $parameterFilePath -Raw)).parameters
+  #           $keyVaultName = $keyVaultParameters.name.value
 
-            # Generate values
-            $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
-            $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
-            $passwordString = (New-Guid).Guid.SubString(0, 19)
-            $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
+  #           # Generate values
+  #           $usernameString = ( -join ((65..90) + (97..122) | Get-Random -Count 9 -SetSeed 1 | ForEach-Object { [char]$_ + "$_" })).substring(0, 19) # max length
+  #           $userName = ConvertTo-SecureString -String $usernameString -AsPlainText -Force
+  #           $passwordString = (New-Guid).Guid.SubString(0, 19)
+  #           $password = ConvertTo-SecureString -String $passwordString -AsPlainText -Force
 
-            # Set secrets
-            # -------
-            @(
-              @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
-              @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
-            ) | ForEach-Object {
-              $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
-              Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-            }
+  #           # Set secrets
+  #           # -------
+  #           @(
+  #             @{ name = 'administratorLogin'; secretValue = $username } # SQLManagedInstances
+  #             @{ name = 'administratorLoginPassword'; secretValue = $password } # SQLManagedInstances
+  #           ) | ForEach-Object {
+  #             $null = Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $_.name -SecretValue $_.secretValue
+  #             Write-Verbose ('Added secret [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #           }
 
-            # Set keys
-            # ----
-            @(
-              @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
-            ) | ForEach-Object {
-                $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
-                Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
-            }
-          azPSVersion: 'latest'
+  #           # Set keys
+  #           # ----
+  #           @(
+  #             @{ name = 'keyEncryptionKeySqlMi'; Destination = 'Software' } # SQLManagedInstances
+  #           ) | ForEach-Object {
+  #               $null = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $_.name -Destination $_.Destination
+  #               Write-Verbose ('Added key [{0}] to key vault [{1}]' -f $_.name, $keyVaultName) -Verbose
+  #           }
+  #         azPSVersion: 'latest'
 
-  job_deploy_avdag:
-    runs-on: ubuntu-20.04
-    name: 'Deploy AVD application group'
-    env:
-      namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
-    needs:
-      - job_deploy_avdhp
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_avdag:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy AVD application group'
+  #   env:
+  #     namespace: 'Microsoft.DesktopVirtualization\applicationgroups'
+  #   needs:
+  #     - job_deploy_avdhp
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
 
   job_deploy_rolea:
     runs-on: ubuntu-20.04
@@ -930,30 +930,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: 'Get msi principal ID and replace token in parameter file'
-        shell: pwsh
-        run: |
-          # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
-
-          # Load Settings File
-          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
-
-          # Initialize Default Parameter File Tokens
-          $OtherCustomParameterFileTokens = @(
-              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-          )
-
-          # Construct Token Function Input
-          $ConvertTokensInputs = @{
-              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-          }
-
-          # Invoke Token Replacement Functionality
-          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
       - name: 'Deploy module'
         uses: ./.github/actions/templates/validateModuleDeployment
         with:
@@ -964,123 +940,175 @@ jobs:
           subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
           managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
           removeDeployment: '${{ env.removeDeployment }}'
+          customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
-  job_deploy_vnet:
-    runs-on: ubuntu-20.04
-    name: 'Deploy virtual networks'
-    env:
-      namespace: 'Microsoft.Network\virtualNetworks'
-    needs:
-      - job_deploy_nsg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths:
-          [
-            '1.bastion.parameters.json',
-            '2.vnetpeer01.parameters.json',
-            '3.vnetpeer02.parameters.json',
-            '4.azfw.parameters.json',
-            '5.aks.parameters.json',
-            'parameters.json',
-          ]
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  # job_deploy_rolea:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy role assignments'
+  #   env:
+  #     namespace: 'Microsoft.Authorization\roleAssignments'
+  #   needs:
+  #     - job_deploy_msi
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Get msi principal ID and replace token in parameter file'
+  #       shell: pwsh
+  #       run: |
+  #         # Load used functions
+  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-  job_deploy_sqlmi_vnet:
-    runs-on: ubuntu-20.04
-    name: 'Deploy sqlmi virtual network'
-    if: github.event.inputs.deploySqlMiDependencies == 'true'
-    env:
-      namespace: 'Microsoft.Network\virtualNetworks'
-    needs:
-      - job_deploy_sqlmi_udr
-      - job_deploy_sqlmi_nsg
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['6.sqlmi.parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Load Settings File
+  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-  job_deploy_dnszone:
-    runs-on: ubuntu-20.04
-    name: 'Deploy private DNS zones'
-    env:
-      namespace: 'Microsoft.Network\privateDnsZones'
-    needs:
-      - job_deploy_vnet
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Initialize Default Parameter File Tokens
+  #         $OtherCustomParameterFileTokens = @(
+  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+  #         )
 
-  job_deploy_vm:
-    runs-on: ubuntu-20.04
-    name: 'Deploy virtual machines'
-    env:
-      namespace: 'Microsoft.Compute\virtualMachines'
-    needs:
-      - job_deploy_kv_secrets
-      - job_deploy_vnet
-      - job_deploy_rsv
-    strategy:
-      fail-fast: false
-      matrix:
-        parameterFilePaths: ['parameters.json']
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: 'Deploy module'
-        uses: ./.github/actions/templates/validateModuleDeployment
-        with:
-          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-          location: '${{ env.defaultLocation }}'
-          resourceGroupName: '${{ env.defaultResourceGroupName }}'
-          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-          removeDeployment: '${{ env.removeDeployment }}'
+  #         # Construct Token Function Input
+  #         $ConvertTokensInputs = @{
+  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+  #         }
+
+  #         # Invoke Token Replacement Functionality
+  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/.bicep/nested_rbac_sub.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
+
+  # job_deploy_vnet:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy virtual networks'
+  #   env:
+  #     namespace: 'Microsoft.Network\virtualNetworks'
+  #   needs:
+  #     - job_deploy_nsg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths:
+  #         [
+  #           '1.bastion.parameters.json',
+  #           '2.vnetpeer01.parameters.json',
+  #           '3.vnetpeer02.parameters.json',
+  #           '4.azfw.parameters.json',
+  #           '5.aks.parameters.json',
+  #           'parameters.json',
+  #         ]
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
+
+  # job_deploy_sqlmi_vnet:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy sqlmi virtual network'
+  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
+  #   env:
+  #     namespace: 'Microsoft.Network\virtualNetworks'
+  #   needs:
+  #     - job_deploy_sqlmi_udr
+  #     - job_deploy_sqlmi_nsg
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['6.sqlmi.parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
+
+  # job_deploy_dnszone:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy private DNS zones'
+  #   env:
+  #     namespace: 'Microsoft.Network\privateDnsZones'
+  #   needs:
+  #     - job_deploy_vnet
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'
+
+  # job_deploy_vm:
+  #   runs-on: ubuntu-20.04
+  #   name: 'Deploy virtual machines'
+  #   env:
+  #     namespace: 'Microsoft.Compute\virtualMachines'
+  #   needs:
+  #     - job_deploy_kv_secrets
+  #     - job_deploy_vnet
+  #     - job_deploy_rsv
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       parameterFilePaths: ['parameters.json']
+  #   steps:
+  #     - name: 'Checkout'
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: 'Deploy module'
+  #       uses: ./.github/actions/templates/validateModuleDeployment
+  #       with:
+  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+  #         location: '${{ env.defaultLocation }}'
+  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
+  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+  #         removeDeployment: '${{ env.removeDeployment }}'

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -869,7 +869,7 @@ jobs:
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
               # @{ Name = 'subscriptionId'; Value = '${{ secrets.ARM_SUBSCRIPTION_ID }}' }
           )
-          $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
+          # $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
 
           # Construct Token Function Input
           $ConvertTokensInputs = @{

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -605,34 +605,59 @@ jobs:
   #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
   #         removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_kv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy key vaults'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json', 'pe.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_kv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy key vaults'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      - job_deploy_msi
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json', 'pe.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Get msi principal ID and replace token in parameter file'
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+
+          # Load Settings File
+          $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
+
+          # Initialize Default Parameter File Tokens
+          $OtherCustomParameterFileTokens = @(
+              @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+          )
+
+          # Construct Token Function Input
+          $ConvertTokensInputs = @{
+              ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
+              TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
+              TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
+          }
+
+          # Invoke Token Replacement Functionality
+          $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
 
   # job_deploy_kv_secrets:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -63,7 +63,7 @@ jobs:
     needs:
       - job_deploy_rg
     outputs:
-      msiPrincipalId: ${{ steps.deploy-msi-out.outputs.msiPrincipalId }}
+      msiPrincipalId: ${{ steps.print_msi_prinId.outputs.msiPrincipalId }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 'Deploy module'
-        id: deploy-msi
+        id: deploy_msi
         uses: ./.github/actions/templates/validateModuleDeployment
         with:
           templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
@@ -85,11 +85,11 @@ jobs:
           managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
           removeDeployment: '${{ env.removeDeployment }}'
       - name: Set msi principal ID output
-        id: deploy-msi-out
+        id: print_msi_prinId
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            $deploymentOutput = '${{ steps.deploy-msi.outputs.deploymentOutput }}'
+            $deploymentOutput = '${{ steps.deploy_msi.outputs.deploymentOutput }}'
             $msiPrincipalId = (ConvertFrom-Json $deploymentOutput).msiPrincipalId
             Write-Output ('::set-output name=msiPrincipalId::{0}' -f $msiPrincipalId)
           azPSVersion: 'latest'

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -867,6 +867,7 @@ jobs:
           # Initialize Default Parameter File Tokens
           $DefaultParameterFileTokens = @(
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
+              @{ Name = 'subscriptionId'; Value = '${{ secrets.ARM_SUBSCRIPTION_ID }}' }
           )
           $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
 

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -867,7 +867,7 @@ jobs:
           # Initialize Default Parameter File Tokens
           $DefaultParameterFileTokens = @(
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-              @{ Name = 'subscriptionId'; Value = '${{ secrets.ARM_SUBSCRIPTION_ID }}' }
+              # @{ Name = 'subscriptionId'; Value = '${{ secrets.ARM_SUBSCRIPTION_ID }}' }
           )
           $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
 

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -933,18 +933,18 @@ jobs:
       - name: 'Get msi principal ID and replace token in parameter file'
         shell: pwsh
         run: |
-          Load used functions
+          # Load used functions
           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
 
-          Load Settings File
+          # Load Settings File
           $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
-          Initialize Default Parameter File Tokens
+          # Initialize Default Parameter File Tokens
           $OtherCustomParameterFileTokens = @(
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
           )
 
-          Construct Token Function Input
+          # Construct Token Function Input
           $ConvertTokensInputs = @{
               ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
               OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
@@ -952,7 +952,7 @@ jobs:
               TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
           }
 
-          Invoke Token Replacement Functionality
+          # Invoke Token Replacement Functionality
           $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
       - name: 'Deploy module'
         uses: ./.github/actions/templates/validateModuleDeployment

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -576,113 +576,67 @@ jobs:
   #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
   #         removeDeployment: '${{ env.removeDeployment }}'
 
-  # job_deploy_rsv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy recovery services vault'
-  #   env:
-  #     namespace: 'Microsoft.RecoveryServices\vaults'
-  #   needs:
-  #     - job_deploy_msi
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Get msi principal ID and replace token in parameter file'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
+  job_deploy_rsv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy recovery services vault'
+    env:
+      namespace: 'Microsoft.RecoveryServices\vaults'
+    needs:
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+      - job_deploy_msi
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
+          customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
-  #         # Load Settings File
-  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
-
-  #         # Initialize Default Parameter File Tokens
-  #         $OtherCustomParameterFileTokens = @(
-  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-  #         )
-
-  #         # Construct Token Function Input
-  #         $ConvertTokensInputs = @{
-  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-  #         }
-
-  #         # Invoke Token Replacement Functionality
-  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
-
-  # job_deploy_kv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy key vaults'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_msi
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['parameters.json', 'pe.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Get msi principal ID and replace token in parameter file'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
-
-  #         # Load Settings File
-  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
-
-  #         # Initialize Default Parameter File Tokens
-  #         $OtherCustomParameterFileTokens = @(
-  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-  #         )
-
-  #         # Construct Token Function Input
-  #         $ConvertTokensInputs = @{
-  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-  #         }
-
-  #         # Invoke Token Replacement Functionality
-  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_kv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy key vaults'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+      - job_deploy_msi
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['parameters.json', 'pe.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
+          customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
   # job_deploy_kv_secrets:
   #   runs-on: ubuntu-20.04
@@ -766,60 +720,37 @@ jobs:
   #           }
   #         azPSVersion: 'latest'
 
-  # job_deploy_sqlmi_kv:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploy sqlmi key vault'
-  #   if: github.event.inputs.deploySqlMiDependencies == 'true'
-  #   env:
-  #     namespace: 'Microsoft.KeyVault\vaults'
-  #   needs:
-  #     - job_deploy_msi
-  #     - job_deploy_sa
-  #     - job_deploy_evh
-  #     - job_deploy_law
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       parameterFilePaths: ['sqlmi.parameters.json']
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - name: 'Get msi principal ID and replace token in parameter file'
-  #       shell: pwsh
-  #       run: |
-  #         # Load used functions
-  #         . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'tokensReplacement' 'Convert-TokensInParameterFile.ps1')
-
-  #         # Load Settings File
-  #         $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
-
-  #         # Initialize Default Parameter File Tokens
-  #         $OtherCustomParameterFileTokens = @(
-  #             @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-  #         )
-
-  #         # Construct Token Function Input
-  #         $ConvertTokensInputs = @{
-  #             ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #             OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
-  #             TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
-  #             TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
-  #         }
-
-  #         # Invoke Token Replacement Functionality
-  #         $null = Convert-TokensInParameterFile @ConvertTokensInputs -Verbose
-  #     - name: 'Deploy module'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
-  #         parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-  #         location: '${{ env.defaultLocation }}'
-  #         resourceGroupName: '${{ env.defaultResourceGroupName }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ env.removeDeployment }}'
+  job_deploy_sqlmi_kv:
+    runs-on: ubuntu-20.04
+    name: 'Deploy sqlmi key vault'
+    if: github.event.inputs.deploySqlMiDependencies == 'true'
+    env:
+      namespace: 'Microsoft.KeyVault\vaults'
+    needs:
+      # - job_deploy_sa
+      # - job_deploy_evh
+      # - job_deploy_law
+      - job_deploy_msi
+    strategy:
+      fail-fast: false
+      matrix:
+        parameterFilePaths: ['sqlmi.parameters.json']
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: 'Deploy module'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: 'arm/${{ env.namespace }}/deploy.bicep'
+          parameterFilePath: '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
+          location: '${{ env.defaultLocation }}'
+          resourceGroupName: '${{ env.defaultResourceGroupName }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ env.removeDeployment }}'
+          customParameterFileTokens: '[{"Name":"msiPrincipalId","Value":"${{ needs.job_deploy_msi.outputs.msiPrincipalId }}"}]'
 
   # job_deploy_sqlmi_kv_secrets:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -91,7 +91,7 @@ jobs:
           inlineScript: |
             $deploymentOutput = '${{ steps.deploy_msi.outputs.deploymentOutput }}'
             $msiPrincipalId = (ConvertFrom-Json $deploymentOutput).msiPrincipalId
-            Write-Output ('::set-output name=msiPrincipalId::{0}' -f $msiPrincipalId)
+            Write-Output ('::set-output name={0}::{1}' -f 'msiPrincipalId', $msiPrincipalId)
           azPSVersion: 'latest'
 
   job_deploy_pa:

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -865,16 +865,14 @@ jobs:
           $Settings = Get-Content -Path "settings.json" | ConvertFrom-Json
 
           # Initialize Default Parameter File Tokens
-          $DefaultParameterFileTokens = @(
+          $OtherCustomParameterFileTokens = @(
               @{ Name = 'msiPrincipalId'; Value = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}' }
-              # @{ Name = 'subscriptionId'; Value = '${{ secrets.ARM_SUBSCRIPTION_ID }}' }
           )
-          # $DefaultParameterFileTokens = $DefaultParameterFileTokens | ForEach-Object { [PSCustomObject]$PSItem }
 
           # Construct Token Function Input
           $ConvertTokensInputs = @{
               ParameterFilePath                 = '${{ env.dependencyPath }}/${{ env.namespace }}/parameters/${{ matrix.parameterFilePaths }}'
-              DefaultParameterFileTokens        = $DefaultParameterFileTokens
+              OtherCustomParameterFileTokens    = $OtherCustomParameterFileTokens
               TokenPrefix                       = $Settings.parameterFileTokens.tokenPrefix
               TokenSuffix                       = $Settings.parameterFileTokens.tokenSuffix
           }

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -855,13 +855,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get msi principal ID output
-        uses: azure/powershell@v1
-        with:
-          inlineScript: |
-            $msiPrincipalId = '${{ needs.job_deploy_msi.outputs.msiPrincipalId }}'
-            Write-Verbose $msiPrincipalId -Verbose
-          azPSVersion: 'latest'
       - name: 'Replace msi principal ID in parameter file'
         shell: pwsh
         run: |

--- a/docs/wiki/TestingDesign.md
+++ b/docs/wiki/TestingDesign.md
@@ -113,8 +113,8 @@ Since also dependency resources are in turn subject to dependencies with each ot
 
 **Second level resources**: This group of resources has a dependency only on the resource group which will host them. Resources in this group can be deployed in parallel.
 
-  1. User assigned identity: This resource is leveraged by all dependency resources
-      > **Note**: The object ID of the [user assigned identity] must be set in several dependency parameter files. However, when you first run the pipeline, this object ID will be unknown. It is hence recommended to either manually create the MSI beforehand - or - run the pipeline without the ID once (which will cause the pipeline to fail during the ID's usage, but **after** the MSI was deployed), then update the value in the parameter files and finally re-run the pipeline.
+  1. User assigned identity: This resource is leveraged by the [role assignment], [key vault] and [recovery services vault] dependency resources.
+      > **Note**: The object ID of the [user assigned identity] is needed by several dependency parameter files. However, before running the dependency pipeline for the first time, the [user assigned identity] resource does not exist yet, thus its object ID is unknown. For this reason, instead of the object ID value, some dependency parameter files contain an `"<<msiPrincipalId>>"` token, for which the correct value is retrieved and replaced by the pipeline at runtime.
   1. Policy assignment: This resource is leveraged by the [policy exemption] resource.
   1. Log analytics workspace: This resource is leveraged by all resources supporting diagnostic settings on LAW.
   1. Storage account: This resource is leveraged by all resources supporting diagnostic settings on a storage account.

--- a/docs/wiki/TestingDesign.md
+++ b/docs/wiki/TestingDesign.md
@@ -114,7 +114,7 @@ Since also dependency resources are in turn subject to dependencies with each ot
 **Second level resources**: This group of resources has a dependency only on the resource group which will host them. Resources in this group can be deployed in parallel.
 
   1. User assigned identity: This resource is leveraged by the [role assignment], [key vault] and [recovery services vault] dependency resources.
-      > **Note**: The object ID of the [user assigned identity] is needed by several dependency parameter files. However, before running the dependency pipeline for the first time, the [user assigned identity] resource does not exist yet, thus its object ID is unknown. For this reason, instead of the object ID value, some dependency parameter files contain an `"<<msiPrincipalId>>"` token, for which the correct value is retrieved and replaced by the pipeline at runtime.
+      > **Note**: The object ID of the [user assigned identity] is needed by several dependency parameter files. However, before running the dependency pipeline for the first time, the [user assigned identity] resource does not exist yet, thus its object ID is unknown. For this reason, instead of the object ID value, some dependency parameter files contain the `"<<msiPrincipalId>>"` token, for which the correct value is retrieved and replaced by the pipeline at runtime.
   1. Policy assignment: This resource is leveraged by the [policy exemption] resource.
   1. Log analytics workspace: This resource is leveraged by all resources supporting diagnostic settings on LAW.
   1. Storage account: This resource is leveraged by all resources supporting diagnostic settings on a storage account.

--- a/utilities/pipelines/dependencies/Microsoft.Authorization/roleAssignments/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Authorization/roleAssignments/parameters/parameters.json
@@ -6,7 +6,7 @@
       "value": "Contributor"
     },
     "principalId": {
-      "value": "<<msiPrincipalID>>" // The object ID of the deployed MSI
+      "value": "<<msiPrincipalID>>" // The object ID of the deployed MSI. Replaced by the pipeline
     },
     "subscriptionId": {
       "value": "<<subscriptionId>>"

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/parameters.json
@@ -26,7 +26,7 @@
         },
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI. Replaced by the pipeline
           "permissions": {
             "keys": [],
             "secrets": [

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/parameters.json
@@ -26,7 +26,7 @@
         },
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "cf33fea8-b30f-424f-ab73-c48d99e0b222", // adding adp-sxx-az-msi-x-001 to get secrets
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
           "permissions": {
             "keys": [],
             "secrets": [

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/pe.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/pe.parameters.json
@@ -9,7 +9,7 @@
       "value": [
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI. Replaced by the pipeline
           "permissions": {
             "keys": [],
             "secrets": [

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/pe.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/pe.parameters.json
@@ -9,7 +9,7 @@
       "value": [
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "cf33fea8-b30f-424f-ab73-c48d99e0b222", // adding adp-sxx-az-msi-x-001 to get secrets
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
           "permissions": {
             "keys": [],
             "secrets": [

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/sqlmi.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/sqlmi.parameters.json
@@ -26,7 +26,7 @@
         },
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI. Replaced by the pipeline
           "permissions": {
             "keys": [
               "Get",

--- a/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/sqlmi.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.KeyVault/vaults/parameters/sqlmi.parameters.json
@@ -26,7 +26,7 @@
         },
         {
           "tenantId": "<<tenantId>>",
-          "objectId": "cf33fea8-b30f-424f-ab73-c48d99e0b222", // adding adp-sxx-az-msi-x-001 to get secrets
+          "objectId": "<<msiPrincipalID>>", // The object ID of the deployed MSI
           "permissions": {
             "keys": [
               "Get",

--- a/utilities/pipelines/dependencies/Microsoft.RecoveryServices/vaults/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.RecoveryServices/vaults/parameters/parameters.json
@@ -254,7 +254,7 @@
                 {
                     "roleDefinitionIdOrName": "Reader",
                     "principalIds": [
-                        "cf33fea8-b30f-424f-ab73-c48d99e0b222" // The object ID of the deployed MSI
+                        "<<msiPrincipalID>>" // The object ID of the deployed MSI
                     ]
                 }
             ]

--- a/utilities/pipelines/dependencies/Microsoft.RecoveryServices/vaults/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.RecoveryServices/vaults/parameters/parameters.json
@@ -254,7 +254,7 @@
                 {
                     "roleDefinitionIdOrName": "Reader",
                     "principalIds": [
-                        "<<msiPrincipalID>>" // The object ID of the deployed MSI
+                        "<<msiPrincipalID>>" // The object ID of the deployed MSI. Replaced by the pipeline
                     ]
                 }
             ]


### PR DESCRIPTION
# Change

msi principal id is retrieved at runtime as an output of the user assigned identity module and used by the next modules deployed by the dependency pipeline. 
It is not needed to create an msi manually or to deploy the dependency pipeline twice anymore.
Updated validate deploy action and ADO template to accept an additional optional parameter in json format to allow additional custom tokens to be replaced by the token replacement step. That is needed by the dependency pipeline change and transparent for pipelines not needing it.
The change is valid for both GH and ADO
[![.Platform: Dependencies](https://github.com/Azure/ResourceModules/actions/workflows/platform.dependencies.yml/badge.svg?branch=users%2Ferikag%2Fdep-msi-id-token)](https://github.com/Azure/ResourceModules/actions/workflows/platform.dependencies.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
