### PR TITLE
Enable budget removal

### DIFF
--- a/.azuredevops/modulePipelines/ms.consumption.budgets.yml
+++ b/.azuredevops/modulePipelines/ms.consumption.budgets.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Deployment does not support tags
+    default: true
   - name: versioningOption
     displayName: The mode to handle the version increments [major|minor|patch]
     type: string

--- a/.github/workflows/ms.consumption.budgets.yml
+++ b/.github/workflows/ms.consumption.budgets.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: 'Remove deployed module'
         required: false
-        default: 'false' # Deployment does not support tags
+        default: 'true'
       versioningOption:
         type: choice
         description: 'The mode to handle the version increments [major|minor|patch]'


### PR DESCRIPTION
# Change

We now can test budgets end2end. Hence we can also enable its removal.

Pipeline reference
[![Consumption: Budgets](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml/badge.svg?branch=users%2Falsehr%2FenableBudgetRemoval)](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml)
## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
