### PR TITLE
Bug fix: Update ADO Dependency Pipeline to support new policy assignment parameter file names, point to the root template instead of child

### DIFF
--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -91,14 +91,17 @@ stages:
       - deploy_rg
     variables:
       resourceType: 'Microsoft.Authorization/policyAssignments'
-      templateFilePath: $(modulesPath)/$(resourceType)/subscription/deploy.bicep
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
     jobs:
       - template: /.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
         parameters:
           deploymentBlocks:
-            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+            - path: $(dependencyPath)/$(resourceType)/parameters/mg.parameters.json
               templateFilePath: $(templateFilePath)
-              displayName: Policy assignment
+              displayName: Policy assignment (mg)
+            - path: $(dependencyPath)/$(resourceType)/parameters/sub.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Policy assignment (sub)
 
   - stage: deploy_evh
     displayName: Deploy event hub


### PR DESCRIPTION
# Change

Bug fix. ADO Dependency pipeline update to include policy module changes

![image](https://user-images.githubusercontent.com/28486158/157360743-b2e18560-3152-4bbb-bb3a-205d9d3af87f.png)

Post change:
![image](https://user-images.githubusercontent.com/28486158/157364037-c3cf2c3b-76ef-4455-ac5a-97a5007b67e4.png)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
