### PR TITLE
Added support for multi-line metadata

### DIFF
--- a/arm/Microsoft.Compute/availabilitySets/deploy.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/deploy.bicep
@@ -7,7 +7,10 @@ param availabilitySetFaultDomain int = 2
 @description('Optional. The number of update domains to use.')
 param availabilitySetUpdateDomain int = 5
 
-@description('Optional. Sku of the availability set. Use \'Aligned\' for virtual machines with managed disks and \'Classic\' for virtual machines with unmanaged disks.')
+@description('''Optional. SKU of the availability set.
+- Use \'Aligned\' for virtual machines with managed disks
+- Use \'Classic\' for virtual machines with unmanaged disks.
+''')
 param availabilitySetSku string = 'Aligned'
 
 @description('Optional. Resource ID of a proximity placement group.')

--- a/arm/Microsoft.Compute/availabilitySets/readme.md
+++ b/arm/Microsoft.Compute/availabilitySets/readme.md
@@ -28,7 +28,7 @@ This template deploys an availability set
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `availabilitySetFaultDomain` | int | `2` |  | The number of fault domains to use. |
-| `availabilitySetSku` | string | `'Aligned'` |  | Sku of the availability set. Use 'Aligned' for virtual machines with managed disks and 'Classic' for virtual machines with unmanaged disks. |
+| `availabilitySetSku` | string | `'Aligned'` |  | SKU of the availability set.<p>- Use \'Aligned\' for virtual machines with managed disks<p>- Use \'Classic\' for virtual machines with unmanaged disks.<p> |
 | `availabilitySetUpdateDomain` | int | `5` |  | The number of update domains to use. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `location` | string | `[resourceGroup().location]` |  | Resource location. |

--- a/arm/Microsoft.Insights/components/readme.md
+++ b/arm/Microsoft.Insights/components/readme.md
@@ -30,10 +30,10 @@
 | `kind` | string | `''` |  | The kind of application that this component refers to, used to customize UI. This value is a freeform string, values should typically be one of the following: web, ios, other, store, java, phone. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all Resources |
 | `publicNetworkAccessForIngestion` | string | `'Enabled'` | `[Enabled, Disabled]` | The network access type for accessing Application Insights ingestion. - Enabled or Disabled |
-| `retentionInDays` | int | `365` | `[30,60,90,120,180,270,365,550,730]` | Retention period in days. |
-| `samplingPercentage` | int | `[0-100]` | | Percentage of the data produced by the application being monitored that is being sampled for Application Insights telemetry. |
 | `publicNetworkAccessForQuery` | string | `'Enabled'` | `[Enabled, Disabled]` | The network access type for accessing Application Insights query. - Enabled or Disabled |
+| `retentionInDays` | int | `365` | `[30, 60, 90, 120, 180, 270, 365, 550, 730]` | Retention period in days. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+| `samplingPercentage` | int | `100` |  | Percentage of the data produced by the application being monitored that is being sampled for Application Insights telemetry. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
 
 

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -16,7 +16,7 @@ This module deploys a key vault and its child resources.
 | `Microsoft.Authorization/locks` | 2017-04-01 |
 | `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
-| `Microsoft.KeyVault/vaults` | 2019-09-01 |
+| `Microsoft.KeyVault/vaults` | 2021-11-01-preview |
 | `Microsoft.KeyVault/vaults/accessPolicies` | 2021-06-01-preview |
 | `Microsoft.KeyVault/vaults/keys` | 2019-09-01 |
 | `Microsoft.KeyVault/vaults/secrets` | 2019-09-01 |
@@ -32,7 +32,7 @@ This module deploys a key vault and its child resources.
 | `createMode` | string | `'default'` |  | The vault's create mode to indicate whether the vault need to be recovered or not. - recover or default. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.  |
 | `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub |
