### PR TITLE
fixing deployment of rule collection groups

### DIFF
--- a/arm/Microsoft.Network/firewallPolicies/deploy.bicep
+++ b/arm/Microsoft.Network/firewallPolicies/deploy.bicep
@@ -153,7 +153,10 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-05-01' = {
   }
 }
 
-// serial deployment is mandatory, otherwise it will fail
+// When a FW policy uses a base policy and have more rule collection groups,
+// they need to be deployed sequentially, otherwise the deployment would fail
+// because of concurrent access to the base policy.
+// The next line forces ARM to deploy them one after the other, so no race concition on the base policy will happen.
 @batchSize(1)
 module firewallPolicy_ruleCollectionGroups 'ruleCollectionGroups/deploy.bicep' = [for (ruleCollectionGroup, index) in ruleCollectionGroups: {
   name: '${uniqueString(deployment().name, location)}-firewallPolicy_ruleCollectionGroups-${index}'

--- a/arm/Microsoft.Network/firewallPolicies/deploy.bicep
+++ b/arm/Microsoft.Network/firewallPolicies/deploy.bicep
@@ -153,6 +153,8 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-05-01' = {
   }
 }
 
+// serial deployment is mandatory, otherwise it will fail
+@batchSize(1)
 module firewallPolicy_ruleCollectionGroups 'ruleCollectionGroups/deploy.bicep' = [for (ruleCollectionGroup, index) in ruleCollectionGroups: {
   name: '${uniqueString(deployment().name, location)}-firewallPolicy_ruleCollectionGroups-${index}'
   params: {


### PR DESCRIPTION
# Description

When a FW policy uses a base policy and have more rule collection groups, they need to be deployed sequentially, otherwise the deployment would fail because of concurrent access to the base policy. This fix deploys forces ARM to deploy them one after the other.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network: FirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml/badge.svg?branch=Azure-main)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
