### PR TITLE
add Azure Active Directory as sql server admin authentication

### DIFF
--- a/arm/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/arm/Microsoft.Sql/servers/.parameters/parameters.json
@@ -23,7 +23,7 @@
                 "azureADOnlyAuthentication": false,
                 "login": "John Doe",
                 "sid": "<<objectId>>",
-                "principalType": "User",
+                "principalType": "Application",
                 "tenantId": "<<tenantId>>"
             }
         },

--- a/arm/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/arm/Microsoft.Sql/servers/.parameters/parameters.json
@@ -22,7 +22,7 @@
             "value": {
                 "azureADOnlyAuthentication": false,
                 "login": "John Doe",
-                "sid": "<<objectId>>",
+                "sid": "<<deploymentSpId>>",
                 "principalType": "Application",
                 "tenantId": "<<tenantId>>"
             }

--- a/arm/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/arm/Microsoft.Sql/servers/.parameters/parameters.json
@@ -18,6 +18,15 @@
                 "secretName": "administratorLoginPassword"
             }
         },
+        "administrators": {
+            "value": {
+                "azureADOnlyAuthentication": false,
+                "login": "John Doe",
+                "sid": "<<objectId>>",
+                "principalType": "User",
+                "tenantId": "<<tenantId>>"
+            }
+        },
         "location": {
             "value": "westeurope"
         },

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -43,7 +43,7 @@ param firewallRules array = []
 @description('Optional. The security alert policies to create in the server')
 param securityAlertPolicies array = []
 
