### PR TITLE
VNET: Removed requirement for default subnet

### DIFF
--- a/arm/Microsoft.Network/virtualNetworks/.parameters/min.parameters.json
+++ b/arm/Microsoft.Network/virtualNetworks/.parameters/min.parameters.json
@@ -9,14 +9,6 @@
             "value": [
                 "10.0.0.0/16"
             ]
-        },
-        "subnets": {
-            "value": [
-                {
-                    "name": "default",
-                    "addressPrefix": "10.0.0.0/16"
-                }
-            ]
         }
     }
 }

--- a/arm/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -7,9 +7,8 @@ param location string = resourceGroup().location
 @description('Required. An Array of 1 or more IP Address Prefixes for the Virtual Network.')
 param addressPrefixes array
 
-@description('Required. An Array of subnets to deploy to the Virual Network.')
-@minLength(1)
-param subnets array
+@description('Optional. An Array of subnets to deploy to the Virtual Network.')
+param subnets array = []
 
 @description('Optional. DNS Servers associated to the Virtual Network.')
 param dnsServers array = []

--- a/arm/Microsoft.Network/virtualNetworks/readme.md
+++ b/arm/Microsoft.Network/virtualNetworks/readme.md
@@ -32,7 +32,7 @@ This template deploys a virtual network (vNet).
 | `metricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |
 | `name` | string |  |  | Required. The Virtual Network (vNet) Name. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
-| `subnets` | _[subnets](subnets/readme.md)_ array |  |  | Required. An Array of subnets to deploy to the Virual Network. |
+| `subnets` | _[subnets](subnets/readme.md)_ array | `[]` |  | Optional. An Array of subnets to deploy to the Virtual Network. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `virtualNetworkPeerings` | _[virtualNetworkPeerings](virtualNetworkPeerings/readme.md)_ array | `[]` |  | Optional. Virtual Network Peerings configurations |
 


### PR DESCRIPTION
# Change

- It's actually not required to deploy a subnet in a VNET (and there are cases were we don't want to deploy one). Hence I removed the requirement 

Pipeline reference:
[![Network: VirtualNetworks](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml/badge.svg?branch=users%2Falsehr%2FvnetDefaultSubnet)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
