### PR TITLE
vm adp token and description fix

### DIFF
--- a/arm/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
@@ -251,7 +251,7 @@ param tags object = {}
 @description('Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered')
 param cuaId string = ''
 
-@description('Optional. The chosen OS type')
+@description('Required. The chosen OS type')
 @allowed([
   'Windows'
   'Linux'

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/readme.md
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/readme.md
@@ -69,7 +69,7 @@ The following resources are required to be able to deploy this resource.
 | `name` | string |  |  | Required. Name of the VMSS. |
 | `nicConfigurations` | array | `[]` |  | Required. Configures NICs and PIPs. |
 | `osDisk` | object |  |  | Required. Specifies the OS disk. |
-| `osType` | string |  | `[Windows, Linux]` | Optional. The chosen OS type |
+| `osType` | string |  | `[Windows, Linux]` | Required. The chosen OS type |
 | `overprovision` | bool |  |  | Optional. Specifies whether the Virtual Machine Scale Set should be overprovisioned. |
 | `pauseTimeBetweenBatches` | string | `PT0S` |  | Optional. The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format |
 | `plan` | object | `{object}` |  | Optional. Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. |

--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -235,7 +235,7 @@ param baseTime string = utcNow('u')
 @description('Optional. SAS token validity length to use to download files from storage accounts. Usage: \'PT8H\' - valid for 8 hours; \'P5D\' - valid for 5 days; \'P1Y\' - valid for 1 year. When not provided, the SAS token will be valid for 8 hours.')
 param sasTokenValidityLength string = 'PT8H'
 
-@description('Optional. The chosen OS type')
+@description('Required. The chosen OS type')
 @allowed([
   'Windows'
   'Linux'

--- a/arm/Microsoft.Compute/virtualMachines/readme.md
+++ b/arm/Microsoft.Compute/virtualMachines/readme.md
@@ -66,7 +66,7 @@ This module deploys one Virtual Machine with one or multiple nics and optionally
 | `nicConfigurations` | array |  |  | Required. Configures NICs and PIPs. |
 | `nicMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |
 | `osDisk` | object |  |  | Required. Specifies the OS disk. |
-| `osType` | string |  | `[Windows, Linux]` | Optional. The chosen OS type |
+| `osType` | string |  | `[Windows, Linux]` | Required. The chosen OS type |
 | `pipLogsToEnable` | array | `[DDoSProtectionNotifications, DDoSMitigationFlowLogs, DDoSMitigationReports]` | `[DDoSProtectionNotifications, DDoSMitigationFlowLogs, DDoSMitigationReports]` | Optional. The name of logs that will be streamed. |
 | `pipMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | Optional. The name of metrics that will be streamed. |
 | `plan` | object | `{object}` |  | Optional. Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use. |

--- a/arm/Microsoft.Network/networkWatchers/.parameters/parameters.json
+++ b/arm/Microsoft.Network/networkWatchers/.parameters/parameters.json
@@ -31,7 +31,7 @@
                         {
                             "name": "<<namePrefix>>-az-subnet-x-001(validation-rg)",
                             "type": "AzureVM",
-                            "resourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Compute/virtualMachines/adp-vm-001"
+                            "resourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Compute/virtualMachines/adp-<<namePrefix>>-vm-001"
                         },
                         {
                             "name": "Office Portal",

--- a/utilities/pipelines/dependencies/Microsoft.Compute/virtualMachines/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Compute/virtualMachines/parameters/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "adp-vm-001"
+            "value": "adp-<<namePrefix>>-vm-001"
         },
         "vmSize": {
             "value": "Standard_B1s"


### PR DESCRIPTION
# Change

Adding name token to dependency vm
Fixing incorrect optional description for osType in vm and vmss modules

[![.Platform: Dependencies](https://github.com/Azure/ResourceModules/actions/workflows/platform.dependencies.yml/badge.svg?branch=users%2Ferikag%2Fvmdepname)](https://github.com/Azure/ResourceModules/actions/workflows/platform.dependencies.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
