### PR TITLE
VNET: Removed subnet property from main deployment

### DIFF
--- a/arm/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -111,15 +111,6 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
     ddosProtectionPlan: !empty(ddosProtectionPlanId) ? ddosProtectionPlan : null
     dhcpOptions: !empty(dnsServers) ? dnsServers_var : null
     enableDdosProtection: !empty(ddosProtectionPlanId)
-    // subnets: [for subnet in subnets: {
-    //   name: subnet.name
-    //   properties: {
-    //     addressPrefix: subnet.addressPrefix
-    //     delegations: contains(subnet, 'delegations') ? subnet.delegations : null
-    //     privateEndpointNetworkPolicies: contains(subnet, 'privateEndpointNetworkPolicies') ? subnet.privateEndpointNetworkPolicies : null
-    //     privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies') ? subnet.privateLinkServiceNetworkPolicies : null
-    //   }
-    // }]
   }
 }
 

--- a/arm/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -111,15 +111,15 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
     ddosProtectionPlan: !empty(ddosProtectionPlanId) ? ddosProtectionPlan : null
     dhcpOptions: !empty(dnsServers) ? dnsServers_var : null
     enableDdosProtection: !empty(ddosProtectionPlanId)
-    subnets: [for subnet in subnets: {
-      name: subnet.name
-      properties: {
-        addressPrefix: subnet.addressPrefix
-        delegations: contains(subnet, 'delegations') ? subnet.delegations : null
-        privateEndpointNetworkPolicies: contains(subnet, 'privateEndpointNetworkPolicies') ? subnet.privateEndpointNetworkPolicies : null
-        privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies') ? subnet.privateLinkServiceNetworkPolicies : null
-      }
-    }]
+    // subnets: [for subnet in subnets: {
+    //   name: subnet.name
+    //   properties: {
+    //     addressPrefix: subnet.addressPrefix
+    //     delegations: contains(subnet, 'delegations') ? subnet.delegations : null
+    //     privateEndpointNetworkPolicies: contains(subnet, 'privateEndpointNetworkPolicies') ? subnet.privateEndpointNetworkPolicies : null
+    //     privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies') ? subnet.privateLinkServiceNetworkPolicies : null
+    //   }
+    // }]
   }
 }
 


### PR DESCRIPTION
# Change

- Removed subnet property from main deployment (as its not required an can cause issues)

Pipeline reference
[![Network: VirtualNetworks](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml/badge.svg?branch=users%2Falsehr%2Fvnet)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)


