### PR TITLE
Enabling NFS 4.1 Fileshares

### DIFF
--- a/.azuredevops/modulePipelines/ms.storage.storageaccounts.yml
+++ b/.azuredevops/modulePipelines/ms.storage.storageaccounts.yml
@@ -43,6 +43,7 @@ stages:
           removeDeployment: '${{ parameters.removeDeployment }}'
           deploymentBlocks:
             - path: $(modulePath)/.parameters/min.parameters.json
+            - path: $(modulePath)/.parameters/nfs.parameters.json
             - path: $(modulePath)/.parameters/parameters.json
             - path: $(modulePath)/.parameters/v1.parameters.json
 

--- a/.github/workflows/ms.storage.storageaccounts.yml
+++ b/.github/workflows/ms.storage.storageaccounts.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         parameterFilePaths:
-          ['parameters.json', 'min.parameters.json', 'v1.parameters.json']
+          ['parameters.json', 'min.parameters.json', 'nfs.parameters.json', 'v1.parameters.json']
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/arm/Microsoft.Storage/storageAccounts/.parameters/nfs.parameters.json
+++ b/arm/Microsoft.Storage/storageAccounts/.parameters/nfs.parameters.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>azsax002"
+        },
+        "storageAccountSku": {
+            "value": "Premium_LRS"
+        },
+        "storageAccountKind": {
+            "value": "FileStorage"
+        },
+        "allowBlobPublicAccess": {
+            "value": false
+        },
+        "supportsHttpsTrafficOnly": {
+            "value": false
+        },
+        "fileServices": {
+            "value": {
+                "shares": [
+                    {
+                        "name": "nfsfileshare",
+                        "enabledProtocols": "NFS"
+                    }
+                ]
+            }
+        },
+        "systemAssignedIdentity": {
+            "value": true
+        },
+        "userAssignedIdentities": {
+            "value": {
+                "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001": {}
+            }
+        },
+        "roleAssignments": {
+            "value": [
+                {
+                    "roleDefinitionIdOrName": "Reader",
+                    "principalIds": [
+                        "<<deploymentSpId>>"
+                    ]
+                }
+            ]
+        },
+        "diagnosticLogsRetentionInDays": {
+            "value": 7
+        },
+        "diagnosticStorageAccountId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001"
+        },
+        "diagnosticWorkspaceId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001"
+        },
+        "diagnosticEventHubAuthorizationRuleId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey"
+        },
+        "diagnosticEventHubName": {
+            "value": "adp-<<namePrefix>>-az-evh-x-001"
+        }
+    }
+}

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/readme.md
@@ -31,7 +31,6 @@ This module can be used to deploy a blob service into a storage account.
 | `name` | string | `default` |  | Optional. The name of the blob service |
 | `storageAccountName` | string |  |  | Required. Name of the Storage Account. |
 
