### PR TITLE
RBAC: Added principal type to RBAC

### DIFF
--- a/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: server
 }]

--- a/arm/Microsoft.AnalysisServices/servers/deploy.bicep
+++ b/arm/Microsoft.AnalysisServices/servers/deploy.bicep
@@ -148,6 +148,7 @@ module server_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: server.id
   }

--- a/arm/Microsoft.AnalysisServices/servers/readme.md
+++ b/arm/Microsoft.AnalysisServices/servers/readme.md
@@ -58,6 +58,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -73,7 +75,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: service
 }]

--- a/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ApiManagement/service/deploy.bicep
+++ b/arm/Microsoft.ApiManagement/service/deploy.bicep
@@ -433,6 +433,7 @@ module apiManagementService_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignme
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: apiManagementService.id
   }

--- a/arm/Microsoft.ApiManagement/service/readme.md
+++ b/arm/Microsoft.ApiManagement/service/readme.md
@@ -76,6 +76,8 @@ This module deploys an API management service.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -91,7 +93,8 @@ This module deploys an API management service.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: automationAccount
 }]

--- a/arm/Microsoft.Automation/automationAccounts/deploy.bicep
+++ b/arm/Microsoft.Automation/automationAccounts/deploy.bicep
@@ -359,6 +359,7 @@ module automationAccount_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment,
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: automationAccount.id
   }

