### PR TITLE
Added some defaults to osDisk and dataDisks for VM

### DIFF
--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.min.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.min.parameters.json
@@ -18,8 +18,6 @@
         },
         "osDisk": {
             "value": {
-                "createOption": "fromImage",
-                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
@@ -34,6 +34,7 @@
             "value": {
                 "createOption": "fromImage",
                 "deleteOption": "Delete",
+                "caching": "ReadOnly",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"
@@ -45,6 +46,7 @@
                 {
                     "createOption": "Empty",
                     "deleteOption": "Delete",
+                    "caching": "ReadWrite",
                     "diskSizeGB": "128",
                     "managedDisk": {
                         "storageAccountType": "Premium_LRS"
@@ -53,6 +55,7 @@
                 {
                     "createOption": "Empty",
                     "deleteOption": "Delete",
+                    "caching": "ReadWrite",
                     "diskSizeGB": "128",
                     "managedDisk": {
                         "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/linux.parameters.json
@@ -40,6 +40,26 @@
                 }
             }
         },
+        "dataDisks": {
+            "value": [
+                {
+                    "createOption": "Empty",
+                    "deleteOption": "Delete",
+                    "diskSizeGB": "128",
+                    "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                    }
+                },
+                {
+                    "createOption": "Empty",
+                    "deleteOption": "Delete",
+                    "diskSizeGB": "128",
+                    "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                    }
+                }
+            ]
+        },
         "adminUsername": {
             "value": "localAdminUser"
         },

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.min.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.min.parameters.json
@@ -15,8 +15,6 @@
         },
         "osDisk": {
             "value": {
-                "createOption": "fromImage",
-                "deleteOption": "Delete",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
@@ -29,6 +29,26 @@
                 }
             }
         },
+        "dataDisks": {
+            "value": [
+                {
+                    "createOption": "Empty",
+                    "deleteOption": "Delete",
+                    "diskSizeGB": "128",
+                    "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                    }
+                },
+                {
+                    "createOption": "Empty",
+                    "deleteOption": "Delete",
+                    "diskSizeGB": "128",
+                    "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                    }
+                }
+            ]
+        },
         "availabilityZone": {
             "value": 2
         },
@@ -73,7 +93,6 @@
                                     "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"
                                 }
                             ]
-
                         }
                     ],
                     "roleAssignments": [

--- a/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
+++ b/arm/Microsoft.Compute/virtualMachines/.parameters/windows.parameters.json
@@ -23,6 +23,7 @@
             "value": {
                 "createOption": "fromImage",
                 "deleteOption": "Delete",
+                "caching": "None",
                 "diskSizeGB": "128",
                 "managedDisk": {
                     "storageAccountType": "Premium_LRS"
@@ -34,6 +35,7 @@
                 {
                     "createOption": "Empty",
                     "deleteOption": "Delete",
+                    "caching": "None",
                     "diskSizeGB": "128",
                     "managedDisk": {
                         "storageAccountType": "Premium_LRS"
@@ -42,6 +44,7 @@
                 {
                     "createOption": "Empty",
                     "deleteOption": "Delete",
+                    "caching": "None",
                     "diskSizeGB": "128",
                     "managedDisk": {
                         "storageAccountType": "Premium_LRS"

--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -380,9 +380,10 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
       imageReference: imageReference
       osDisk: {
         name: '${name}-disk-os-01'
-        createOption: osDisk.createOption
+        createOption: contains(osDisk, 'createOption') ? osDisk.createOption : 'FromImage'
         deleteOption: contains(osDisk, 'deleteOption') ? osDisk.deleteOption : 'Delete'
         diskSizeGB: osDisk.diskSizeGB
+        caching: contains(osDisk, 'caching') ? osDisk.caching : 'ReadOnly'
         managedDisk: {
           storageAccountType: osDisk.managedDisk.storageAccountType
           diskEncryptionSet: contains(osDisk.managedDisk, 'diskEncryptionSet') ? osDisk.managedDisk.diskEncryptionSet : null
@@ -392,9 +393,9 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
         lun: index
         name: '${name}-disk-data-${padLeft((index + 1), 2, '0')}'
         diskSizeGB: dataDisk.diskSizeGB
-        createOption: dataDisk.createOption
+        createOption: contains(dataDisk, 'createOption') ? dataDisk.createOption : 'Empty'
         deleteOption: contains(dataDisk, 'deleteOption') ? dataDisk.deleteOption : 'Delete'
-        caching: dataDisk.caching
+        caching: contains(dataDisk, 'caching') ? dataDisk.caching : 'ReadOnly'
         managedDisk: {
           storageAccountType: dataDisk.managedDisk.storageAccountType
           diskEncryptionSet: {


### PR DESCRIPTION
# Change

Added some smart defaults to `osDisk` and `dataDisks` for VM

[![Compute: VirtualMachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg?branch=users%2Fmast%2FVMDiskDefaults)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml)


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