-| `diagnosticLogCategoriesToEnable` | array | `[AuditEvent]` | `[AuditEvent]` | The name of logs that will be streamed. |
+| `diagnosticLogCategoriesToEnable` | array | `[AuditEvent, AzurePolicyEvaluationDetails]` | `[AuditEvent, AzurePolicyEvaluationDetails]` | The name of logs that will be streamed. |
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
 | `diagnosticMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | The name of metrics that will be streamed. |
 | `diagnosticSettingsName` | string | `[format('{0}-diagnosticSettings', parameters('name'))]` |  | The name of the diagnostic setting, if deployed. |
@@ -50,8 +50,8 @@ This module deploys a key vault and its child resources.
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `name` | string | `''` |  | Name of the Key Vault. If no name is provided, then unique name will be created. |
 | `networkAcls` | object | `{object}` |  | Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny |
-| `publicNetworkAccess` | string | `enabled` | `[enabled, disabled]` | Property to specify whether the vault will accept traffic from public internet. If set to "disabled" all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, meaning that even if the firewall rules are present we will not honor the rules. |
 | `privateEndpoints` | array | `[]` |  | Configuration Details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible |
+| `publicNetworkAccess` | string | `'enabled'` | `[enabled, disabled]` | Property to specify whether the vault will accept traffic from public internet. If set to "disabled" all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, meaning that even if the firewall rules are present we will not honor the rules. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `secrets` | secureObject | `{object}` |  | All secrets to create |
 | `softDeleteRetentionInDays` | int | `90` |  | softDelete data retention days. It accepts >=7 and <=90. |
@@ -210,7 +210,7 @@ To use Private Endpoint the following dependencies must be deployed:
 - [Privateendpoints](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/privateEndpoints)
 - [Privateendpoints/Privatednszonegroups](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-02-01/privateEndpoints/privateDnsZoneGroups)
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
-- [Vaults](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2019-09-01/vaults)
+- [Vaults](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2021-11-01-preview/vaults)
 - [Vaults/Accesspolicies](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2021-06-01-preview/vaults/accessPolicies)
 - [Vaults/Keys](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2019-09-01/vaults/keys)
 - [Vaults/Secrets](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2019-09-01/vaults/secrets)

--- a/arm/Microsoft.KubernetesConfiguration/extensions/readme.md
+++ b/arm/Microsoft.KubernetesConfiguration/extensions/readme.md
@@ -38,7 +38,7 @@ For Details see [Prerequisites](https://docs.microsoft.com/en-us/azure/azure-arc
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `clusterName` | string |  | The name of the AKS cluster that should be configured. |
+| `clusterName` | string | The name of the AKS cluster that should be configured. |
 | `extensionType` | string | Type of the Extension, of which this resource is an instance of. It must be one of the Extension Types registered with Microsoft.KubernetesConfiguration by the Extension publisher. |
 | `name` | string | The name of the Flux Configuration |
 
@@ -50,10 +50,11 @@ For Details see [Prerequisites](https://docs.microsoft.com/en-us/azure/azure-arc
 | `configurationSettings` | object | `{object}` | Configuration settings, as name-value pairs for configuring this extension. |
 | `enableDefaultTelemetry` | bool | `True` | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `location` | string | `[resourceGroup().location]` | Location for all resources. |
-| `releaseNamespace` | string |  | Namespace where the extension Release must be placed, for a Cluster scoped extension. If this namespace does not exist, it will be created |
-| `releaseTrain` | string | `Stable` | ReleaseTrain this extension participates in for auto-upgrade (e.g. Stable, Preview, etc.) - only if autoUpgradeMinorVersion is "true". |
-| `targetNamespace` | string |  | Namespace where the extension will be created for an Namespace scoped extension. If this namespace does not exist, it will be created |
-| `version` | string |  | Version of the extension for this extension, if it is "pinned" to a specific version. autoUpgradeMinorVersion must be "false". |
+| `releaseNamespace` | string | `''` | Namespace where the extension Release must be placed, for a Cluster scoped extension. If this namespace does not exist, it will be created |
+| `releaseTrain` | string | `'Stable'` | ReleaseTrain this extension participates in for auto-upgrade (e.g. Stable, Preview, etc.) - only if autoUpgradeMinorVersion is "true". |
+| `targetNamespace` | string | `''` | Namespace where the extension will be created for an Namespace scoped extension. If this namespace does not exist, it will be created |
+| `version` | string | `''` | Version of the extension for this extension, if it is "pinned" to a specific version. autoUpgradeMinorVersion must be "false". |
+
 
 ## Outputs
 

--- a/arm/Microsoft.KubernetesConfiguration/fluxConfigurations/readme.md
+++ b/arm/Microsoft.KubernetesConfiguration/fluxConfigurations/readme.md
@@ -56,6 +56,7 @@ For Details see [Prerequisites](https://docs.microsoft.com/en-us/azure/azure-arc
 | `location` | string | `[resourceGroup().location]` | Location for all resources. |
 | `suspend` | bool | `False` | Whether this configuration should suspend its reconciliation of its kustomizations and sources. |
 
+
 ### Parameter Usage: `bucket`
 
 ```json

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
@@ -92,6 +92,6 @@ Create a role assignment for the given resource. If you want to assign a service
 
 ## Template references
 
