### PR TITLE
changed virtualnetworkrules to use resourceid instead of name

### DIFF
--- a/arm/Microsoft.EventHub/namespaces/.parameters/parameters.json
+++ b/arm/Microsoft.EventHub/namespaces/.parameters/parameters.json
@@ -105,6 +105,19 @@
         "systemAssignedIdentity": {
             "value": true
         },
+        "networkAcls": {
+            "value": {
+                "bypass": "AzureServices",
+                "defaultAction": "Deny",
+                "virtualNetworkRules": [
+                    {
+                        "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001",
+                        "action": "Allow"
+                    }
+                ],
+                "ipRules": []
+            }
+        },
         "userAssignedIdentities": {
             "value": {
                 "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001": {}

--- a/arm/Microsoft.EventHub/namespaces/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/deploy.bicep
@@ -46,9 +46,6 @@ param privateEndpoints array = []
 @description('Optional. Service endpoint object information')
 param networkAcls object = {}
 
-@description('Optional. Virtual Network ID to lock down the Event Hub.')
-param vNetId string = ''
-
 @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
 @minValue(0)
 @maxValue(365)

--- a/arm/Microsoft.EventHub/namespaces/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/deploy.bicep
@@ -128,14 +128,11 @@ var uniqueEventHubNamespaceUntrim = uniqueString('EventHub Namespace${baseTime}'
 var uniqueEventHubNamespace = length(uniqueEventHubNamespaceUntrim) > maxNameLength ? substring(uniqueEventHubNamespaceUntrim, 0, maxNameLength) : uniqueEventHubNamespaceUntrim
 var name_var = empty(name) ? uniqueEventHubNamespace : name
 var maximumThroughputUnits_var = !isAutoInflateEnabled ? 0 : maximumThroughputUnits
-var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
-  id: virtualNetworkRule.subnetId
-}]
 var networkAcls_var = {
   bypass: !empty(networkAcls) ? networkAcls.bypass : null
   defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
-  virtualNetworkRules: !empty(networkAcls) ? virtualNetworkRules : null
-  ipRules: !empty(networkAcls) ? (length(networkAcls.ipRules) > 0 ? networkAcls.ipRules : null) : null
+  virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
+  ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
 }
 
 @description('Optional. The name of the diagnostic setting, if deployed.')

--- a/arm/Microsoft.EventHub/namespaces/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/deploy.bicep
@@ -43,7 +43,7 @@ param authorizationRules array = [
 @description('Optional. Configuration Details for private endpoints.For security reasons, it is recommended to use private endpoints whenever possible.')
 param privateEndpoints array = []
 
-@description('Optional. Service endpoint object information')
+@description('Optional. Networks ACLs, this value contains IPs to whitelist and/or Subnet information. For security reasons, it is recommended to set the DefaultAction Deny')
 param networkAcls object = {}
 
 @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
@@ -128,12 +128,6 @@ var uniqueEventHubNamespaceUntrim = uniqueString('EventHub Namespace${baseTime}'
 var uniqueEventHubNamespace = length(uniqueEventHubNamespaceUntrim) > maxNameLength ? substring(uniqueEventHubNamespaceUntrim, 0, maxNameLength) : uniqueEventHubNamespaceUntrim
 var name_var = empty(name) ? uniqueEventHubNamespace : name
 var maximumThroughputUnits_var = !isAutoInflateEnabled ? 0 : maximumThroughputUnits
-var networkAcls_var = {
-  bypass: !empty(networkAcls) ? networkAcls.bypass : null
-  defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
-  virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
-  ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
-}
 
 @description('Optional. The name of the diagnostic setting, if deployed.')
 param diagnosticSettingsName string = '${name}-diagnosticSettings'
@@ -190,7 +184,12 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-06-01-preview' = 
     zoneRedundant: zoneRedundant
     isAutoInflateEnabled: isAutoInflateEnabled
     maximumThroughputUnits: maximumThroughputUnits_var
-    networkAcls: !empty(networkAcls) ? networkAcls_var : null
+    networkAcls: !empty(networkAcls) ? {
+      bypass: !empty(networkAcls) ? networkAcls.bypass : null
+      defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
+      virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
+      ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
+    } : null
   }
 }
 

--- a/arm/Microsoft.EventHub/namespaces/deploy.bicep
+++ b/arm/Microsoft.EventHub/namespaces/deploy.bicep
@@ -131,8 +131,8 @@ var uniqueEventHubNamespaceUntrim = uniqueString('EventHub Namespace${baseTime}'
 var uniqueEventHubNamespace = length(uniqueEventHubNamespaceUntrim) > maxNameLength ? substring(uniqueEventHubNamespaceUntrim, 0, maxNameLength) : uniqueEventHubNamespaceUntrim
 var name_var = empty(name) ? uniqueEventHubNamespace : name
 var maximumThroughputUnits_var = !isAutoInflateEnabled ? 0 : maximumThroughputUnits
-var virtualNetworkRules = [for index in range(0, (empty(networkAcls) ? 0 : length(networkAcls.virtualNetworkRules))): {
-  id: '${vNetId}/subnets/${networkAcls.virtualNetworkRules[index].subnet}'
+var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
+  id: virtualNetworkRule.subnetId
 }]
 var networkAcls_var = {
   bypass: !empty(networkAcls) ? networkAcls.bypass : null

--- a/arm/Microsoft.EventHub/namespaces/readme.md
+++ b/arm/Microsoft.EventHub/namespaces/readme.md
@@ -47,7 +47,7 @@ This module deploys an event hub namespace.
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `maximumThroughputUnits` | int | `1` |  | Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units. |
 | `name` | string | `''` |  | The name of the event hub namespace. If no name is provided, then unique name will be created. |
-| `networkAcls` | object | `{object}` |  | Service endpoint object information |
+| `networkAcls` | object | `{object}` |  | Networks ACLs, this value contains IPs to whitelist and/or Subnet information. For security reasons, it is recommended to set the DefaultAction Deny |
 | `privateEndpoints` | array | `[]` |  | Configuration Details for private endpoints.For security reasons, it is recommended to use private endpoints whenever possible. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `skuCapacity` | int | `1` |  | Event Hub plan scale-out capacity of the resource |
@@ -55,7 +55,6 @@ This module deploys an event hub namespace.
 | `systemAssignedIdentity` | bool | `False` |  | Enables system assigned managed identity on the resource. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
 | `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |
-| `vNetId` | string | `''` |  | Virtual Network ID to lock down the Event Hub. |
 | `zoneRedundant` | bool | `False` |  | Switch to make the Event Hub Namespace zone redundant. |
 
 **Generated parameters**

--- a/arm/Microsoft.KeyVault/vaults/.parameters/parameters.json
+++ b/arm/Microsoft.KeyVault/vaults/.parameters/parameters.json
@@ -23,7 +23,12 @@
             "value": {
                 "bypass": "AzureServices",
                 "defaultAction": "Deny",
-                "virtualNetworkRules": [],
+                "virtualNetworkRules": [
+                    {
+                        "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001",
+                        "action": "Allow"
+                    }
+                ],
                 "ipRules": []
             }
         },

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -158,13 +158,11 @@ var maxNameLength = 24
 var uniquenameUntrim = uniqueString('Key Vault${baseTime}')
 var uniquename = (length(uniquenameUntrim) > maxNameLength ? substring(uniquenameUntrim, 0, maxNameLength) : uniquenameUntrim)
 var name_var = !empty(name) ? name : uniquename
-var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
-  id: virtualNetworkRule.subnetId
-}]
+
 var networkAcls_var = {
   bypass: !empty(networkAcls) ? networkAcls.bypass : null
   defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
-  virtualNetworkRules: !empty(networkAcls) ? virtualNetworkRules : null
+  virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
   ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
 }
 

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -161,8 +161,8 @@ var maxNameLength = 24
 var uniquenameUntrim = uniqueString('Key Vault${baseTime}')
 var uniquename = (length(uniquenameUntrim) > maxNameLength ? substring(uniquenameUntrim, 0, maxNameLength) : uniquenameUntrim)
 var name_var = !empty(name) ? name : uniquename
-var virtualNetworkRules = [for networkrule in ((contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []): {
-  id: '${vNetId}/subnets/${networkrule.subnet}'
+var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
+  id: virtualNetworkRule.subnetId
 }]
 var networkAcls_var = {
   bypass: !empty(networkAcls) ? networkAcls.bypass : null

--- a/arm/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/arm/Microsoft.KeyVault/vaults/deploy.bicep
@@ -71,9 +71,6 @@ param networkAcls object = {}
 ])
 param publicNetworkAccess string = 'enabled'
 
-@description('Optional. Virtual Network resource identifier, if networkAcls is passed, this value must be passed as well')
-param vNetId string = ''
-
 @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
 @minValue(0)
 @maxValue(365)

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -64,7 +64,6 @@ This module deploys a key vault and its child resources.
 | :-- | :-- | :-- | :-- |
 | `baseTime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
 
-
 ### Parameter Usage: `roleAssignments`
 
 Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to `'ServicePrincipal'`. This will ensure the role assignment waits for the principal's propagation in Azure.
@@ -117,7 +116,7 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
         "defaultAction": "Deny",
         "virtualNetworkRules": [
             {
-                "subnet": "sharedsvcs"
+                "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001"
             }
         ],
         "ipRules": []

--- a/arm/Microsoft.KeyVault/vaults/readme.md
+++ b/arm/Microsoft.KeyVault/vaults/readme.md
@@ -57,12 +57,12 @@ This module deploys a key vault and its child resources.
 | `softDeleteRetentionInDays` | int | `90` |  | softDelete data retention days. It accepts >=7 and <=90. |
 | `tags` | object | `{object}` |  | Resource tags. |
 | `vaultSku` | string | `'premium'` | `[premium, standard]` | Specifies the SKU for the vault |
-| `vNetId` | string | `''` |  | Virtual Network resource identifier, if networkAcls is passed, this value must be passed as well |
 
 **Generated parameters**
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `baseTime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
+
 
 ### Parameter Usage: `roleAssignments`
 

--- a/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
+++ b/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
@@ -43,7 +43,8 @@
                 "defaultAction": "Deny",
                 "virtualNetworkRules": [
                     {
-                        "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                        "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001",
+                        "action": "Allow"
                     }
                 ],
                 "ipRules": []

--- a/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
+++ b/arm/Microsoft.Storage/storageAccounts/.parameters/parameters.json
@@ -41,7 +41,11 @@
             "value": {
                 "bypass": "AzureServices",
                 "defaultAction": "Deny",
-                "virtualNetworkRules": [],
+                "virtualNetworkRules": [
+                    {
+                        "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                    }
+                ],
                 "ipRules": []
             }
         },

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -154,8 +154,8 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   }
 }]
 
-var virtualNetworkRules = [for index in range(0, (empty(networkAcls) ? 0 : length(networkAcls.virtualNetworkRules))): {
-  id: '${vNetId}/subnets/${networkAcls.virtualNetworkRules[index].subnet}'
+var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
+  id: virtualNetworkRule.subnetId
 }]
 
 var maxNameLength = 24

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -151,10 +151,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   }
 }]
 
-var virtualNetworkRules = [for virtualNetworkRule in networkAcls.virtualNetworkRules: {
-  id: virtualNetworkRule.subnetId
-}]
-
 var maxNameLength = 24
 var uniqueStorageNameUntrim = '${uniqueString('Storage Account${basetime}')}'
 var uniqueStorageName = length(uniqueStorageNameUntrim) > maxNameLength ? substring(uniqueStorageNameUntrim, 0, maxNameLength) : uniqueStorageNameUntrim
@@ -209,8 +205,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
     networkAcls: !empty(networkAcls) ? {
       bypass: !empty(networkAcls) ? networkAcls.bypass : null
       defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
-      virtualNetworkRules: !empty(networkAcls) ? virtualNetworkRules : null
-      ipRules: !empty(networkAcls) ? (length(networkAcls.ipRules) != 0 ? networkAcls.ipRules : null) : null
+      virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
+      ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
     } : null
     allowBlobPublicAccess: allowBlobPublicAccess
     publicNetworkAccess: publicNetworkAccess

--- a/arm/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -47,9 +47,6 @@ param storageAccountAccessTier string = 'Hot'
 @description('Optional. Provides the identity based authentication settings for Azure Files.')
 param azureFilesIdentityBasedAuthentication object = {}
 
-@description('Optional. Virtual Network Identifier used to create a service endpoint.')
-param vNetId string = ''
-
 @description('Optional. Configuration Details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible')
 param privateEndpoints array = []
 

--- a/arm/Microsoft.Storage/storageAccounts/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/readme.md
@@ -75,7 +75,6 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | :-- | :-- | :-- | :-- |
 | `basetime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
 
-
 ### Parameter Usage: `roleAssignments`
 
 Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to `'ServicePrincipal'`. This will ensure the role assignment waits for the principal's propagation in Azure.
@@ -111,7 +110,7 @@ Create a role assignment for the given resource. If you want to assign a service
         "defaultAction": "Deny",
         "virtualNetworkRules": [
             {
-                "subnet": "sharedsvcs"
+                "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001"
             }
         ],
         "ipRules": []

--- a/arm/Microsoft.Storage/storageAccounts/readme.md
+++ b/arm/Microsoft.Storage/storageAccounts/readme.md
@@ -68,12 +68,12 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | `tableServices` | _[tableServices](tableServices/readme.md)_ object | `{object}` |  | Table service and tables to create. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
 | `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |
-| `vNetId` | string | `''` |  | Virtual Network Identifier used to create a service endpoint. |
 
 **Generated parameters**
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `basetime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
+
 
 ### Parameter Usage: `roleAssignments`
 


### PR DESCRIPTION
# Description

Discussed here:  #1287 

This PR changes the networkACL sections, so that a resource id is required instead of just a name.


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
