### PR TITLE
[Pester] Added test to make sure the `Set-ModuleReadMe` script was applied

### DIFF
--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -416,15 +416,20 @@ Describe 'Readme tests' -Tag Readme {
                 [string] $readMeFilePath
             )
 
+            # Get current hash
             $fileHashBefore = (Get-FileHash $readMeFilePath).Hash
 
             # Load function
-            $rootPath = (Get-Item $PSScriptRoot).Parent.Parent.Parent.Parent
+            $rootPath = (Get-Item $PSScriptRoot).Parent.Parent
             . (Join-Path $rootPath 'utilities' 'tools' 'Set-ModuleReadMe.ps1')
+
+            # Apply update
             Set-ModuleReadMe -TemplateFilePath $templateFilePath
 
+            # Get hash after 'update'
             $fileHashAfter = (Get-FileHash $readMeFilePath).Hash
 
+            # Compare
             $fileHashBefore -eq $fileHashAfter | Should -Be $true -Because 'The file hashes before and after applying the Set-ModuleReadMe function should be identical'
         }
     }

--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -6,7 +6,7 @@ param (
         })
 )
 
-$script:RepoRoot = (Get-Item $PSScriptRoot).Parent.Parent
+$script:RepoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $script:Settings = Get-Content -Path (Join-Path $PSScriptRoot '..\..\settings.json') | ConvertFrom-Json
 $script:RGdeployment = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
 $script:Subscriptiondeployment = 'https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#'

--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -6,6 +6,7 @@ param (
         })
 )
 
+$script:RepoRoot = (Get-Item $PSScriptRoot).Parent.Parent
 $script:Settings = Get-Content -Path (Join-Path $PSScriptRoot '..\..\settings.json') | ConvertFrom-Json
 $script:RGdeployment = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
 $script:Subscriptiondeployment = 'https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#'
@@ -420,8 +421,7 @@ Describe 'Readme tests' -Tag Readme {
             $fileHashBefore = (Get-FileHash $readMeFilePath).Hash
 
             # Load function
-            $rootPath = (Get-Item $PSScriptRoot).Parent.Parent
-            . (Join-Path $rootPath 'utilities' 'tools' 'Set-ModuleReadMe.ps1')
+            . (Join-Path $repoRoot 'utilities' 'tools' 'Set-ModuleReadMe.ps1')
 
             # Apply update
             Set-ModuleReadMe -TemplateFilePath $templateFilePath

--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -15,6 +15,7 @@ $script:Tenantdeployment = 'https://schema.management.azure.com/schemas/2019-08-
 $script:moduleFolderPaths = $moduleFolderPaths
 $script:moduleFolderPathsFiltered = $moduleFolderPaths | Where-Object {
     (Split-Path $_ -Leaf) -notin @( 'AzureNetappFiles', 'TrafficManager', 'PrivateDnsZones', 'ManagementGroups') }
+$script:convertedTemplates = @{}
 
 # Import any helper function used in this test script
 Import-Module (Join-Path $PSScriptRoot 'shared\helper.psm1')
@@ -110,14 +111,19 @@ Describe 'Readme tests' -Tag Readme {
         $readmeFolderTestCases = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
-            if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
-                $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
-                $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
-            } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
-                $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
-                $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+            if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+                if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
+                    $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
+                    $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
+                } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
+                    $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
+                    $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+                } else {
+                    throw "No template file found in folder [$moduleFolderPath]"
+                }
+                $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
             } else {
-                throw "No template file found in folder [$moduleFolderPath]"
+                $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
             }
 
             $readmeFolderTestCases += @{
@@ -414,6 +420,7 @@ Describe 'Readme tests' -Tag Readme {
             param(
                 [string] $moduleFolderName,
                 [string] $templateFilePath,
+                [hashtable] $templateContent,
                 [string] $readMeFilePath
             )
 
@@ -424,7 +431,7 @@ Describe 'Readme tests' -Tag Readme {
             . (Join-Path $repoRoot 'utilities' 'tools' 'Set-ModuleReadMe.ps1')
 
             # Apply update
-            Set-ModuleReadMe -TemplateFilePath $templateFilePath
+            Set-ModuleReadMe -TemplateFilePath $templateFilePath -TemplateFileContent $templateContent
 
             # Get hash after 'update'
             $fileHashAfter = (Get-FileHash $readMeFilePath).Hash
@@ -443,12 +450,19 @@ Describe 'Deployment template tests' -Tag Template {
         $deploymentFolderTestCasesException = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
-            if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
-                $templateContent = az bicep build --file (Join-Path $moduleFolderPath 'deploy.bicep') --stdout | ConvertFrom-Json -AsHashtable
-            } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
-                $templateContent = Get-Content (Join-Path $moduleFolderPath 'deploy.json') -Raw | ConvertFrom-Json -AsHashtable
+            if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+                if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
+                    $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
+                    $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
+                } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
+                    $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
+                    $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+                } else {
+                    throw "No template file found in folder [$moduleFolderPath]"
+                }
+                $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
             } else {
-                throw "No template file found in folder [$moduleFolderPath]"
+                $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
             }
 
             # Parameter file test cases
