### PR TITLE
Add static value for 'principalType' for the Policy Assignment with Role Assignment Option

### DIFF
--- a/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_mg.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_mg.bicep
@@ -77,6 +77,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: roleDefinitionId
     principalId: policyAssignment.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }]
 

--- a/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_rg.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_rg.bicep
@@ -80,6 +80,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: roleDefinitionId
     principalId: policyAssignment.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }]
 

--- a/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_sub.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/.bicep/nested_policyAssignments_sub.bicep
@@ -77,6 +77,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: roleDefinitionId
     principalId: policyAssignment.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }]
 


### PR DESCRIPTION
# Change

Addresses #981 where policy assignments with Role assignments might fail due to Azure AD replication delay. Suggestion by @azMantas to include a static value to set the principal Type for the role assignment resource to 'ServicePrincipal. That also aligns with the recommendation [documentation - role assignments](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/role-based-access-control/role-assignments-template.md#new-service-principal)

## Type of Change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Pipeline run

[![Authorization: PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Fahmad%2FpolicyAssignmentRbac)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