--- a/arm/Microsoft.Automation/automationAccounts/readme.md
+++ b/arm/Microsoft.Automation/automationAccounts/readme.md
@@ -124,6 +124,8 @@ To use Private Endpoint the following dependencies must be deployed:
 ```
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -139,7 +141,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -46,6 +47,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: account
 }]

--- a/arm/Microsoft.CognitiveServices/accounts/deploy.bicep
+++ b/arm/Microsoft.CognitiveServices/accounts/deploy.bicep
@@ -227,6 +227,7 @@ module cognitiveServices_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment,
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: cognitiveServices.id
   }

--- a/arm/Microsoft.CognitiveServices/accounts/readme.md
+++ b/arm/Microsoft.CognitiveServices/accounts/readme.md
@@ -78,6 +78,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -93,7 +95,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: availabilitySet
 }]

--- a/arm/Microsoft.Compute/availabilitySets/deploy.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/deploy.bicep
@@ -75,6 +75,7 @@ module availabilitySet_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: availabilitySet.id
   }

--- a/arm/Microsoft.Compute/availabilitySets/readme.md
+++ b/arm/Microsoft.Compute/availabilitySets/readme.md
@@ -27,6 +27,8 @@ This template deploys an availability set
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -42,7 +44,8 @@ This template deploys an availability set
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -35,6 +36,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: diskEncryptionSet
 }]

--- a/arm/Microsoft.Compute/diskEncryptionSets/deploy.bicep
+++ b/arm/Microsoft.Compute/diskEncryptionSets/deploy.bicep
@@ -89,6 +89,7 @@ module diskEncryptionSet_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment,
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: diskEncryptionSet.id
   }

--- a/arm/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/arm/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -26,6 +26,8 @@ This template deploys a disk encryption set.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -41,7 +43,8 @@ This template deploys a disk encryption set.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: disk
 }]

--- a/arm/Microsoft.Compute/disks/deploy.bicep
+++ b/arm/Microsoft.Compute/disks/deploy.bicep
@@ -181,6 +181,7 @@ module disk_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in ro
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: disk.id
   }

--- a/arm/Microsoft.Compute/disks/readme.md
+++ b/arm/Microsoft.Compute/disks/readme.md
@@ -43,6 +43,8 @@ This template deploys a disk
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -58,7 +60,8 @@ This template deploys a disk
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: gallery
 }]

--- a/arm/Microsoft.Compute/galleries/deploy.bicep
+++ b/arm/Microsoft.Compute/galleries/deploy.bicep
@@ -64,6 +64,7 @@ module gallery_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: gallery.id
   }

--- a/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: galleryImage
 }]

--- a/arm/Microsoft.Compute/galleries/images/deploy.bicep
+++ b/arm/Microsoft.Compute/galleries/images/deploy.bicep
@@ -155,6 +155,7 @@ module galleryImage_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, inde
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: image.id
   }

--- a/arm/Microsoft.Compute/galleries/images/readme.md
+++ b/arm/Microsoft.Compute/galleries/images/readme.md
@@ -41,6 +41,8 @@ This module deploys an Image Definition in a Shared Image Gallery.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -56,7 +58,8 @@ This module deploys an Image Definition in a Shared Image Gallery.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/galleries/readme.md
+++ b/arm/Microsoft.Compute/galleries/readme.md
@@ -26,6 +26,8 @@ This module deploys an Azure compute gallery (formerly known as shared image gal
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -41,7 +43,8 @@ This module deploys an Azure compute gallery (formerly known as shared image gal
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: image
 }]

--- a/arm/Microsoft.Compute/images/deploy.bicep
+++ b/arm/Microsoft.Compute/images/deploy.bicep
@@ -67,6 +67,7 @@ module image_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: image.id
   }

--- a/arm/Microsoft.Compute/images/readme.md
+++ b/arm/Microsoft.Compute/images/readme.md
@@ -27,6 +27,8 @@ This module deploys a compute image.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -42,7 +44,8 @@ This module deploys a compute image.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -35,6 +36,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: proximityPlacementGroup
 }]

--- a/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/proximityPlacementGroups/deploy.bicep
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/deploy.bicep
@@ -63,6 +63,7 @@ module proximityPlacementGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssig
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: proximityPlacementGroup.id
   }

--- a/arm/Microsoft.Compute/proximityPlacementGroups/readme.md
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/readme.md
@@ -24,6 +24,8 @@ This template deploys a proximity placement group.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -39,7 +41,8 @@ This template deploys a proximity placement group.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: vmss
 }]

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
@@ -642,6 +642,7 @@ module vmss_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in ro
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: vmss.id
   }

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/readme.md
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/readme.md
@@ -370,6 +370,8 @@ Only for OSType Windows
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -385,7 +387,8 @@ Only for OSType Windows
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
@@ -116,6 +116,7 @@ module networkInterface_rbac 'nested_networkInterface_rbac.bicep' = [for (roleAs
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: networkInterface.id
   }

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress.bicep
@@ -80,6 +80,7 @@ module publicIpAddress_rbac 'nested_networkInterface_publicIPAddress_rbac.bicep'
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: publicIpAddress.id
   }

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: publicIpAddress
 }]

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: networkInterface
 }]

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: virtualMachine
 }]

--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -621,6 +621,7 @@ module virtualMachine_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: virtualMachine.id
   }

--- a/arm/Microsoft.Compute/virtualMachines/readme.md
+++ b/arm/Microsoft.Compute/virtualMachines/readme.md
@@ -480,6 +480,8 @@ Only for OSType Windows
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -495,7 +497,8 @@ Only for OSType Windows
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -38,6 +39,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: registry
 }]

--- a/arm/Microsoft.ContainerRegistry/registries/deploy.bicep
+++ b/arm/Microsoft.ContainerRegistry/registries/deploy.bicep
@@ -273,6 +273,7 @@ module registry_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: registry.id
   }

--- a/arm/Microsoft.ContainerRegistry/registries/readme.md
+++ b/arm/Microsoft.ContainerRegistry/registries/readme.md
@@ -65,6 +65,8 @@ Azure Container Registry is a managed, private Docker registry service based on 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -80,7 +82,8 @@ Azure Container Registry is a managed, private Docker registry service based on 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -38,6 +39,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: managedCluster
 }]

--- a/arm/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -544,6 +544,7 @@ module managedCluster_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: managedCluster.id
   }

--- a/arm/Microsoft.ContainerService/managedClusters/readme.md
+++ b/arm/Microsoft.ContainerService/managedClusters/readme.md
@@ -99,6 +99,8 @@ This module deploys Azure Kubernetes Cluster (AKS).
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -114,7 +116,8 @@ This module deploys Azure Kubernetes Cluster (AKS).
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: dataFactory
 }]

--- a/arm/Microsoft.DataFactory/factories/deploy.bicep
+++ b/arm/Microsoft.DataFactory/factories/deploy.bicep
@@ -207,6 +207,7 @@ module dataFactory_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: dataFactory.id
   }

--- a/arm/Microsoft.DataFactory/factories/readme.md
+++ b/arm/Microsoft.DataFactory/factories/readme.md
@@ -44,6 +44,8 @@
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -59,7 +61,8 @@
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: workspace
 }]

--- a/arm/Microsoft.Databricks/workspaces/deploy.bicep
+++ b/arm/Microsoft.Databricks/workspaces/deploy.bicep
@@ -144,6 +144,7 @@ module workspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: workspace.id
   }

--- a/arm/Microsoft.Databricks/workspaces/readme.md
+++ b/arm/Microsoft.Databricks/workspaces/readme.md
@@ -32,6 +32,8 @@
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -47,7 +49,8 @@
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: appGroup
 }]

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep
@@ -152,6 +152,7 @@ module appGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: appGroup.id
   }

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/readme.md
@@ -37,6 +37,8 @@ This module deploys an Azure virtual desktop application group.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -52,7 +54,8 @@ This module deploys an Azure virtual desktop application group.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -38,6 +39,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: hostPool
 }]

--- a/arm/Microsoft.DesktopVirtualization/hostpools/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/deploy.bicep
@@ -195,6 +195,7 @@ module hostPool_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: hostPool.id
   }

--- a/arm/Microsoft.DesktopVirtualization/hostpools/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/readme.md
@@ -45,6 +45,8 @@ This module deploys an Azure virtual desktop host pool.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -60,7 +62,8 @@ This module deploys an Azure virtual desktop host pool.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -38,6 +39,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: hostPool
 }]

--- a/arm/Microsoft.DesktopVirtualization/scalingplans/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/scalingplans/deploy.bicep
@@ -140,6 +140,7 @@ module scalingplan_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: scalingPlan.id
   }

--- a/arm/Microsoft.DesktopVirtualization/scalingplans/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/scalingplans/readme.md
@@ -99,6 +99,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -114,7 +116,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -34,6 +35,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: workspace
 }]

--- a/arm/Microsoft.DesktopVirtualization/workspaces/deploy.bicep
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/deploy.bicep
@@ -122,6 +122,7 @@ module workspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: workspace.id
   }

--- a/arm/Microsoft.DesktopVirtualization/workspaces/readme.md
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/readme.md
@@ -35,6 +35,8 @@ This module deploys an Azure virtual desktop workspace.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -50,7 +52,8 @@ This module deploys an Azure virtual desktop workspace.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: databaseAccount
 }]

--- a/arm/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
@@ -243,6 +243,7 @@ module databaseAccount_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: databaseAccount.id
   }

--- a/arm/Microsoft.DocumentDB/databaseAccounts/readme.md
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/readme.md
@@ -47,6 +47,8 @@ This module deploys a DocumentDB database account and its child resources.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -62,7 +64,8 @@ This module deploys a DocumentDB database account and its child resources.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }
@@ -144,6 +147,8 @@ Please reference the documentation for [mongodbDatabases](./mongodbDatabases/rea
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -165,7 +170,8 @@ Please reference the documentation for [mongodbDatabases](./mongodbDatabases/rea
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: systemTopic
 }]

--- a/arm/Microsoft.EventGrid/systemTopics/deploy.bicep
+++ b/arm/Microsoft.EventGrid/systemTopics/deploy.bicep
@@ -158,6 +158,7 @@ module systemTopic_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: systemTopic.id
   }

--- a/arm/Microsoft.EventGrid/systemTopics/readme.md
+++ b/arm/Microsoft.EventGrid/systemTopics/readme.md
@@ -75,6 +75,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -90,7 +92,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: eventGrid
 }]

--- a/arm/Microsoft.EventGrid/topics/deploy.bicep
+++ b/arm/Microsoft.EventGrid/topics/deploy.bicep
@@ -146,6 +146,7 @@ module eventGrid_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: eventGrid.id
   }

--- a/arm/Microsoft.EventGrid/topics/readme.md
+++ b/arm/Microsoft.EventGrid/topics/readme.md
@@ -73,6 +73,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -88,7 +90,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -34,6 +35,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: eventHubNamespace
 }]

--- a/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.EventHub/namespaces/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/deploy.bicep
@@ -290,6 +290,7 @@ module eventHubNamespace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment,
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: eventHubNamespace.id
   }

--- a/arm/Microsoft.EventHub/namespaces/eventhubs/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventHub/namespaces/eventhubs/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.EventHub/namespaces/eventhubs/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventHub/namespaces/eventhubs/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: eventHub
 }]

--- a/arm/Microsoft.EventHub/namespaces/eventhubs/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/eventhubs/deploy.bicep
@@ -178,6 +178,7 @@ module eventHub_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: eventHub.id
   }

--- a/arm/Microsoft.EventHub/namespaces/eventhubs/readme.md
+++ b/arm/Microsoft.EventHub/namespaces/eventhubs/readme.md
@@ -38,6 +38,8 @@ This module deploys an Event Hub.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -53,7 +55,8 @@ This module deploys an Event Hub.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.EventHub/namespaces/readme.md
+++ b/arm/Microsoft.EventHub/namespaces/readme.md
@@ -89,6 +89,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -104,7 +106,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: healthBot
 }]

--- a/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.HealthBot/healthBots/deploy.bicep
+++ b/arm/Microsoft.HealthBot/healthBots/deploy.bicep
@@ -60,6 +60,7 @@ module healthBot_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: azureHealthBot.id
   }

--- a/arm/Microsoft.HealthBot/healthBots/readme.md
+++ b/arm/Microsoft.HealthBot/healthBots/readme.md
@@ -41,6 +41,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -56,7 +58,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: actionGroup
 }]

--- a/arm/Microsoft.Insights/actionGroups/deploy.bicep
+++ b/arm/Microsoft.Insights/actionGroups/deploy.bicep
@@ -86,6 +86,7 @@ module actionGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: actionGroup.id
   }

--- a/arm/Microsoft.Insights/actionGroups/readme.md
+++ b/arm/Microsoft.Insights/actionGroups/readme.md
@@ -65,6 +65,8 @@ Example:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -80,7 +82,8 @@ Example:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: activityLogAlert
 }]

--- a/arm/Microsoft.Insights/activityLogAlerts/deploy.bicep
+++ b/arm/Microsoft.Insights/activityLogAlerts/deploy.bicep
@@ -69,6 +69,7 @@ module activityLogAlert_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: activityLogAlert.id
   }

--- a/arm/Microsoft.Insights/activityLogAlerts/readme.md
+++ b/arm/Microsoft.Insights/activityLogAlerts/readme.md
@@ -131,6 +131,8 @@ Each condition can specify only one field between `equals` and `containsAny`.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -146,7 +148,8 @@ Each condition can specify only one field between `equals` and `containsAny`.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: appInsights
 }]

--- a/arm/Microsoft.Insights/components/deploy.bicep
+++ b/arm/Microsoft.Insights/components/deploy.bicep
@@ -70,6 +70,7 @@ module appInsights_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: appInsights.id
   }

--- a/arm/Microsoft.Insights/components/readme.md
+++ b/arm/Microsoft.Insights/components/readme.md
@@ -24,6 +24,8 @@
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -39,7 +41,8 @@
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: metricAlert
 }]

--- a/arm/Microsoft.Insights/metricAlerts/deploy.bicep
+++ b/arm/Microsoft.Insights/metricAlerts/deploy.bicep
@@ -124,6 +124,7 @@ module metricAlert_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: metricAlert.id
   }

--- a/arm/Microsoft.Insights/metricAlerts/readme.md
+++ b/arm/Microsoft.Insights/metricAlerts/readme.md
@@ -115,6 +115,8 @@ The following sample can be use both for Single and Multiple criterias. The othe
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -130,7 +132,8 @@ The following sample can be use both for Single and Multiple criterias. The othe
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: privateLinkScope
 }]

--- a/arm/Microsoft.Insights/privateLinkScopes/deploy.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/deploy.bicep
@@ -80,6 +80,7 @@ module privateLinkScope_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: privateLinkScope.id
   }

--- a/arm/Microsoft.Insights/privateLinkScopes/readme.md
+++ b/arm/Microsoft.Insights/privateLinkScopes/readme.md
@@ -28,6 +28,8 @@ This module deploys an Azure Monitor Private Link Scope.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -43,7 +45,8 @@ This module deploys an Azure Monitor Private Link Scope.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: queryAlert
 }]

--- a/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/deploy.bicep
@@ -110,6 +110,7 @@ module queryRule_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: queryRule.id
   }

--- a/arm/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/arm/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -35,6 +35,8 @@ This module deploys a scheduled query rule.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -50,7 +52,8 @@ This module deploys a scheduled query rule.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -38,6 +39,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: keyVault
 }]

--- a/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -277,6 +277,7 @@ module keyVault_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: keyVault.id
   }

--- a/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: key
 }]

--- a/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/deploy.bicep
@@ -93,6 +93,7 @@ module key_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in rol
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: key.id
   }

--- a/arm/Microsoft.KeyVault/vaults/keys/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/keys/readme.md
@@ -45,6 +45,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -60,7 +62,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -53,6 +53,8 @@ This module deploys a key vault and its child resources.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -68,7 +70,8 @@ This module deploys a key vault and its child resources.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: secret
 }]

--- a/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/deploy.bicep
@@ -66,6 +66,7 @@ module secret_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: secret.id
   }

--- a/arm/Microsoft.KeyVault/vaults/secrets/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/secrets/readme.md
@@ -43,6 +43,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -58,7 +60,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: logicApp
 }]

--- a/arm/Microsoft.Logic/workflows/deploy.bicep
+++ b/arm/Microsoft.Logic/workflows/deploy.bicep
@@ -217,6 +217,7 @@ module logicApp_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: logicApp.id
   }

--- a/arm/Microsoft.Logic/workflows/readme.md
+++ b/arm/Microsoft.Logic/workflows/readme.md
@@ -102,6 +102,8 @@ This module deploys a Logic App resource.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -117,7 +119,8 @@ This module deploys a Logic App resource.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: workspace
 }]

--- a/arm/Microsoft.MachineLearningServices/workspaces/deploy.bicep
+++ b/arm/Microsoft.MachineLearningServices/workspaces/deploy.bicep
@@ -190,6 +190,7 @@ module workspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: workspace.id
   }

--- a/arm/Microsoft.MachineLearningServices/workspaces/readme.md
+++ b/arm/Microsoft.MachineLearningServices/workspaces/readme.md
@@ -43,6 +43,8 @@ This module deploys a Machine Learning Services Workspace.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -58,7 +60,8 @@ This module deploys a Machine Learning Services Workspace.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: userMsi
 }]

--- a/arm/Microsoft.ManagedIdentity/userAssignedIdentities/deploy.bicep
+++ b/arm/Microsoft.ManagedIdentity/userAssignedIdentities/deploy.bicep
@@ -53,6 +53,7 @@ module userMsi_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: userMsi.id
   }

--- a/arm/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
+++ b/arm/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
@@ -23,6 +23,8 @@ This module deploys a user assigned identity.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -38,7 +40,8 @@ This module deploys a user assigned identity.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Management/managementGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Management/managementGroups/.bicep/nested_rbac.bicep
@@ -295,5 +295,6 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
 }]

--- a/arm/Microsoft.Management/managementGroups/deploy.bicep
+++ b/arm/Microsoft.Management/managementGroups/deploy.bicep
@@ -49,6 +49,7 @@ module managementGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceName: managementGroup.name
   }

--- a/arm/Microsoft.Management/managementGroups/readme.md
+++ b/arm/Microsoft.Management/managementGroups/readme.md
@@ -27,6 +27,8 @@ This module has some known **limitations**:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -42,7 +44,8 @@ This module has some known **limitations**:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: netAppAccount
 }]

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: capacityPool
 }]

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/deploy.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/deploy.bicep
@@ -93,6 +93,7 @@ module capacityPool_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, inde
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: capacityPool.id
   }

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
@@ -45,6 +45,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -60,7 +62,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: volume
 }]

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/deploy.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/deploy.bicep
@@ -81,6 +81,7 @@ module volume_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: volume.id
   }

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/readme.md
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/readme.md
@@ -28,6 +28,8 @@ This template deploys volumes in a capacity pool of an Azure NetApp files.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -43,7 +45,8 @@ This template deploys volumes in a capacity pool of an Azure NetApp files.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.NetApp/netAppAccounts/deploy.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/deploy.bicep
@@ -89,6 +89,7 @@ module netAppAccount_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: netAppAccount.id
   }

--- a/arm/Microsoft.NetApp/netAppAccounts/readme.md
+++ b/arm/Microsoft.NetApp/netAppAccounts/readme.md
@@ -32,6 +32,8 @@ This template deploys Azure NetApp Files.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -47,7 +49,8 @@ This template deploys Azure NetApp Files.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: applicationGateway
 }]

--- a/arm/Microsoft.Network/applicationGateways/deploy.bicep
+++ b/arm/Microsoft.Network/applicationGateways/deploy.bicep
@@ -347,6 +347,7 @@ module applicationGateway_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: applicationGateway.id
   }

--- a/arm/Microsoft.Network/applicationGateways/readme.md
+++ b/arm/Microsoft.Network/applicationGateways/readme.md
@@ -604,6 +604,8 @@ This module deploys Network ApplicationGateways.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -619,7 +621,8 @@ This module deploys Network ApplicationGateways.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: applicationSecurityGroup
 }]

--- a/arm/Microsoft.Network/applicationSecurityGroups/deploy.bicep
+++ b/arm/Microsoft.Network/applicationSecurityGroups/deploy.bicep
@@ -54,6 +54,7 @@ module applicationSecurityGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssi
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: applicationSecurityGroup.id
   }

--- a/arm/Microsoft.Network/applicationSecurityGroups/readme.md
+++ b/arm/Microsoft.Network/applicationSecurityGroups/readme.md
@@ -40,6 +40,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -55,7 +57,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: azureFirewall
 }]

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -196,6 +196,7 @@ module azureFirewall_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: azureFirewall.id
   }

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -41,6 +41,8 @@ This module deploys a firewall.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -56,7 +58,8 @@ This module deploys a firewall.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress.bicep
@@ -137,6 +137,7 @@ module publicIpAddress_rbac 'nested_publicIPAddress_rbac.bicep' = [for (roleAssi
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: publicIpAddress.id
   }

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -37,6 +38,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: publicIpAddress
 }]

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: azureBastion
 }]

--- a/arm/Microsoft.Network/bastionHosts/deploy.bicep
+++ b/arm/Microsoft.Network/bastionHosts/deploy.bicep
@@ -181,6 +181,7 @@ module azureBastion_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, inde
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: azureBastion.id
   }

--- a/arm/Microsoft.Network/bastionHosts/readme.md
+++ b/arm/Microsoft.Network/bastionHosts/readme.md
@@ -54,6 +54,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -69,7 +71,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: ddosProtectionPlan
 }]

--- a/arm/Microsoft.Network/ddosProtectionPlans/deploy.bicep
+++ b/arm/Microsoft.Network/ddosProtectionPlans/deploy.bicep
@@ -55,6 +55,7 @@ module ddosProtectionPlan_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: ddosProtectionPlan.id
   }

--- a/arm/Microsoft.Network/ddosProtectionPlans/readme.md
+++ b/arm/Microsoft.Network/ddosProtectionPlans/readme.md
@@ -23,6 +23,8 @@ This template deploys a DDoS protection plan.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -38,7 +40,8 @@ This template deploys a DDoS protection plan.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: expressRouteCircuits
 }]

--- a/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/expressRouteCircuits/deploy.bicep
+++ b/arm/Microsoft.Network/expressRouteCircuits/deploy.bicep
@@ -201,6 +201,7 @@ module expressRouteCircuits_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignme
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: expressRouteCircuits.id
   }

--- a/arm/Microsoft.Network/expressRouteCircuits/readme.md
+++ b/arm/Microsoft.Network/expressRouteCircuits/readme.md
@@ -44,6 +44,8 @@ This template deploys an express route circuit.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -59,7 +61,8 @@ This template deploys an express route circuit.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: frontDoor
 }]

--- a/arm/Microsoft.Network/frontDoors/deploy.bicep
+++ b/arm/Microsoft.Network/frontDoors/deploy.bicep
@@ -162,6 +162,7 @@ module frontDoor_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: frontDoor.id
   }

--- a/arm/Microsoft.Network/frontDoors/readme.md
+++ b/arm/Microsoft.Network/frontDoors/readme.md
@@ -44,6 +44,8 @@ This module deploys Network FrontDoors.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -59,7 +61,8 @@ This module deploys Network FrontDoors.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: ipGroup
 }]

--- a/arm/Microsoft.Network/ipGroups/deploy.bicep
+++ b/arm/Microsoft.Network/ipGroups/deploy.bicep
@@ -60,6 +60,7 @@ module ipGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: ipGroup.id
   }

--- a/arm/Microsoft.Network/ipGroups/readme.md
+++ b/arm/Microsoft.Network/ipGroups/readme.md
@@ -24,6 +24,8 @@ This module deploys an IP group.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -39,7 +41,8 @@ This module deploys an IP group.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -35,6 +36,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: loadBalancer
 }]

--- a/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/loadBalancers/deploy.bicep
+++ b/arm/Microsoft.Network/loadBalancers/deploy.bicep
@@ -247,6 +247,7 @@ module loadBalancer_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, inde
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: loadBalancer.id
   }

--- a/arm/Microsoft.Network/loadBalancers/readme.md
+++ b/arm/Microsoft.Network/loadBalancers/readme.md
@@ -170,6 +170,8 @@ This module deploys a load balancer.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -185,7 +187,8 @@ This module deploys a load balancer.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: localNetworkGateway
 }]

--- a/arm/Microsoft.Network/localNetworkGateways/deploy.bicep
+++ b/arm/Microsoft.Network/localNetworkGateways/deploy.bicep
@@ -86,6 +86,7 @@ module localNetworkGateway_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignmen
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: localNetworkGateway.id
   }

--- a/arm/Microsoft.Network/localNetworkGateways/readme.md
+++ b/arm/Microsoft.Network/localNetworkGateways/readme.md
@@ -29,6 +29,8 @@ This module deploys a local network gateway.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -44,7 +46,8 @@ This module deploys a local network gateway.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: natGateway
 }]

--- a/arm/Microsoft.Network/natGateways/deploy.bicep
+++ b/arm/Microsoft.Network/natGateways/deploy.bicep
@@ -198,6 +198,7 @@ module natGateway_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index)
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: natGateway.id
   }

--- a/arm/Microsoft.Network/natGateways/readme.md
+++ b/arm/Microsoft.Network/natGateways/readme.md
@@ -41,6 +41,8 @@ This module deploys a NAT gateway.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -56,7 +58,8 @@ This module deploys a NAT gateway.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -34,6 +35,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: networkSecurityGroup
 }]

--- a/arm/Microsoft.Network/networkSecurityGroups/deploy.bicep
+++ b/arm/Microsoft.Network/networkSecurityGroups/deploy.bicep
@@ -152,6 +152,7 @@ module networkSecurityGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignme
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: networkSecurityGroup.id
   }

--- a/arm/Microsoft.Network/networkSecurityGroups/readme.md
+++ b/arm/Microsoft.Network/networkSecurityGroups/readme.md
@@ -33,6 +33,8 @@ This template deploys a network security group (NSG) with optional security rule
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -48,7 +50,8 @@ This template deploys a network security group (NSG) with optional security rule
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: networkWatcher
 }]

--- a/arm/Microsoft.Network/networkWatchers/deploy.bicep
+++ b/arm/Microsoft.Network/networkWatchers/deploy.bicep
@@ -61,6 +61,7 @@ module networkWatcher_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: networkWatcher.id
   }

--- a/arm/Microsoft.Network/networkWatchers/readme.md
+++ b/arm/Microsoft.Network/networkWatchers/readme.md
@@ -28,6 +28,8 @@ This template deploys a network watcher.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -43,7 +45,8 @@ This template deploys a network watcher.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: privateDnsZone
 }]

--- a/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/privateDnsZones/deploy.bicep
+++ b/arm/Microsoft.Network/privateDnsZones/deploy.bicep
@@ -180,6 +180,7 @@ module privateDnsZone_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: privateDnsZone.id
   }

--- a/arm/Microsoft.Network/privateDnsZones/readme.md
+++ b/arm/Microsoft.Network/privateDnsZones/readme.md
@@ -41,6 +41,8 @@ This template deploys a private DNS zone.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -56,7 +58,8 @@ This template deploys a private DNS zone.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: privateEndpoint
 }]

--- a/arm/Microsoft.Network/privateEndpoints/deploy.bicep
+++ b/arm/Microsoft.Network/privateEndpoints/deploy.bicep
@@ -89,6 +89,7 @@ module privateEndpoint_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: privateEndpoint.id
   }

--- a/arm/Microsoft.Network/privateEndpoints/readme.md
+++ b/arm/Microsoft.Network/privateEndpoints/readme.md
@@ -55,6 +55,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -70,7 +72,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -35,6 +36,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: publicIpAddress
 }]

--- a/arm/Microsoft.Network/publicIPAddresses/deploy.bicep
+++ b/arm/Microsoft.Network/publicIPAddresses/deploy.bicep
@@ -175,6 +175,7 @@ module publicIpAddress_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: publicIpAddress.id
   }

--- a/arm/Microsoft.Network/publicIPAddresses/readme.md
+++ b/arm/Microsoft.Network/publicIPAddresses/readme.md
@@ -53,6 +53,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -68,7 +70,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: publicIpPrefix
 }]

--- a/arm/Microsoft.Network/publicIPPrefixes/deploy.bicep
+++ b/arm/Microsoft.Network/publicIPPrefixes/deploy.bicep
@@ -66,6 +66,7 @@ module publicIpPrefix_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: publicIpPrefix.id
   }

--- a/arm/Microsoft.Network/publicIPPrefixes/readme.md
+++ b/arm/Microsoft.Network/publicIPPrefixes/readme.md
@@ -24,6 +24,8 @@ This template deploys a public IP prefix.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -39,7 +41,8 @@ This template deploys a public IP prefix.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: routeTable
 }]

--- a/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/routeTables/deploy.bicep
+++ b/arm/Microsoft.Network/routeTables/deploy.bicep
@@ -63,6 +63,7 @@ module routeTable_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index)
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: routeTable.id
   }

--- a/arm/Microsoft.Network/routeTables/readme.md
+++ b/arm/Microsoft.Network/routeTables/readme.md
@@ -67,6 +67,8 @@ Here's an example of specifying a few routes:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -82,7 +84,8 @@ Here's an example of specifying a few routes:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: trafficmanagerprofile
 }]

--- a/arm/Microsoft.Network/trafficmanagerprofiles/deploy.bicep
+++ b/arm/Microsoft.Network/trafficmanagerprofiles/deploy.bicep
@@ -175,6 +175,7 @@ module trafficManagerProfile_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignm
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: trafficManagerProfile.id
   }

--- a/arm/Microsoft.Network/trafficmanagerprofiles/readme.md
+++ b/arm/Microsoft.Network/trafficmanagerprofiles/readme.md
@@ -77,6 +77,8 @@ This module deploys a traffic manager profile.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -92,7 +94,8 @@ This module deploys a traffic manager profile.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: virtualNetworkGateway
 }]

--- a/arm/Microsoft.Network/virtualNetworkGateways/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworkGateways/deploy.bicep
@@ -384,6 +384,7 @@ module virtualNetworkGateway_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignm
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: virtualNetworkGateway.id
   }

--- a/arm/Microsoft.Network/virtualNetworkGateways/readme.md
+++ b/arm/Microsoft.Network/virtualNetworkGateways/readme.md
@@ -80,6 +80,8 @@ Here's an example of specifying a couple Subnets to deploy:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -95,7 +97,8 @@ Here's an example of specifying a couple Subnets to deploy:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -46,6 +47,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: virtualNetwork
 }]

--- a/arm/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -240,6 +240,7 @@ module virtualNetwork_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: virtualNetwork.id
   }

--- a/arm/Microsoft.Network/virtualNetworks/readme.md
+++ b/arm/Microsoft.Network/virtualNetworks/readme.md
@@ -124,6 +124,8 @@ Here's an example of specifying a single Address Prefix:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -139,7 +141,8 @@ Here's an example of specifying a single Address Prefix:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: virtualWan
 }]

--- a/arm/Microsoft.Network/virtualWans/deploy.bicep
+++ b/arm/Microsoft.Network/virtualWans/deploy.bicep
@@ -75,6 +75,7 @@ module virtualWan_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index)
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: virtualWan.id
   }

--- a/arm/Microsoft.Network/virtualWans/readme.md
+++ b/arm/Microsoft.Network/virtualWans/readme.md
@@ -27,6 +27,8 @@ This template deploys a virtual WAN.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -42,7 +44,8 @@ This template deploys a virtual WAN.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Network/vpnSites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/vpnSites/.bicep/nested_rbac.bicep
@@ -1,4 +1,5 @@
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: vpnSite
 }]

--- a/arm/Microsoft.Network/vpnSites/readme.md
+++ b/arm/Microsoft.Network/vpnSites/readme.md
@@ -113,6 +113,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -128,7 +130,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: logAnalyticsWorkspace
 }]

--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -254,6 +254,7 @@ module logAnalyticsWorkspace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignm
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: logAnalyticsWorkspace.id
   }

--- a/arm/Microsoft.OperationalInsights/workspaces/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/readme.md
@@ -178,6 +178,8 @@ This template deploys a log analytics workspace.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -193,7 +195,8 @@ This template deploys a log analytics workspace.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -36,6 +37,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: rsv
 }]

--- a/arm/Microsoft.RecoveryServices/vaults/deploy.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/deploy.bicep
@@ -256,6 +256,7 @@ module rsv_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in rol
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: rsv.id
   }

--- a/arm/Microsoft.RecoveryServices/vaults/readme.md
+++ b/arm/Microsoft.RecoveryServices/vaults/readme.md
@@ -59,6 +59,8 @@ This module deploys a recovery service vault.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -74,7 +76,8 @@ This module deploys a recovery service vault.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Resources/resourceGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Resources/resourceGroups/.bicep/nested_rbac.bicep
@@ -185,5 +185,6 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
 }]

--- a/arm/Microsoft.Resources/resourceGroups/deploy.bicep
+++ b/arm/Microsoft.Resources/resourceGroups/deploy.bicep
@@ -57,6 +57,7 @@ module resourceGroup_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceGroupName: resourceGroup.name
   }

--- a/arm/Microsoft.Resources/resourceGroups/readme.md
+++ b/arm/Microsoft.Resources/resourceGroups/readme.md
@@ -23,6 +23,8 @@ This module deploys a resource group.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -38,7 +40,8 @@ This module deploys a resource group.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: namespace
 }]

--- a/arm/Microsoft.ServiceBus/namespaces/deploy.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/deploy.bicep
@@ -315,6 +315,7 @@ module serviceBusNamespace_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignmen
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: serviceBusNamespace.id
   }

--- a/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssigment 'Microsoft.Authorization/roleAssignments@2021-04-01-previ
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: queue
 }]

--- a/arm/Microsoft.ServiceBus/namespaces/queues/deploy.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/queues/deploy.bicep
@@ -142,6 +142,7 @@ module queue_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: queue.id
   }

--- a/arm/Microsoft.ServiceBus/namespaces/queues/readme.md
+++ b/arm/Microsoft.ServiceBus/namespaces/queues/readme.md
@@ -36,6 +36,8 @@ This module deploys a queue for a service bus namespace.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -51,7 +53,8 @@ This module deploys a queue for a service bus namespace.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ServiceBus/namespaces/readme.md
+++ b/arm/Microsoft.ServiceBus/namespaces/readme.md
@@ -56,6 +56,8 @@ This module deploys a service bus namespace resource.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -71,7 +73,8 @@ This module deploys a service bus namespace resource.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssigment 'Microsoft.Authorization/roleAssignments@2021-04-01-previ
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: topic
 }]

--- a/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ServiceBus/namespaces/topics/deploy.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/topics/deploy.bicep
@@ -138,6 +138,7 @@ module topic_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: topic.id
   }

--- a/arm/Microsoft.ServiceBus/namespaces/topics/readme.md
+++ b/arm/Microsoft.ServiceBus/namespaces/topics/readme.md
@@ -35,6 +35,8 @@ This module deploys a topic for a service bus namespace.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -50,7 +52,8 @@ This module deploys a topic for a service bus namespace.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: serviceFabricCluster
 }]

--- a/arm/Microsoft.ServiceFabric/clusters/deploy.bicep
+++ b/arm/Microsoft.ServiceFabric/clusters/deploy.bicep
@@ -293,6 +293,7 @@ module serviceFabricCluster_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignme
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: serviceFabricCluster.id
   }

--- a/arm/Microsoft.ServiceFabric/clusters/readme.md
+++ b/arm/Microsoft.ServiceFabric/clusters/readme.md
@@ -74,6 +74,8 @@ This module deploys a service fabric cluster.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -89,7 +91,8 @@ This module deploys a service fabric cluster.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -32,6 +33,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: managedInstance
 }]

--- a/arm/Microsoft.Sql/managedInstances/deploy.bicep
+++ b/arm/Microsoft.Sql/managedInstances/deploy.bicep
@@ -273,6 +273,7 @@ module managedInstance_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, i
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: managedInstance.id
   }

--- a/arm/Microsoft.Sql/managedInstances/readme.md
+++ b/arm/Microsoft.Sql/managedInstances/readme.md
@@ -93,6 +93,8 @@ SQL MI allows for Azure AD Authentication via an [Azure AD Admin](https://docs.m
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -108,7 +110,8 @@ SQL MI allows for Azure AD Authentication via an [Azure AD Admin](https://docs.m
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: server
 }]

--- a/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Sql/servers/deploy.bicep
+++ b/arm/Microsoft.Sql/servers/deploy.bicep
@@ -99,6 +99,7 @@ module server_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: server.id
   }

--- a/arm/Microsoft.Sql/servers/readme.md
+++ b/arm/Microsoft.Sql/servers/readme.md
@@ -35,6 +35,8 @@ This module deploys a SQL server.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -50,7 +52,8 @@ This module deploys a SQL server.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -56,6 +57,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: storageAccount
 }]

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -47,6 +48,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: container
 }]

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/deploy.bicep
@@ -72,6 +72,7 @@ module container_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: container.id
   }

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/readme.md
@@ -38,6 +38,8 @@ This module deploys a blob container
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -53,7 +55,8 @@ This module deploys a blob container
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -247,6 +247,7 @@ module storageAccount_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: storageAccount.id
   }

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -56,6 +57,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: fileShare
 }]

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
@@ -67,6 +67,7 @@ module fileShare_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) 
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: fileShare.id
   }

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
@@ -37,6 +37,8 @@ This module deploys a storage account file share.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -52,7 +54,8 @@ This module deploys a storage account file share.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -53,6 +54,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: queue
 }]

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/deploy.bicep
@@ -50,6 +50,7 @@ module queue_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in r
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: '${queue.id}'
   }

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/readme.md
@@ -35,6 +35,8 @@ This module deploys a storage account queue
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -50,7 +52,8 @@ This module deploys a storage account queue
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Storage/storageAccounts/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/readme.md
@@ -78,6 +78,8 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -93,7 +95,8 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: privateLinkHub
 }]

--- a/arm/Microsoft.Synapse/privateLinkHubs/deploy.bicep
+++ b/arm/Microsoft.Synapse/privateLinkHubs/deploy.bicep
@@ -58,6 +58,7 @@ module privateLinkHub_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: privateLinkHub.id
   }

--- a/arm/Microsoft.Synapse/privateLinkHubs/readme.md
+++ b/arm/Microsoft.Synapse/privateLinkHubs/readme.md
@@ -62,6 +62,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -77,7 +79,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -29,6 +30,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: imageTemplate
 }]

--- a/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.VirtualMachineImages/imageTemplates/deploy.bicep
+++ b/arm/Microsoft.VirtualMachineImages/imageTemplates/deploy.bicep
@@ -169,6 +169,7 @@ module imageTemplate_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: imageTemplate.id
   }

--- a/arm/Microsoft.VirtualMachineImages/imageTemplates/readme.md
+++ b/arm/Microsoft.VirtualMachineImages/imageTemplates/readme.md
@@ -87,6 +87,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -102,7 +104,8 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: connection
 }]

--- a/arm/Microsoft.Web/connections/deploy.bicep
+++ b/arm/Microsoft.Web/connections/deploy.bicep
@@ -96,6 +96,7 @@ module connection_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index)
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: connection.id
   }

--- a/arm/Microsoft.Web/connections/readme.md
+++ b/arm/Microsoft.Web/connections/readme.md
@@ -33,6 +33,8 @@ This module deploys an Azure API connection.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -48,7 +50,8 @@ This module deploys an Azure API connection.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -30,6 +31,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: appServiceEnvironment
 }]

--- a/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Web/hostingEnvironments/deploy.bicep
+++ b/arm/Microsoft.Web/hostingEnvironments/deploy.bicep
@@ -193,6 +193,7 @@ module appServiceEnvironment_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignm
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: appServiceEnvironment.id
   }

--- a/arm/Microsoft.Web/hostingEnvironments/readme.md
+++ b/arm/Microsoft.Web/hostingEnvironments/readme.md
@@ -47,6 +47,8 @@ This module deploys an app service environment.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -62,7 +64,8 @@ This module deploys an app service environment.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -33,6 +34,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: appServicePlan
 }]

--- a/arm/Microsoft.Web/serverfarms/deploy.bicep
+++ b/arm/Microsoft.Web/serverfarms/deploy.bicep
@@ -103,6 +103,7 @@ module appServicePlan_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: appServicePlan.id
   }

--- a/arm/Microsoft.Web/serverfarms/readme.md
+++ b/arm/Microsoft.Web/serverfarms/readme.md
@@ -45,6 +45,8 @@ This module deploys an app service plan.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -60,7 +62,8 @@ This module deploys an app service plan.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
@@ -1,8 +1,25 @@
-param description string = ''
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
 param principalIds array
-param principalType string = ''
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
 param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
 param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
 
 var builtInRoleNames = {
   'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')

--- a/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
@@ -1,5 +1,6 @@
 param description string = ''
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -31,6 +32,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: app
 }]

--- a/arm/Microsoft.Web/sites/deploy.bicep
+++ b/arm/Microsoft.Web/sites/deploy.bicep
@@ -229,6 +229,7 @@ module app_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in rol
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     resourceId: app.id
   }

--- a/arm/Microsoft.Web/sites/readme.md
+++ b/arm/Microsoft.Web/sites/readme.md
@@ -86,6 +86,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -101,7 +103,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/arm/Microsoft.Web/staticSites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/staticSites/.bicep/nested_rbac.bicep
@@ -1,21 +1,22 @@
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
 var builtInRoleNames = {
-  'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
-  'Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','b24988ac-6180-42a0-ab88-20f7382dd24c')
-  'Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','acdd72a7-3385-48ef-bd42-f606fba81ae7')
-  'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','92aaf0da-9dab-42b6-94a3-d43ce8d16293')
-  'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','73c42c96-874c-492b-b04d-ab87d138a893')
-  'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','641177b8-a67a-45b9-a033-47bc880bb21e')
-  'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','c7393b34-138c-406f-901b-d8cf2b17e6ae')
-  'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','b9331d33-8a36-4f8c-b097-4f54124fdb44')
-  'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','749f88d5-cbae-40b8-bcfc-e573ddc772fa')
-  'Monitoring Metrics Publisher': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','3913510d-42f4-4e42-8a64-420c390055eb')
-  'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','43d0d8ad-25c7-4714-9337-8ba259a9fe05')
-  'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','36243c78-bf99-498c-9df9-86d9f8d28608')
-  'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
+  'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  'Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  'Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
+  'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')
+  'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')
+  'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')
+  'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')
+  'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')
+  'Monitoring Metrics Publisher': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')
+  'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
+  'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')
+  'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
 }
 
 resource staticSite 'Microsoft.Web/staticSites@2021-02-01' existing = {
@@ -27,6 +28,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: staticSite
 }]

--- a/arm/Microsoft.Web/staticSites/readme.md
+++ b/arm/Microsoft.Web/staticSites/readme.md
@@ -108,6 +108,8 @@ To use Private Endpoint the following dependencies must be deployed:
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -123,7 +125,8 @@ To use Private Endpoint the following dependencies must be deployed:
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/constructs/Microsoft.Authorization/roleAssignments-multiRolesMultiPrincipals/readme.md
+++ b/constructs/Microsoft.Authorization/roleAssignments-multiRolesMultiPrincipals/readme.md
@@ -21,6 +21,8 @@ This module deploys Role Assignments.
 
 ### Parameter Usage: `roleAssignments`
 
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to 'ServicePrincipal'. This will ensure the role assignment waits for the principal's propagation in Azure.
+
 ```json
 "roleAssignments": {
     "value": [
@@ -36,7 +38,8 @@ This module deploys Role Assignments.
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }

--- a/docs/wiki/ModulesDesign.md
+++ b/docs/wiki/ModulesDesign.md
@@ -183,6 +183,7 @@ The element requires you to provide both the `principalIds` & `roleDefinitionOrI
 
 ```bicep
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -208,6 +209,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: <mainResource>
 }]

