### PR TITLE
Fix deployment validation at scope different than rg

### DIFF
--- a/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
+++ b/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
@@ -243,13 +243,6 @@ jobs:
                   $functionInput['parameterFilePath'] = Join-Path '$(ParametersRepoRoot)' '${{ deploymentBlock.path }}'
                 }
 
-                # Enables us to pass the resource group name as a deployment parameter
-                if(-not [String]::IsNullOrEmpty('${{ parameters.resourceGroupName }}')) {
-                  $functionInput['additionalParameters'] = @{
-                    resourceGroupName = '${{ parameters.resourceGroupName }}'
-                  }
-                }
-
                 $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json
                 if (-not [String]::IsNullOrEmpty($projectSettings.enableDefaultTelemetry) -and (Get-Content -Path $functionInput.templateFilePath -Raw) -like '*param enableDefaultTelemetry*') {
                     $functionInput['additionalParameters'] += @{
@@ -301,13 +294,6 @@ jobs:
 
                 if(-not [String]::IsNullOrEmpty('${{ deploymentBlock.path }}')) {
                   $functionInput['parameterFilePath'] = Join-Path '$(ParametersRepoRoot)' '${{ deploymentBlock.path }}'
-                }
-
-                # Enables us to pass the resource group name as a deployment parameter
-                if(-not [String]::IsNullOrEmpty('${{ parameters.resourceGroupName }}')) {
-                  $functionInput['additionalParameters'] = @{
-                    resourceGroupName = '${{ parameters.resourceGroupName }}'
-                  }
                 }
 
                 $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -196,13 +196,6 @@ runs:
           $functionInput['parameterFilePath'] = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.parameterFilePath }}'
         }
 
-        # # Enables us to pass the resource group name as a deployment parameter
-        # if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
-        #   $functionInput['additionalParameters'] = @{
-        #     resourceGroupName = '${{ inputs.resourceGroupName }}'
-        #   }
-        # }
-
         $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json
         if (-not [String]::IsNullOrEmpty($projectSettings.enableDefaultTelemetry) -and (Get-Content -Path $functionInput.templateFilePath -Raw) -like '*param enableDefaultTelemetry*') {
             $functionInput['additionalParameters'] += @{
@@ -242,13 +235,6 @@ runs:
         if(-not [String]::IsNullOrEmpty('${{ inputs.parameterFilePath }}')) {
           $functionInput['parameterFilePath'] = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.parameterFilePath }}'
         }
-
-        # # Enables us to pass the resource group name as a deployment parameter
-        # if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
-        #   $functionInput['additionalParameters'] = @{
-        #     resourceGroupName = '${{ inputs.resourceGroupName }}'
-        #   }
-        # }
 
         $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json
         if (-not [String]::IsNullOrEmpty($projectSettings.enableDefaultTelemetry) -and (Get-Content -Path $functionInput.templateFilePath -Raw) -like '*param enableDefaultTelemetry*') {

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -196,12 +196,12 @@ runs:
           $functionInput['parameterFilePath'] = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.parameterFilePath }}'
         }
 
-        # Enables us to pass the resource group name as a deployment parameter
-        if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
-          $functionInput['additionalParameters'] = @{
-            resourceGroupName = '${{ inputs.resourceGroupName }}'
-          }
-        }
+        # # Enables us to pass the resource group name as a deployment parameter
+        # if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
+        #   $functionInput['additionalParameters'] = @{
+        #     resourceGroupName = '${{ inputs.resourceGroupName }}'
+        #   }
+        # }
 
         $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json
         if (-not [String]::IsNullOrEmpty($projectSettings.enableDefaultTelemetry) -and (Get-Content -Path $functionInput.templateFilePath -Raw) -like '*param enableDefaultTelemetry*') {
@@ -243,12 +243,12 @@ runs:
           $functionInput['parameterFilePath'] = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.parameterFilePath }}'
         }
 
-        # Enables us to pass the resource group name as a deployment parameter
-        if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
-          $functionInput['additionalParameters'] = @{
-            resourceGroupName = '${{ inputs.resourceGroupName }}'
-          }
-        }
+        # # Enables us to pass the resource group name as a deployment parameter
+        # if(-not [String]::IsNullOrEmpty('${{ inputs.resourceGroupName }}')) {
+        #   $functionInput['additionalParameters'] = @{
+        #     resourceGroupName = '${{ inputs.resourceGroupName }}'
+        #   }
+        # }
 
         $projectSettings = Get-Content -Path 'settings.json' | ConvertFrom-Json
         if (-not [String]::IsNullOrEmpty($projectSettings.enableDefaultTelemetry) -and (Get-Content -Path $functionInput.templateFilePath -Raw) -like '*param enableDefaultTelemetry*') {


### PR DESCRIPTION
# Change

Passing resourceGroupName as an additional deployment parameter does not work for resources deployed to a scope different than resourcegroup. 
Something to rethink for the dependencies restructuring PoC.

Tested at both sub and rg level

[![Insights: DiagnosticSettings](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.diagnosticsettings.yml/badge.svg?branch=users%2Ferikag%2Ffix-sub-level)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.diagnosticsettings.yml)
[![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Ferikag%2Ffix-sub-level)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
