### PR TITLE
[FirewallPolicies] Removed `batch` for ruleCollectionGroups

### DIFF
--- a/arm/Microsoft.Network/firewallPolicies/deploy.bicep
+++ b/arm/Microsoft.Network/firewallPolicies/deploy.bicep
@@ -153,7 +153,6 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-05-01' = {
   }
 }
 
-@batchSize(1)
 module firewallPolicy_ruleCollectionGroups 'ruleCollectionGroups/deploy.bicep' = [for (ruleCollectionGroup, index) in ruleCollectionGroups: {
   name: '${uniqueString(deployment().name, location)}-firewallPolicy_ruleCollectionGroups-${index}'
   params: {


### PR DESCRIPTION
# Change

- Test showed the `batch` seems not needed (anymore)

Pipeline reference
[![Network: FirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml/badge.svg?branch=users%2Falsehr%2FbatchTestFirewallPolicies&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