--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -174,7 +174,7 @@ module <mainResource>_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, in
 
 Here you specify the platform roles available for the main resource.
 
-The `builtInRoleNames` variable contains the list of applicable roles for the specific resource to which the nested_rbac.bicep module applies.
+The `builtInRoleNames` variable contains the list of applicable roles for the specific resource which the `nested_rbac.bicep` template applies.
 >**Note**: You use the helper script [Get-FormattedRBACRoles.ps1](./Contribution%20guide%20-%20Get%20formatted%20RBAC%20roles) to extract a formatted list of RBAC roles used in the CARML modules based on the RBAC lists in Azure.
 
 The element requires you to provide both the `principalIds` & `roleDefinitionOrIdName` to assign to the principal IDs. Also, the `resourceId` is target resource's resource ID that allows us to reference it as an `existing` resource. Note, the implementation of the `split` in the resource reference becomes longer the deeper you go in the child-resource hierarchy.

--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -181,6 +181,7 @@ The element requires you to provide both the `principalIds` & `roleDefinitionOrI
 
 ```bicep
 param principalIds array
+param principalType string = ''
 param roleDefinitionIdOrName string
 param resourceId string
 
@@ -206,6 +207,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-prev
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
   }
   scope: <mainResource>
 }]

--- a/utilities/tools/moduleReadMeSource/resourceUsage-roleAssignments.md
+++ b/utilities/tools/moduleReadMeSource/resourceUsage-roleAssignments.md
@@ -13,7 +13,8 @@
             "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
             "principalIds": [
                 "12345678-1234-1234-1234-123456789012" // object 1
-            ]
+            ],
+            "principalType": "ServicePrincipal"
         }
     ]
 }


### PR DESCRIPTION
# Change

- Added principal type to RBAC
- Extended RBAC example in ReadMe

Pipeline reference:
[![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2F1178_rbacPrincipalType)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)
[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2F1178_rbacPrincipalType)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