-
 ## Outputs
 
 | Output Name | Type | Description |

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
@@ -108,11 +108,13 @@ resource fileServices_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@
 }
 
 module fileServices_shares 'shares/deploy.bicep' = [for (share, index) in shares: {
-  name: '${deployment().name}-File-${index}'
+  name: '${deployment().name}-shares-${index}'
   params: {
     storageAccountName: storageAccount.name
     fileServicesName: fileServices.name
     name: share.name
+    enabledProtocols: contains(share, 'enabledProtocols') ? share.enabledProtocols : 'SMB'
+    rootSquash: contains(share, 'rootSquash') ? share.rootSquash : 'NoRootSquash'
     sharedQuota: contains(share, 'sharedQuota') ? share.sharedQuota : 5120
     roleAssignments: contains(share, 'roleAssignments') ? share.roleAssignments : []
   }

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/readme.md
@@ -1,45 +1,58 @@
-# Storage Account file share services `[Microsoft.Storage/storageAccounts/fileServices]`
+# File Share `[Microsoft.Storage/storageAccounts/fileServices/shares]`
 
-This module can be used to deploy a file share service into a storage account.
+This module deploys a storage account file share.
 
 ## Resource Types
 
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
-| `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
-| `Microsoft.Storage/storageAccounts/fileServices` | 2021-04-01 |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2019-06-01 |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2021-08-01 |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
-| `diagnosticEventHubAuthorizationRuleId` | string |  |  | Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
-| `diagnosticEventHubName` | string |  |  | Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |
-| `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
-| `diagnosticStorageAccountId` | string |  |  | Optional. Resource ID of the diagnostic storage account. |
-| `diagnosticWorkspaceId` | string |  |  | Optional. Resource ID of a log analytics workspace. |
-| `logsToEnable` | array | `[StorageRead, StorageWrite, StorageDelete]` | `[StorageRead, StorageWrite, StorageDelete]` | Optional. The name of logs that will be streamed. |
-| `metricsToEnable` | array | `[Transaction]` | `[Transaction]` | Optional. The name of metrics that will be streamed. |
-| `name` | string | `default` |  | Optional. The name of the file service |
-| `protocolSettings` | object | `{object}` |  | Optional. Protocol settings for file service |
-| `shareDeleteRetentionPolicy` | object | `{object}` |  | Optional. The service properties for soft delete. |
-| `shares` | _[shares](shares/readme.md)_ array | `[]` |  | Optional. File shares to create. |
+| `enabledProtocols` | string | `SMB` | `[NFS, SMB]` | Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share. |
+| `fileServicesName` | string | `default` |  | Optional. The name of the file service |
+| `name` | string |  |  | Required. The name of the file share to create |
+| `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
+| `rootSquash` | string | `NoRootSquash` | `[AllSquash, NoRootSquash, RootSquash]` | Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares. |
+| `sharedQuota` | int | `5120` |  | Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400. |
 | `storageAccountName` | string |  |  | Required. Name of the Storage Account. |
+
+### Parameter Usage: `roleAssignments`
+
+```json
+"roleAssignments": {
+    "value": [
+        {
+            "roleDefinitionIdOrName": "Reader",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012", // object 1
+                "78945612-1234-1234-1234-123456789012" // object 2
+            ]
+        },
+        {
+            "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012" // object 1
+            ]
+        }
+    ]
+}
+```
 
 ## Outputs
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | The name of the deployed file share service |
-| `resourceGroupName` | string | The resource group of the deployed file share service |
-| `resourceId` | string | The resource ID of the deployed file share service |
+| `name` | string | The name of the deployed file share |
+| `resourceGroupName` | string | The resource group of the deployed file share |
+| `resourceId` | string | The resource ID of the deployed file share |
 
 ## Template references
 
-- [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
-- [Storageaccounts/Fileservices](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-04-01/storageAccounts/fileServices)
-- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2019-06-01/storageAccounts/fileServices/shares)
+- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-08-01/storageAccounts/fileServices/shares)

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/readme.md
@@ -1,58 +1,45 @@
-# File Share `[Microsoft.Storage/storageAccounts/fileServices/shares]`
+# Storage Account file share services `[Microsoft.Storage/storageAccounts/fileServices]`
 
-This module deploys a storage account file share.
+This module can be used to deploy a file share service into a storage account.
 
 ## Resource Types
 
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2021-08-01 |
+| `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
+| `Microsoft.Storage/storageAccounts/fileServices` | 2021-04-01 |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2019-06-01 |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
-| `enabledProtocols` | string | `SMB` | `[NFS, SMB]` | Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share. |
-| `fileServicesName` | string | `default` |  | Optional. The name of the file service |
-| `name` | string |  |  | Required. The name of the file share to create |
-| `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
-| `rootSquash` | string | `NoRootSquash` | `[AllSquash, NoRootSquash, RootSquash]` | Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares. |
-| `sharedQuota` | int | `5120` |  | Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400. |
+| `diagnosticEventHubAuthorizationRuleId` | string |  |  | Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
+| `diagnosticEventHubName` | string |  |  | Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |
+| `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
+| `diagnosticStorageAccountId` | string |  |  | Optional. Resource ID of the diagnostic storage account. |
+| `diagnosticWorkspaceId` | string |  |  | Optional. Resource ID of a log analytics workspace. |
+| `logsToEnable` | array | `[StorageRead, StorageWrite, StorageDelete]` | `[StorageRead, StorageWrite, StorageDelete]` | Optional. The name of logs that will be streamed. |
+| `metricsToEnable` | array | `[Transaction]` | `[Transaction]` | Optional. The name of metrics that will be streamed. |
+| `name` | string | `default` |  | Optional. The name of the file service |
+| `protocolSettings` | object | `{object}` |  | Optional. Protocol settings for file service |
+| `shareDeleteRetentionPolicy` | object | `{object}` |  | Optional. The service properties for soft delete. |
+| `shares` | _[shares](shares/readme.md)_ array | `[]` |  | Optional. File shares to create. |
 | `storageAccountName` | string |  |  | Required. Name of the Storage Account. |