-- [Define resources with Bicep and ARM templates](https://docs.microsoft.com/en-us/azure/templates)
 - [Netappaccounts/Capacitypools](https://docs.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2021-06-01/netAppAccounts/capacityPools)
 - [Netappaccounts/Capacitypools/Volumes](https://docs.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2021-06-01/netAppAccounts/capacityPools/volumes)
+- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/readme.md
@@ -92,6 +92,6 @@ Create a role assignment for the given resource. If you want to assign a service
 
 ## Template references
 
+- [Define resources with Bicep and ARM templates](https://docs.microsoft.com/en-us/azure/templates)
 - [Netappaccounts/Capacitypools](https://docs.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2021-06-01/netAppAccounts/capacityPools)
 - [Netappaccounts/Capacitypools/Volumes](https://docs.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2021-06-01/netAppAccounts/capacityPools/volumes)
-- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)

--- a/arm/Microsoft.Network/firewallPolicies/deploy.bicep
+++ b/arm/Microsoft.Network/firewallPolicies/deploy.bicep
@@ -72,7 +72,7 @@ param fqdns array = []
 @description('Optional. List of IP addresses for the ThreatIntel Allowlist.')
 param ipAddresses array = []
 
-@description('Optional. Secret Id of (base-64 encoded unencrypted pfx) Secret or Certificate object stored in KeyVault.	')
+@description('Optional. Secret ID of (base-64 encoded unencrypted pfx) Secret or Certificate object stored in KeyVault.	')
 param keyVaultSecretId string = ''
 
 @description('Optional. Name of the CA certificate.')

--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -500,7 +500,7 @@ Generate the Module ReadMe files into a specific folder path
 
 .EXAMPLE
 $templatePaths = (Get-ChildItem 'C:/Microsoft.Network' -Filter 'deploy.bicep' -Recurse).FullName
-$templatePaths | ForEach-Object { Set-ModuleReadMe -TemplateFilePath $_ }
+$templatePaths | ForEach-Object -Parallel { . '<PathToRepo>/utilities/tools/Set-ModuleReadMe.ps1' ; Set-ModuleReadMe -TemplateFilePath $_ }
 
 Generate the Module ReadMe for any template in a folder path
 

--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -210,7 +210,7 @@ function Set-ParametersSection {
             # Add external single quotes to all default values of type string except for those using functions
             $defaultValue = ($parameter.defaultValue -is [array]) ? ('[{0}]' -f ($parameter.defaultValue -join ', ')) : (($parameter.defaultValue -is [hashtable]) ? '{object}' : (($parameter.defaultValue -is [string]) -and ($parameter.defaultValue -notmatch '\[\w+\(.*\).*\]') ? '''' + $parameter.defaultValue + '''' : $parameter.defaultValue))
             $allowedValue = ($parameter.allowedValues -is [array]) ? ('[{0}]' -f ($parameter.allowedValues -join ', ')) : (($parameter.allowedValues -is [hashtable]) ? '{object}' : $parameter.allowedValues)
-            $description = $parameter.metadata.description
+            $description = $parameter.metadata.description.Replace("`r`n", '<p>').Replace("`n", '<p>')
 
             # Update parameter table content based on parameter category
             ## Remove category from parameter description
@@ -299,7 +299,8 @@ function Set-OutputsSection {
         )
         foreach ($outputName in ($templateFileContent.outputs.Keys | Sort-Object -Culture en-US)) {
             $output = $TemplateFileContent.outputs[$outputName]
-            $SectionContent += ("| ``{0}`` | {1} | {2} |" -f $outputName, $output.type, $output.metadata.description)
+            $description = $output.metadata.description.Replace("`r`n", '<p>').Replace("`n", '<p>')
+            $SectionContent += ("| ``{0}`` | {1} | {2} |" -f $outputName, $output.type, $description)
         }
     } else {
         $SectionContent = [System.Collections.ArrayList]@(


### PR DESCRIPTION
# Change

- Added support for multi-line metadata (both parameters & outputs)
- Tested it with an availability set example

Parameter reference
[![Compute: AvailabilitySets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml/badge.svg?branch=users%2Falsehr%2FmarkdownTest)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