@@ -821,12 +835,19 @@ Describe "API version tests [All apiVersions in the template should be 'recent']
 
         $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/arm/')[1]
 
-        if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
-            $templateContent = az bicep build --file (Join-Path $moduleFolderPath 'deploy.bicep') --stdout | ConvertFrom-Json -AsHashtable
-        } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
-            $templateContent = Get-Content (Join-Path $moduleFolderPath 'deploy.json') -Raw | ConvertFrom-Json -AsHashtable
+        if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+            if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
+                $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
+                $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
+            } elseif (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
+                $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
+                $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+            } else {
+                throw "No template file found in folder [$moduleFolderPath]"
+            }
+            $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
         } else {
-            throw "No template file found in folder [$moduleFolderPath]"
+            $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
         }
 
         $nestedResources = Get-NestedResourceList -TemplateContent $templateContent | Where-Object {

--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -430,7 +430,7 @@ Describe 'Readme tests' -Tag Readme {
             # Load function
             . (Join-Path $repoRoot 'utilities' 'tools' 'Set-ModuleReadMe.ps1')
 
-            # Apply update
+            # Apply update with already compiled template content
             Set-ModuleReadMe -TemplateFilePath $templateFilePath -TemplateFileContent $templateContent
 
             # Get hash after 'update'

--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -476,6 +476,10 @@ Supports both ARM & bicep templates.
 .PARAMETER TemplateFilePath
 Mandatory. The path to the template to update
 
+.PARAMETER TemplateFileContent
+Optional. The template file content to process. If not provided, the template file content will be read from the TemplateFilePath file.
+Using this property is useful if you already compiled the bicep template before invoking this function and want to avoid re-compiling it.
+
 .PARAMETER ReadMeFilePath
 Optional. The path to the readme to update. If not provided assumes a 'readme.md' file in the same folder as the template
 
@@ -492,6 +496,11 @@ Update the readme in path 'C:\readme.md' based on the bicep template in path 'C:
 Set-ModuleReadMe -TemplateFilePath 'C:/Microsoft.Network/loadBalancers/deploy.bicep' -SectionsToRefresh @('Parameters', 'Outputs')
 
 Generate the Module ReadMe only for specific sections. Updates only the sections `Parameters` & `Outputs`. Other sections remain untouched.
+
+.EXAMPLE
+Set-ModuleReadMe -TemplateFilePath 'C:/Microsoft.Network/loadBalancers/deploy.bicep' -TemplateFileContent @{...}
+
+(Re)Generate the readme file for template 'loadBalancer' based on the content provided in the TemplateFileContent parameter
 
 .EXAMPLE
 Set-ModuleReadMe -TemplateFilePath 'C:/Microsoft.Network/loadBalancers/deploy.bicep' -ReadMeFilePath 'C:/differentFolder'
@@ -515,6 +524,9 @@ function Set-ModuleReadMe {
     param (
         [Parameter(Mandatory)]
         [string] $TemplateFilePath,
+
+        [Parameter(Mandatory = $false)]
+        [Hashtable] $TemplateFileContent,
 
         [Parameter(Mandatory = $false)]
         [string] $ReadMeFilePath = (Join-Path (Split-Path $TemplateFilePath -Parent) 'readme.md'),
@@ -541,10 +553,12 @@ function Set-ModuleReadMe {
     # Check template
     $null = Test-Path $TemplateFilePath -ErrorAction Stop
 
-    if ((Split-Path -Path $TemplateFilePath -Extension) -eq '.bicep') {
-        $templateFileContent = az bicep build --file $TemplateFilePath --stdout | ConvertFrom-Json -AsHashtable
-    } else {
-        $templateFileContent = ConvertFrom-Json (Get-Content $TemplateFilePath -Encoding 'utf8' -Raw) -ErrorAction Stop -AsHashtable
+    if (-not $TemplateFileContent) {
+        if ((Split-Path -Path $TemplateFilePath -Extension) -eq '.bicep') {
+            $templateFileContent = az bicep build --file $TemplateFilePath --stdout | ConvertFrom-Json -AsHashtable
+        } else {
+            $templateFileContent = ConvertFrom-Json (Get-Content $TemplateFilePath -Encoding 'utf8' -Raw) -ErrorAction Stop -AsHashtable
+        }
     }
 
     $fullResourcePath = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/arm/')[1]


### PR DESCRIPTION
# Change

- [Pester] Added test to make sure the `Set-ModuleReadMe` script was applied
- Note: This test may fail for quite a few modules as we did not have this test before
- Optimized runtime by avoiding to compile the template 3 times

A failed test would look like
![image](https://user-images.githubusercontent.com/5365358/163046871-e2727f6b-b676-4c09-87a9-c5f34ce8b019.png)

Pipeline reference
[![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2F1241_readmetest&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)
[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2FruntimeOpt)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