-
-### Parameter Usage: `roleAssignments`
-
-```json
-"roleAssignments": {
-    "value": [
-        {
-            "roleDefinitionIdOrName": "Reader",
-            "principalIds": [
-                "12345678-1234-1234-1234-123456789012", // object 1
-                "78945612-1234-1234-1234-123456789012" // object 2
-            ]
-        },
-        {
-            "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
-            "principalIds": [
-                "12345678-1234-1234-1234-123456789012" // object 1
-            ]
-        }
-    ]
-}
-```
 
 ## Outputs
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | The name of the deployed file share |
-| `resourceGroupName` | string | The resource group of the deployed file share |
-| `resourceId` | string | The resource ID of the deployed file share |
+| `name` | string | The name of the deployed file share service |
+| `resourceGroupName` | string | The resource group of the deployed file share service |
+| `resourceId` | string | The resource ID of the deployed file share service |
 
 ## Template references
 
+- [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
-- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-08-01/storageAccounts/fileServices/shares)
+- [Storageaccounts/Fileservices](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-04-01/storageAccounts/fileServices)
+- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2019-06-01/storageAccounts/fileServices/shares)

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
@@ -11,6 +11,21 @@ param name string
 @description('Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.')
 param sharedQuota int = 5120
 
+@allowed([
+    'NFS'
+    'SMB'
+])
+@description('Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share.')
+param enabledProtocols string = 'SMB'
+
+@allowed([
+    'AllSquash'
+    'NoRootSquash'
+    'RootSquash'
+])
+@description('Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares.')
+param rootSquash string = 'NoRootSquash'
+
 @description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'')
 param roleAssignments array = []
 
@@ -30,11 +45,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
   }
 }
 
-resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2019-06-01' = {
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2021-08-01' = {
   name: name
   parent: storageAccount::fileService
   properties: {
     shareQuota: sharedQuota
+    rootSquash: enabledProtocols == 'NFS' ? rootSquash : null
+    enabledProtocols: enabledProtocols
   }
 }
 

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
@@ -7,16 +7,18 @@ This module deploys a storage account file share.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2019-06-01 |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | 2021-08-01 |
 
 ## Parameters
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
+| `enabledProtocols` | string | `SMB` | `[NFS, SMB]` | Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share. |
 | `fileServicesName` | string | `default` |  | Optional. The name of the file service |
 | `name` | string |  |  | Required. The name of the file share to create |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
+| `rootSquash` | string | `NoRootSquash` | `[AllSquash, NoRootSquash, RootSquash]` | Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares. |
 | `sharedQuota` | int | `5120` |  | Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400. |
 | `storageAccountName` | string |  |  | Required. Name of the Storage Account. |
 
@@ -53,4 +55,4 @@ This module deploys a storage account file share.
 ## Template references
 
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
-- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2019-06-01/storageAccounts/fileServices/shares)
+- [Storageaccounts/Fileservices/Shares](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-08-01/storageAccounts/fileServices/shares)

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/readme.md
@@ -27,7 +27,6 @@ This module can be used to deploy a file share service into a storage account.
 | `queues` | _[queues](queues/readme.md)_ array | `[]` |  | Optional. Queues to create. |
 | `storageAccountName` | string |  |  | Required. Name of the Storage Account. |
 
-
 ## Outputs
 
 | Output Name | Type | Description |


### PR DESCRIPTION
# Change

Adding support for NFS 4.1 file shares

[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Fmast%2FSA_NFS)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
