### PR TITLE
Service Fabric: Fix incorrect parameter file references in pipeline

### DIFF
--- a/.azuredevops/modulePipelines/ms.servicefabric.clusters.yml
+++ b/.azuredevops/modulePipelines/ms.servicefabric.clusters.yml
@@ -51,7 +51,8 @@ stages:
           removeDeployment: '${{ parameters.removeDeployment }}'
           deploymentBlocks:
             - path: $(modulePath)/.parameters/min.parameters.json
-            - path: $(modulePath)/.parameters/parameters.json
+            - path: $(modulePath)/.parameters/full.parameters.json
+            - path: $(modulePath)/.parameters/cert.parameters.json
 
   - stage: Publishing
     displayName: Publish module

--- a/.github/workflows/ms.servicefabric.clusters.yml
+++ b/.github/workflows/ms.servicefabric.clusters.yml
@@ -91,7 +91,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parameterFilePaths: ['min.parameters.json', 'parameters.json']
+        parameterFilePaths:
+          [
+            'min.parameters.json',
+            'full.parameters.json',
+            'cert.parameters.json',
+          ]
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2


### PR DESCRIPTION
# Change

- Fix incorrect parameter file references in pipeline

Pipeline reference
[![Service Fabric: Clusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicefabric.clusters.yml/badge.svg?branch=users%2Falsehr%2FserviceFabricPipelineFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicefabric.clusters.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

