### PR TITLE
Fixed diagnostic references on storage & SQL

### DIFF
--- a/arm/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/arm/Microsoft.Sql/servers/.parameters/parameters.json
@@ -46,7 +46,7 @@
                     "diagnosticLogsRetentionInDays": 7,
                     "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
                     "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
-                    "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
+                    "diagnosticEventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
                     "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001"
                 }
             ]

--- a/arm/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/arm/Microsoft.Sql/servers/.parameters/parameters.json
@@ -45,9 +45,9 @@
                     "licenseType": "LicenseIncluded",
                     "diagnosticLogsRetentionInDays": 7,
                     "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
-                    "workspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
+                    "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
                     "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
-                    "eventHubName": "adp-<<namePrefix>>-az-evh-x-001"
+                    "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001"
                 }
             ]
         },

--- a/arm/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/databases/deploy.bicep
@@ -1,20 +1,20 @@
-@description('Optional. The collation of the database.')
-param collation string
-
 @description('Required. The name of the database.')
 param name string
 
-@description('Optional. The tier or edition of the particular SKU.')
-param tier string
-
-@description('Required. The name of the SKU.')
-param skuName string
-
-@description('Optional. The max size of the database expressed in bytes.')
-param maxSizeBytes int
-
 @description('Required. The Name of SQL Server')
 param serverName string
+
+@description('Optional. The collation of the database.')
+param collation string = 'SQL_Latin1_General_CP1_CI_AS'
+
+@description('Optional. The tier or edition of the particular SKU.')
+param tier string = 'GeneralPurpose'
+
+@description('Optional. The name of the SKU.')
+param skuName string = 'GP_Gen5_2'
+
+@description('Optional. The max size of the database expressed in bytes.')
+param maxSizeBytes int = 34359738368
 
 @description('Optional. The name of the sample schema to apply when creating this database.')
 param sampleName string = ''

--- a/arm/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/databases/deploy.bicep
@@ -75,7 +75,7 @@ param diagnosticEventHubName string = ''
   'QueryStoreWaitStatistics'
   'Errors'
   'DatabaseWaitStatistics'
-  'Timouts'
+  'Timeouts'
   'Blocks'
   'Deadlocks'
 ])
@@ -86,7 +86,7 @@ param logsToEnable array = [
   'QueryStoreWaitStatistics'
   'Errors'
   'DatabaseWaitStatistics'
-  'Timouts'
+  'Timeouts'
   'Blocks'
   'Deadlocks'
 ]

--- a/arm/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/databases/deploy.bicep
@@ -78,6 +78,8 @@ param diagnosticEventHubName string = ''
   'Timeouts'
   'Blocks'
   'Deadlocks'
