### PR TITLE
Bug fix for ConvertTo-ARMTemplate

### DIFF
--- a/utilities/tools/ConvertTo-ARMTemplate.ps1
+++ b/utilities/tools/ConvertTo-ARMTemplate.ps1
@@ -173,29 +173,33 @@ if (-not $SkipPipelineUpdate) {
 
     # GitHub workflow files
     $ghWorkflowFolderPath = Join-Path -Path $rootPath -ChildPath '.github\workflows'
-    $ghWorkflowFilesToUpdate = Get-ChildItem -Path $ghWorkflowFolderPath -Filter 'ms.*.yml' -File -Force
-    Write-Verbose ('Update workflow files - Processing [{0}] file(s)' -f $ghWorkflowFilesToUpdate.count)
-    if ($PSCmdlet.ShouldProcess(('[{0}] ms.*.yml file(s) in path [{1}]' -f $ghWorkflowFilesToUpdate.Count, $ghWorkflowFolderPath), 'Set-Content')) {
-        # parallelism is not supported on GitHub runners
-        #$ghWorkflowFilesToUpdate | ForEach-Object -ThrottleLimit $env:NUMBER_OF_PROCESSORS -Parallel {
-        $ghWorkflowFilesToUpdate | ForEach-Object {
-            $content = $_ | Get-Content
-            $content = $content -replace 'templateFilePath:(.*).bicep', 'templateFilePath:$1.json'
-            $_ | Set-Content -Value $content
+    if (Test-Path -Path $ghWorkflowFolderPath) {
+        $ghWorkflowFilesToUpdate = Get-ChildItem -Path $ghWorkflowFolderPath -Filter 'ms.*.yml' -File -Force
+        Write-Verbose ('Update workflow files - Processing [{0}] file(s)' -f $ghWorkflowFilesToUpdate.count)
+        if ($PSCmdlet.ShouldProcess(('[{0}] ms.*.yml file(s) in path [{1}]' -f $ghWorkflowFilesToUpdate.Count, $ghWorkflowFolderPath), 'Set-Content')) {
+            # parallelism is not supported on GitHub runners
+            #$ghWorkflowFilesToUpdate | ForEach-Object -ThrottleLimit $env:NUMBER_OF_PROCESSORS -Parallel {
+            $ghWorkflowFilesToUpdate | ForEach-Object {
+                $content = $_ | Get-Content
+                $content = $content -replace 'templateFilePath:(.*).bicep', 'templateFilePath:$1.json'
+                $_ | Set-Content -Value $content
+            }
         }
     }
 
     # Azure DevOps Pipelines
     $adoPipelineFolderPath = Join-Path -Path $rootPath -ChildPath '.azuredevops\modulePipelines'
-    $adoPipelineFilesToUpdate = Get-ChildItem -Path $adoPipelineFolderPath -Filter 'ms.*.yml' -File -Force
-    Write-Verbose ('Update Azure DevOps pipeline files - Processing [{0}] file(s)' -f $adoPipelineFilesToUpdate.count)
-    if ($PSCmdlet.ShouldProcess(('[{0}] ms.*.yml file(s) in path [{1}]' -f $adoPipelineFilesToUpdate.Count, $adoPipelineFolderPath), 'Set-Content')) {
-        # parallelism is not supported on GitHub runners
-        #$adoPipelineFilesToUpdate | ForEach-Object -ThrottleLimit $env:NUMBER_OF_PROCESSORS -Parallel {
-        $adoPipelineFilesToUpdate | ForEach-Object {
-            $content = $_ | Get-Content
-            $content = $content -replace 'templateFilePath:(.*).bicep', 'templateFilePath:$1.json'
-            $_ | Set-Content -Value $content
+    if (Test-Path -Path $adoPipelineFolderPath) {
+        $adoPipelineFilesToUpdate = Get-ChildItem -Path $adoPipelineFolderPath -Filter 'ms.*.yml' -File -Force
+        Write-Verbose ('Update Azure DevOps pipeline files - Processing [{0}] file(s)' -f $adoPipelineFilesToUpdate.count)
+        if ($PSCmdlet.ShouldProcess(('[{0}] ms.*.yml file(s) in path [{1}]' -f $adoPipelineFilesToUpdate.Count, $adoPipelineFolderPath), 'Set-Content')) {
+            # parallelism is not supported on GitHub runners
+            #$adoPipelineFilesToUpdate | ForEach-Object -ThrottleLimit $env:NUMBER_OF_PROCESSORS -Parallel {
+            $adoPipelineFilesToUpdate | ForEach-Object {
+                $content = $_ | Get-Content
+                $content = $content -replace 'templateFilePath:(.*).bicep', 'templateFilePath:$1.json'
+                $_ | Set-Content -Value $content
+            }
         }
     }
 

--- a/utilities/tools/ConvertTo-ARMTemplate.ps1
+++ b/utilities/tools/ConvertTo-ARMTemplate.ps1
@@ -66,13 +66,22 @@ if ($ConvertChildren) {
 #region Remove existing deploy.json files
 Write-Verbose 'Remove existing deploy.json files'
 
-$JsonFilesToRemove = Get-ChildItem -Path $armFolderPath -Filter 'deploy.json' -Recurse -Force -File
-Write-Verbose "Remove existing deploy.json files - Remove [$($JsonFilesToRemove.count)] file(s)"
-if ($PSCmdlet.ShouldProcess("[$($JsonFilesToRemove.count)] deploy.json files(s) in path [$armFolderPath]", 'Remove-Item')) {
-    $JsonFilesToRemove | Remove-Item -Force
+
+# Use case: New module is brought in and needs to be converted to json
+
+# Suggestion: Skip JSON
+# Suggestion: Provide path on the script on what to convert
+# Suggestion: Only remove if bicep exists
+
+if (Test-Path -Path (Join-Path -Path $armFolderPath -ChildPath 'deploy.bicep')) {
+    $JsonFilesToRemove = Get-ChildItem -Path $armFolderPath -Filter 'deploy.json' -Recurse -Force -File
+    Write-Verbose "Remove existing deploy.json files - Remove [$($JsonFilesToRemove.count)] file(s)"
+    if ($PSCmdlet.ShouldProcess("[$($JsonFilesToRemove.count)] deploy.json files(s) in path [$armFolderPath]", 'Remove-Item')) {
+        $JsonFilesToRemove | Remove-Item -Force
+    }
+    Write-Verbose 'Remove existing deploy.json files - Done'
 }
 
-Write-Verbose 'Remove existing deploy.json files - Done'
 #endregion
 
 #region Convert bicep files to json

--- a/utilities/tools/ConvertTo-ARMTemplate.ps1
+++ b/utilities/tools/ConvertTo-ARMTemplate.ps1
@@ -66,13 +66,6 @@ if ($ConvertChildren) {
 #region Remove existing deploy.json files
 Write-Verbose 'Remove existing deploy.json files'
 
-
-# Use case: New module is brought in and needs to be converted to json
-
-# Suggestion: Skip JSON
-# Suggestion: Provide path on the script on what to convert
-# Suggestion: Only remove if bicep exists
-
 if (Test-Path -Path (Join-Path -Path $armFolderPath -ChildPath 'deploy.bicep')) {
     $JsonFilesToRemove = Get-ChildItem -Path $armFolderPath -Filter 'deploy.json' -Recurse -Force -File
     Write-Verbose "Remove existing deploy.json files - Remove [$($JsonFilesToRemove.count)] file(s)"


### PR DESCRIPTION
# Change

- Only clean up `deploy.json` when bicep exists before the conversion.
- Don't attempt to replace workflow or pipeline files if they do not exist. (i.e folders for ado or gh is removed)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
