### PR TITLE
[OperationalInsights] Removed `batch` for solutions deployment

### DIFF
--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -228,7 +228,6 @@ module logAnalyticsWorkspace_dataSources 'dataSources/deploy.bicep' = [for (data
   }
 }]
 
-@batchSize(1) // Serial loop deployment
 module logAnalyticsWorkspace_solutions '.bicep/nested_solutions.bicep' = [for (gallerySolution, index) in gallerySolutions: if (!empty(gallerySolutions)) {
   name: '${uniqueString(deployment().name, location)}-LAW-Solution-${index}'
   params: {


### PR DESCRIPTION
# Change

- Removed the `batch` as it seems not needed (anymore)

Pipeline reference
[![OperationalInsights: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml/badge.svg?branch=users%2Falsehr%2FbatchTestLAW)](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