+  'DevOpsOperationsAudit'
+  'SQLSecurityAuditEvents'
 ])
 param logsToEnable array = [
   'SQLInsights'
@@ -89,14 +91,20 @@ param logsToEnable array = [
   'Timeouts'
   'Blocks'
   'Deadlocks'
+  'DevOpsOperationsAudit'
+  'SQLSecurityAuditEvents'
 ]
 
 @description('Optional. The name of metrics that will be streamed.')
 @allowed([
   'Basic'
+  'InstanceAndAppAdvanced'
+  'WorkloadManagement'
 ])
 param metricsToEnable array = [
   'Basic'
+  'InstanceAndAppAdvanced'
+  'WorkloadManagement'
 ]
 
 var diagnosticsLogs = [for log in logsToEnable: {

--- a/arm/Microsoft.Sql/servers/databases/readme.md
+++ b/arm/Microsoft.Sql/servers/databases/readme.md
@@ -25,10 +25,10 @@ This module deploys an Azure SQL Server.
 | `isLedgerOn` | bool | `False` |  | Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created. |
 | `licenseType` | string |  |  | Optional. The license type to apply for this database. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `logsToEnable` | array | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | Optional. The name of logs that will be streamed. |
+| `logsToEnable` | array | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks, DevOpsOperationsAudit, SQLSecurityAuditEvents]` | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks, DevOpsOperationsAudit, SQLSecurityAuditEvents]` | Optional. The name of logs that will be streamed. |
 | `maintenanceConfigurationId` | string |  |  | Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur. |
 | `maxSizeBytes` | int | `34359738368` |  | Optional. The max size of the database expressed in bytes. |
-| `metricsToEnable` | array | `[Basic]` | `[Basic]` | Optional. The name of metrics that will be streamed. |
+| `metricsToEnable` | array | `[Basic, InstanceAndAppAdvanced, WorkloadManagement]` | `[Basic, InstanceAndAppAdvanced, WorkloadManagement]` | Optional. The name of metrics that will be streamed. |
 | `minCapacity` | string |  |  | Optional. Minimal capacity that database will always have allocated. |
 | `name` | string |  |  | Required. The name of the database. |
 | `readScale` | string | `Disabled` | `[Enabled, Disabled]` | Optional. The state of read-only routing. |

--- a/arm/Microsoft.Sql/servers/databases/readme.md
+++ b/arm/Microsoft.Sql/servers/databases/readme.md
@@ -25,7 +25,7 @@ This module deploys an Azure SQL Server.
 | `isLedgerOn` | bool | `False` |  | Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created. |
 | `licenseType` | string |  |  | Optional. The license type to apply for this database. |
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
-| `logsToEnable` | array | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timouts, Blocks, Deadlocks]` | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timouts, Blocks, Deadlocks]` | Optional. The name of logs that will be streamed. |
+| `logsToEnable` | array | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | Optional. The name of logs that will be streamed. |
 | `maintenanceConfigurationId` | string |  |  | Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur. |
 | `maxSizeBytes` | int |  |  | Optional. The max size of the database expressed in bytes. |
 | `metricsToEnable` | array | `[Basic]` | `[Basic]` | Optional. The name of metrics that will be streamed. |

--- a/arm/Microsoft.Sql/servers/databases/readme.md
+++ b/arm/Microsoft.Sql/servers/databases/readme.md
@@ -14,7 +14,7 @@ This module deploys an Azure SQL Server.
 | Parameter Name | Type | Default Value | Possible Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `autoPauseDelay` | string |  |  | Optional. Time in minutes after which database is automatically paused. |
-| `collation` | string |  |  | Optional. The collation of the database. |
+| `collation` | string | `SQL_Latin1_General_CP1_CI_AS` |  | Optional. The collation of the database. |
 | `diagnosticEventHubAuthorizationRuleId` | string |  |  | Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
 | `diagnosticEventHubName` | string |  |  | Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
@@ -27,7 +27,7 @@ This module deploys an Azure SQL Server.
 | `location` | string | `[resourceGroup().location]` |  | Optional. Location for all resources. |
 | `logsToEnable` | array | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | `[SQLInsights, AutomaticTuning, QueryStoreRuntimeStatistics, QueryStoreWaitStatistics, Errors, DatabaseWaitStatistics, Timeouts, Blocks, Deadlocks]` | Optional. The name of logs that will be streamed. |
 | `maintenanceConfigurationId` | string |  |  | Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur. |
-| `maxSizeBytes` | int |  |  | Optional. The max size of the database expressed in bytes. |
+| `maxSizeBytes` | int | `34359738368` |  | Optional. The max size of the database expressed in bytes. |
 | `metricsToEnable` | array | `[Basic]` | `[Basic]` | Optional. The name of metrics that will be streamed. |
 | `minCapacity` | string |  |  | Optional. Minimal capacity that database will always have allocated. |
 | `name` | string |  |  | Required. The name of the database. |
@@ -35,9 +35,9 @@ This module deploys an Azure SQL Server.
 | `requestedBackupStorageRedundancy` | string |  | `[Geo, Local, Zone, ]` | Optional. The storage account type to be used to store backups for this database. |
 | `sampleName` | string |  |  | Optional. The name of the sample schema to apply when creating this database. |
 | `serverName` | string |  |  | Required. The Name of SQL Server |
-| `skuName` | string |  |  | Required. The name of the SKU. |
+| `skuName` | string | `GP_Gen5_2` |  | Optional. The name of the SKU. |
 | `tags` | object | `{object}` |  | Optional. Tags of the resource. |
-| `tier` | string |  |  | Optional. The tier or edition of the particular SKU. |
+| `tier` | string | `GeneralPurpose` |  | Optional. The tier or edition of the particular SKU. |
 | `zoneRedundant` | bool | `False` |  | Optional. Whether or not this database is zone redundant. |
 
 ### Parameter Usage: `tags`

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -109,10 +109,10 @@ module server_databases 'databases/deploy.bicep' = [for (database, index) in dat
   params: {
     name: database.name
     serverName: server.name
-    maxSizeBytes: database.maxSizeBytes
-    tier: database.tier
-    skuName: database.skuName
-    collation: database.collation
+    tier: contains(database, 'tier') ? database.tier : 'GeneralPurpose'
+    skuName: contains(database, 'skuName') ? database.skuName : 'GP_Gen5_2'
+    collation: contains(database, 'collation') ? database.collation : 'SQL_Latin1_General_CP1_CI_AS'
+    maxSizeBytes: contains(database, 'maxSizeBytes') ? database.maxSizeBytes : 34359738368
     autoPauseDelay: contains(database, 'autoPauseDelay') ? database.autoPauseDelay : ''
     diagnosticLogsRetentionInDays: contains(database, 'diagnosticLogsRetentionInDays') ? database.diagnosticLogsRetentionInDays : 365
     diagnosticStorageAccountId: contains(database, 'diagnosticStorageAccountId') ? database.diagnosticStorageAccountId : ''

--- a/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
+++ b/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
@@ -50,7 +50,7 @@
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
                 "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
-                "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
+                "diagnosticEventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
                 "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "containers": [
                     {
@@ -80,7 +80,7 @@
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
                 "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
-                "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
+                "diagnosticEventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
                 "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "shares": [
                     {
@@ -107,7 +107,7 @@
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
                 "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
-                "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
+                "diagnosticEventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
                 "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "tables": [
                     "table1",
@@ -120,7 +120,7 @@
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
                 "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
-                "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
+                "diagnosticEventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
                 "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "queues": [
                     {

--- a/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
+++ b/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
@@ -49,9 +49,9 @@
             "value": {
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
-                "workspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
+                "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
                 "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
-                "eventHubName": "adp-<<namePrefix>>-az-evh-x-001",
+                "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "containers": [
                     {
                         "name": "avdscripts",
@@ -79,9 +79,9 @@
             "value": {
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
-                "workspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
+                "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
                 "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
-                "eventHubName": "adp-<<namePrefix>>-az-evh-x-001",
+                "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "shares": [
                     {
                         "name": "avdprofiles",
@@ -106,9 +106,9 @@
             "value": {
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
-                "workspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
+                "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
                 "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
-                "eventHubName": "adp-<<namePrefix>>-az-evh-x-001",
+                "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "tables": [
                     "table1",
                     "table2"
@@ -119,9 +119,9 @@
             "value": {
                 "diagnosticLogsRetentionInDays": 7,
                 "diagnosticStorageAccountId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001",
-                "workspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
+                "diagnosticWorkspaceId": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001",
                 "eventHubAuthorizationRuleId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.EventHub/namespaces/adp-<<namePrefix>>-az-evhns-x-001/AuthorizationRules/RootManageSharedAccessKey",
-                "eventHubName": "adp-<<namePrefix>>-az-evh-x-001",
+                "diagnosticEventHubName": "adp-<<namePrefix>>-az-evh-x-001",
                 "queues": [
                     {
                         "name": "queue1",


### PR DESCRIPTION
# Change

- Fixed diagnostic references on storage & SQL

Pipeline reference:
[![Sql: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=users%2Falsehr%2FsqldatabaseDiag)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml)
[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2FsqldatabaseDiag)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
