### PR TITLE
VM encryptionAtHost set to null if not true

### DIFF
--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -369,7 +369,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' = {
       vmSize: vmSize
     }
     securityProfile: {
-      encryptionAtHost: encryptionAtHost
+      encryptionAtHost: encryptionAtHost ? encryptionAtHost : null
       securityType: securityType
       uefiSettings: securityType == 'TrustedLaunch' ? {
         secureBootEnabled: secureBootEnabled


### PR DESCRIPTION
Error Message: 
>  Status Message: The property
     | 'securityProfile.encryptionAtHost' is not valid because the
     | 'Microsoft.Compute/EncryptionAtHost' feature is not enabled
     | for this subscription. (Code:InvalidParameter)

If this feature is not enabled in the subscription, the parameter needs to be empty. 
Then the parameter.json can be look like this: 
`"encryptionAtHost": { 
            "value": false
        }`

related: 
#1048

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
