### PR TITLE
Fixed GitHub parameter fetch

### DIFF
--- a/.github/actions/templates/getParameterFiles/action.yml
+++ b/.github/actions/templates/getParameterFiles/action.yml
@@ -28,7 +28,7 @@ runs:
         Write-Verbose "Invoke task with" -Verbose
         Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
         # Get the list of parameter file paths
-        $parameterFilePaths = Get-ModuleParameterFiles @functionInput -Verbose
+        [array]$parameterFilePaths = Get-ModuleParameterFiles @functionInput -Verbose
         # Output values to be accessed by next jobs
         Write-Output ('::set-output name=parameterFilePaths::{0}' -f ($parameterFilePaths | ConvertTo-Json -Compress))
         Write-Output "::endgroup::"

--- a/.github/actions/templates/getParameterFiles/action.yml
+++ b/.github/actions/templates/getParameterFiles/action.yml
@@ -30,5 +30,7 @@ runs:
         # Get the list of parameter file paths
         [array]$parameterFilePaths = Get-ModuleParameterFiles @functionInput -Verbose
         # Output values to be accessed by next jobs
-        Write-Output ('::set-output name=parameterFilePaths::{0}' -f ($parameterFilePaths | ConvertTo-Json -Compress))
+        $compressedOutput = $parameterFilePaths | ConvertTo-Json -Compress
+        Write-Verbose "Publishing output: $compressedOutput" -Verbose
+        Write-Output ('::set-output name=parameterFilePaths::$compressedOutput')
         Write-Output "::endgroup::"

--- a/.github/actions/templates/getParameterFiles/action.yml
+++ b/.github/actions/templates/getParameterFiles/action.yml
@@ -32,5 +32,5 @@ runs:
         # Output values to be accessed by next jobs
         $compressedOutput = $parameterFilePaths | ConvertTo-Json -Compress
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
-        Write-Output ('::set-output name=parameterFilePaths::$compressedOutput')
+        Write-Output "::set-output name=parameterFilePaths::$compressedOutput"
         Write-Output "::endgroup::"

--- a/.github/actions/templates/getParameterFiles/action.yml
+++ b/.github/actions/templates/getParameterFiles/action.yml
@@ -28,9 +28,12 @@ runs:
         Write-Verbose "Invoke task with" -Verbose
         Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
         # Get the list of parameter file paths
-        [array]$parameterFilePaths = Get-ModuleParameterFiles @functionInput -Verbose
+        $parameterFilePaths = Get-ModuleParameterFiles @functionInput -Verbose
         # Output values to be accessed by next jobs
         $compressedOutput = $parameterFilePaths | ConvertTo-Json -Compress
+        if($compressedOutput -notmatch "\[.*\]") {
+          $compressedOutput = "[$compressedOutput]"
+        }
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
         Write-Output "::set-output name=parameterFilePaths::$compressedOutput"
         Write-Output "::endgroup::"

--- a/arm/Microsoft.Web/sites/.parameters/fa.parameters.json
+++ b/arm/Microsoft.Web/sites/.parameters/fa.parameters.json
@@ -23,7 +23,7 @@
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsafa001"
         },
         "functionsWorkerRuntime": {
-            "value": "<<tenantId>>"
+            "value": "powershell"
         },
         "systemAssignedIdentity": {
             "value": true

--- a/arm/Microsoft.Web/sites/.parameters/fa.parameters.json
+++ b/arm/Microsoft.Web/sites/.parameters/fa.parameters.json
@@ -23,7 +23,7 @@
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsafa001"
         },
         "functionsWorkerRuntime": {
-            "value": "powershell"
+            "value": "<<tenantId>>"
         },
         "systemAssignedIdentity": {
             "value": true


### PR DESCRIPTION
# Change

- The compression used for passing the parameter files from one job to another auto-converted arrays into single strings that broke the consumption via the matrix. This is now fixed.

Pipeline reference
[![DesktopVirtualization: HostPools](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml/badge.svg?branch=users%2Falsehr%2FsingleParameterFileFetch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml)

Re-test with multi-param example
[![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2FsingleParameterFileFetch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
