### PR TITLE
Keyvaults - Securing secrets parameter by using object

### DIFF
--- a/arm/Microsoft.KeyVault/vaults/.parameters/parameters.json
+++ b/arm/Microsoft.KeyVault/vaults/.parameters/parameters.json
@@ -38,23 +38,25 @@
             ]
         },
         "secrets": {
-            "value": [
-                {
-                    "name": "secretName",
-                    "value": "secretValue",
-                    "contentType": "Something",
-                    "attributesExp": 1702648632,
-                    "attributesNbf": 10000,
-                    "roleAssignments": [
-                        {
-                            "roleDefinitionIdOrName": "Reader",
-                            "principalIds": [
-                                "<<deploymentSpId>>"
-                            ]
-                        }
-                    ]
-                }
-            ]
+            "value": {
+                "secureList": [
+                    {
+                        "name": "secretName",
+                        "value": "secretValue",
+                        "contentType": "Something",
+                        "attributesExp": 1702648632,
+                        "attributesNbf": 10000,
+                        "roleAssignments": [
+                            {
+                                "roleDefinitionIdOrName": "Reader",
+                                "principalIds": [
+                                    "<<deploymentSpId>>"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
         },
         "keys": {
             "value": [

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -160,7 +160,7 @@ var formattedAccessPolicies = [for accessPolicy in accessPolicies: {
   tenantId: contains(accessPolicy, 'tenantId') ? accessPolicy.tenantId : tenant().tenantId
 }]
 
-var secretList = !empty(secrets) ? secrets.secrets : []
+var secretList = !empty(secrets) ? secrets.secureList : []
 
 module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   name: 'pid-${cuaId}'

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -9,7 +9,8 @@ param location string = resourceGroup().location
 param accessPolicies array = []
 
 @description('Optional. All secrets to create')
-param secrets array = []
+@secure()
+param secrets object = {}
 
 @description('Optional. All keys to create')
 param keys array = []
@@ -159,6 +160,8 @@ var formattedAccessPolicies = [for accessPolicy in accessPolicies: {
   tenantId: contains(accessPolicy, 'tenantId') ? accessPolicy.tenantId : tenant().tenantId
 }]
 
+var secretList = !empty(secrets) ? secrets.secrets : []
+
 module pid_cuaId '.bicep/nested_cuaId.bicep' = if (!empty(cuaId)) {
   name: 'pid-${cuaId}'
   params: {}
@@ -217,7 +220,7 @@ module keyVault_accessPolicies 'accessPolicies/deploy.bicep' = if (!empty(access
   }
 }
 
-module keyVault_secrets 'secrets/deploy.bicep' = [for (secret, index) in secrets: {
+module keyVault_secrets 'secrets/deploy.bicep' = [for (secret, index) in secretList: {
   name: '${uniqueString(deployment().name, location)}-KeyVault-Secret-${index}'
   params: {
     name: secret.name

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -44,7 +44,7 @@ This module deploys a key vault and its child resources.
 | `networkAcls` | object | `{object}` |  | Optional. Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny |
 | `privateEndpoints` | array | `[]` |  | Optional. Configuration Details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
-| `secrets` | _[secrets](secrets/readme.md)_ array | `[]` |  | Optional. All secrets to create |
+| `secrets` | _[secrets](secrets/readme.md)_ object | `[]` |  | Optional. All secrets to create |
 | `softDeleteRetentionInDays` | int | `90` |  | Optional. softDelete data retention days. It accepts >=7 and <=90. |
 | `tags` | object | `{object}` |  | Optional. Resource tags. |
 | `vaultSku` | string | `premium` | `[premium, standard]` | Optional. Specifies the SKU for the vault |


### PR DESCRIPTION
# Change

Converting `secrets` parameter to secure object. The array type does not have the `secure` option and will therefore be displayed in plaintext in Azure portal (in deployments or export template). 

## Type of Change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(Due to change from array to object)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
