### PR TITLE
[Netapp] Removed `batch` for Capacity Pools

### DIFF
--- a/arm/Microsoft.NetApp/netAppAccounts/deploy.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/deploy.bicep
@@ -95,7 +95,6 @@ module netAppAccount_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   }
 }]
 
-@batchSize(1)
 module netAppAccount_capacityPools 'capacityPools/deploy.bicep' = [for (capacityPool, index) in capacityPools: {
   name: '${uniqueString(deployment().name, location)}-ANFAccount-CapPool-${index}'
   params: {


### PR DESCRIPTION
# Change

- Removed `batch` processing as it seems not to be needed (anymore)

| Pipeline reference |
| - |
| [![NetApp: NetAppAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml/badge.svg?branch=users%2Falsehr%2FbatchTestNetApp&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml) |

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
