### PR TITLE
[Pester] Fixed an issue with the runtime optimization

### DIFF
--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -20,6 +20,8 @@ $script:moduleFolderPaths = $moduleFolderPaths
 $script:moduleFolderPathsFiltered = $moduleFolderPaths | Where-Object {
     (Split-Path $_ -Leaf) -notin @( 'AzureNetappFiles', 'TrafficManager', 'PrivateDnsZones', 'ManagementGroups') }
 $script:enforcedTokenList = $enforcedTokenList
+
+# For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
 $script:convertedTemplates = @{}
 
 # Import any helper function used in this test script
@@ -116,6 +118,7 @@ Describe 'Readme tests' -Tag Readme {
         $readmeFolderTestCases = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
+            # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
             $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
             if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
                 if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
@@ -456,6 +459,7 @@ Describe 'Deployment template tests' -Tag Template {
         $deploymentFolderTestCasesException = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
+            # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
             $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
             if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
                 if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
@@ -858,6 +862,7 @@ Describe "API version tests [All apiVersions in the template should be 'recent']
 
         $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/arm/')[1]
 
+        # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
         $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
         if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
             if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {

--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -116,7 +116,8 @@ Describe 'Readme tests' -Tag Readme {
         $readmeFolderTestCases = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
-            if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+            $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
+            if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
                 if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
                     $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
                     $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
@@ -126,9 +127,9 @@ Describe 'Readme tests' -Tag Readme {
                 } else {
                     throw "No template file found in folder [$moduleFolderPath]"
                 }
-                $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
+                $convertedTemplates[$moduleFolderPathKey] = $templateContent
             } else {
-                $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
+                $templateContent = $convertedTemplates[$moduleFolderPathKey]
             }
 
             $readmeFolderTestCases += @{
@@ -455,7 +456,8 @@ Describe 'Deployment template tests' -Tag Template {
         $deploymentFolderTestCasesException = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
 
-            if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+            $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
+            if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
                 if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
                     $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
                     $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
@@ -465,9 +467,9 @@ Describe 'Deployment template tests' -Tag Template {
                 } else {
                     throw "No template file found in folder [$moduleFolderPath]"
                 }
-                $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
+                $convertedTemplates[$moduleFolderPathKey] = $templateContent
             } else {
-                $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
+                $templateContent = $convertedTemplates[$moduleFolderPathKey]
             }
 
             # Parameter file test cases
@@ -856,7 +858,8 @@ Describe "API version tests [All apiVersions in the template should be 'recent']
 
         $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/arm/')[1]
 
-        if (-not ($convertedTemplates.Keys -contains (Split-Path $moduleFolderPath -Leaf))) {
+        $moduleFolderPathKey = $moduleFolderPath.Split('arm')[1].Replace('\', '/').Trim('/').Replace('/', '-')
+        if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
             if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
                 $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
                 $templateContent = az bicep build --file $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
@@ -866,9 +869,9 @@ Describe "API version tests [All apiVersions in the template should be 'recent']
             } else {
                 throw "No template file found in folder [$moduleFolderPath]"
             }
-            $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)] = $templateContent
+            $convertedTemplates[$moduleFolderPathKey] = $templateContent
         } else {
-            $templateContent = $convertedTemplates[(Split-Path $moduleFolderPath -Leaf)]
+            $templateContent = $convertedTemplates[$moduleFolderPathKey]
         }
 
         $nestedResources = Get-NestedResourceList -TemplateContent $templateContent | Where-Object {


### PR DESCRIPTION
# Description

- Updated the caching to work with duplicated resource type names

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![ServiceBus: Namespaces](https://github.com/Azure/ResourceModules/workflows/ServiceBus:%20Namespaces/badge.svg?branch=users%2Falsehr%2FruntimeFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml) |
| [![EventHub: Namespaces](https://github.com/Azure/ResourceModules/workflows/EventHub:%20Namespaces/badge.svg?branch=users%2Falsehr%2FruntimeFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml) |
| [![ApiManagement: Service](https://github.com/Azure/ResourceModules/workflows/ApiManagement:%20Service/badge.svg?branch=users%2Falsehr%2FruntimeFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.apimanagement.service.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