-@description('Conditional. The Azure Active Directory (AAD) administrator authentiaction.')
+@description('Optional. The Azure Active Directory (AAD) administrator authentiaction. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
 param administrators object = {}
 
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -43,7 +43,7 @@ param firewallRules array = []
 @description('Optional. The security alert policies to create in the server')
 param securityAlertPolicies array = []
 
-@description('Optional. The Azure Active Directory (AAD) administrator authentiaction. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
+@description('Optional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
 param administrators object = {}
 
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -1,7 +1,7 @@
-@description('Optional if AAD Admin is assigned. Administrator username for the server.')
+@description('Conditional. Administrator username for the server.')
 param administratorLogin string = ''
 
-@description('Optional if AAD Admin is assigned. The administrator login password.')
+@description('Conditional. The administrator login password.')
 @secure()
 param administratorLoginPassword string = ''
 
@@ -43,7 +43,7 @@ param firewallRules array = []
 @description('Optional. The security alert policies to create in the server')
 param securityAlertPolicies array = []
 
-@description('Optional. The Azure Active Directory (AAD) administrator authentiaction.')
+@description('Conditional. The Azure Active Directory (AAD) administrator authentiaction.')
 param administrators object = {}
 
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
@@ -71,7 +71,7 @@ resource server 'Microsoft.Sql/servers@2021-05-01-preview' = {
       azureADOnlyAuthentication: administrators.azureADOnlyAuthentication
       login: administrators.login
       principalType: administrators.principalType
-      sid: administrators.sid 
+      sid: administrators.sid
       tenantId: administrators.tenantId
     } : null
     version: '12.0'

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -1,9 +1,9 @@
-@description('Required. Administrator username for the server.')
-param administratorLogin string
+@description('Optional if AAD Admin is assigned. Administrator username for the server.')
+param administratorLogin string = ''
 
-@description('Required. The administrator login password.')
+@description('Optional if AAD Admin is assigned. The administrator login password.')
 @secure()
-param administratorLoginPassword string
+param administratorLoginPassword string = ''
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -43,6 +43,9 @@ param firewallRules array = []
 @description('Optional. The security alert policies to create in the server')
 param securityAlertPolicies array = []
 
+@description('Optional. The Azure Active Directory (AAD) administrator authentiaction.')
+param administrators object = {}
+
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
 
 var identity = identityType != 'None' ? {
@@ -61,8 +64,16 @@ resource server 'Microsoft.Sql/servers@2021-05-01-preview' = {
   tags: tags
   identity: identity
   properties: {
-    administratorLogin: administratorLogin
-    administratorLoginPassword: administratorLoginPassword
+    administratorLogin: !empty(administratorLogin) ? administratorLogin : null
+    administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
+    administrators: !empty(administrators) ? {
+      administratorType: 'ActiveDirectory'
+      azureADOnlyAuthentication: administrators.azureADOnlyAuthentication
+      login: administrators.login
+      principalType: administrators.principalType
+      sid: administrators.sid 
+      tenantId: administrators.tenantId
+    } : null
     version: '12.0'
   }
 }

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -1,4 +1,4 @@
-@description('Conditional. Administrator username for the server.')
+@description('Optional. Administrator username for the server. Required if no `administrators` object for AAD authentication is provided.')
 param administratorLogin string = ''
 
 @description('Conditional. The administrator login password.')

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -1,7 +1,7 @@
 @description('Optional. Administrator username for the server. Required if no `administrators` object for AAD authentication is provided.')
 param administratorLogin string = ''
 
-@description('Conditional. The administrator login password.')
+@description('Optional. The administrator login password. Required if no `administrators` object for AAD authentication is provided.')
 @secure()
 param administratorLoginPassword string = ''
 

--- a/arm/Microsoft.Sql/servers/readme.md
+++ b/arm/Microsoft.Sql/servers/readme.md
@@ -18,8 +18,9 @@ This module deploys a SQL server.
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `administratorLogin` | string |  |  | Required. Administrator username for the server. |
-| `administratorLoginPassword` | secureString |  |  | Required. The administrator login password. |
+| `administrators` | object |  |  | Conditional. Azure Active Directory admin of the server. |
+| `administratorLogin` | string |  |  | Conditional. Administrator username for the server. |
+| `administratorLoginPassword` | secureString |  |  | Conditional. The administrator login password. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `databases` | _[databases](databases/readme.md)_ array | `[]` |  | Optional. The databases to create in the server |
 | `firewallRules` | _[firewallRules](firewallRules/readme.md)_ array | `[]` |  | Optional. The firewall rules to create in the server |

--- a/arm/Microsoft.Sql/servers/readme.md
+++ b/arm/Microsoft.Sql/servers/readme.md
@@ -18,9 +18,9 @@ This module deploys a SQL server.
 
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `administrators` | object |  |  | Conditional. Azure Active Directory admin of the server. |
-| `administratorLogin` | string |  |  | Conditional. Administrator username for the server. |
-| `administratorLoginPassword` | secureString |  |  | Conditional. The administrator login password. |
+| `administratorLogin` | string |  |  | Optional. Administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
+| `administratorLoginPassword` | secureString |  |  | Optional. The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
+| `administrators` | object | `{object}` |  | Optional. The Azure Active Directory (AAD) administrator authentiaction. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `databases` | _[databases](databases/readme.md)_ array | `[]` |  | Optional. The databases to create in the server |
 | `firewallRules` | _[firewallRules](firewallRules/readme.md)_ array | `[]` |  | Optional. The firewall rules to create in the server |
@@ -29,7 +29,7 @@ This module deploys a SQL server.
 | `name` | string |  |  | Required. The name of the server. |
 | `roleAssignments` | array | `[]` |  | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `securityAlertPolicies` | _[securityAlertPolicies](securityAlertPolicies/readme.md)_ array | `[]` |  | Optional. The security alert policies to create in the server |
-| `systemAssignedIdentity` | bool |  |  | Optional. Enables system assigned managed identity on the resource. |
+| `systemAssignedIdentity` | bool | `False` |  | Optional. Enables system assigned managed identity on the resource. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
 | `userAssignedIdentities` | object | `{object}` |  | Optional. The ID(s) to assign to the resource. |
 

--- a/arm/Microsoft.Sql/servers/readme.md
+++ b/arm/Microsoft.Sql/servers/readme.md
@@ -20,7 +20,7 @@ This module deploys a SQL server.
 | :-- | :-- | :-- | :-- | :-- |
 | `administratorLogin` | string |  |  | Optional. Administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
 | `administratorLoginPassword` | secureString |  |  | Optional. The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
-| `administrators` | object | `{object}` |  | Optional. The Azure Active Directory (AAD) administrator authentiaction. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
+| `administrators` | object | `{object}` |  | Optional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | `cuaId` | string |  |  | Optional. Customer Usage Attribution ID (GUID). This GUID must be previously registered |
 | `databases` | _[databases](databases/readme.md)_ array | `[]` |  | Optional. The databases to create in the server |
 | `firewallRules` | _[firewallRules](firewallRules/readme.md)_ array | `[]` |  | Optional. The firewall rules to create in the server |

--- a/arm/Microsoft.Sql/servers/readme.md
+++ b/arm/Microsoft.Sql/servers/readme.md
@@ -84,6 +84,23 @@ You can specify multiple user assigned identities to a resource by providing add
 },
 ```
 
+### Parameter Usage: `administrators`
+
+Configure Azure Active Directory Authentication method for server administrator.
+https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/servers/administrators?tabs=bicep
+
+```json
+"administrators": {
+    "value": {
+        "azureADOnlyAuthentication": false
+        "login": "John Doe"
+        "sid": "<<objectId>>"
+        "principalType" : "User" // options: "User", "Group", "Application"
+        "tenantId": "<<tenantId>>"
+    }
+},
+```
+
 ## Outputs
 
 | Output Name | Type | Description |


### PR DESCRIPTION
# Change

Add the configuration to use AAD as sql server admin authentication. 
SQL admin credentials were previously required parameters, this is changed to conditional as they are no longer necessary if AAD is configured to be only authentication method.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
