### PR TITLE
Added proximity placement groups in the ADO dependency pipeline

### DIFF
--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -47,6 +47,21 @@ stages:
               templateFilePath: $(templateFilePath)
               displayName: Validation Resource Group
 
+  - stage: deploy_ppg
+    displayName: Deploy proximity placement group
+    dependsOn:
+      - deploy_rg
+    variables:
+      resourceType: 'Microsoft.Compute/proximityPlacementGroups'
+      templateFilePath: $(modulesPath)/$(resourceType)/deploy.bicep
+    jobs:
+      - template: /.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
+        parameters:
+          deploymentBlocks:
+            - path: $(dependencyPath)/$(resourceType)/parameters/parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Proximity Placement Group
+
   - stage: deploy_msi
     displayName: Deploy user assigned identity
     dependsOn:


### PR DESCRIPTION
# Change

Fixes #1134 where the ADO pipeline does not have the PPG dependency needed for the availability set module:

**Before**:
![image](https://user-images.githubusercontent.com/28486158/158508159-8444f158-80fa-4a8f-ba05-54fc09299626.png)
![image](https://user-images.githubusercontent.com/28486158/158509407-e252fc18-5a81-4ae8-aac8-52204fedb555.png)

**After**:
![image](https://user-images.githubusercontent.com/28486158/158509313-528a6d71-a18f-4a81-bf80-3c153dfe0455.png)
![image](https://user-images.githubusercontent.com/28486158/158509997-01325783-723c-4f15-bc6a-49168385593b.png)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
