### PR TITLE
Bugfix for bgpsettings trying to apply even when disabled

### DIFF
--- a/arm/Microsoft.Network/virtualNetworkGateways/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworkGateways/deploy.bicep
@@ -336,7 +336,7 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2021-05
     ipConfigurations: activeActive_var ? activeActiveIpConfiguration : activePassiveIpConfiguration
     activeActive: activeActive_var
     enableBgp: enableBgp_var
-    bgpSettings: virtualNetworkGatewayType == 'ExpressRoute' ? null : bgpSettings
+    bgpSettings: enableBgp_var ? bgpSettings : null
     sku: {
       name: virtualNetworkGatewaySku
       tier: virtualNetworkGatewaySku


### PR DESCRIPTION
# Change

bgpsettings were trying to still apply the object even when set to false.
This caused an issue when trying to use the module to deploy a 'Basic' type vpn gateway, as bgp isnt supported.
The fix checks the variable enableBgp_var instead of type expressroute before trying to apply settings

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I did format my code
