### PR TITLE
Quick fix for Local Test Script and Documentation

### DIFF
--- a/docs/wiki/TestingUsage.md
+++ b/docs/wiki/TestingUsage.md
@@ -60,11 +60,13 @@ $TestModuleLocallyInput = @{
         SubscriptionId    = '12345678-1234-1234-1234-123456789123'
         ManagementGroupId = 'mg-contoso'
     }
-    AdditionalTokens      = @(
-        @{ Name = 'deploymentSpId'; Value = '12345678-1234-1234-1234-123456789123' }
-        @{ Name = 'tenantId'; Value = '12345678-1234-1234-1234-123456789123' }
-    )
+    AdditionalTokens              = @{
+        'deploymentSpId' = '12345678-1234-1234-1234-123456789123'
+        'tenantId'       = '12345678-1234-1234-1234-123456789123'
+    }
 }
+
+Test-ModuleLocally @TestModuleLocallyInput -Verbose
 ```
 
 > You can use the `Get-Help` cmdlet to show more options on how you can use this script.


### PR DESCRIPTION
# Change

- Quick fix for Local Test Script (imported token map process from pipeline, fixed names for parameters)
- Updated Test documentation to reference hashtable instead of object for the additional tokens.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
