### PR TITLE
Fixed local tests ref

### DIFF
--- a/.azuredevops/pipelineTemplates/jobs.validateModulePester.yml
+++ b/.azuredevops/pipelineTemplates/jobs.validateModulePester.yml
@@ -145,16 +145,28 @@ jobs:
               Write-Verbose "- [($moduleFolderPath]" -Verbose
             }
 
+            $enforcedTokenList = @{}
+            if (-not [String]::IsNullOrEmpty('${{ parameters.subscriptionId }}')) {
+                $enforcedTokenList['subscriptionId'] = '${{ parameters.subscriptionId }}'
+            }
+            if (-not [String]::IsNullOrEmpty('${{ parameters.managementGroupId }}')) {
+                $enforcedTokenList['managementGroupId'] = '${{ parameters.managementGroupId }}'
+            }
+            if (-not [String]::IsNullOrEmpty('$(ARM_TENANT_ID)')) {
+                $enforcedTokenList['deploymentSpId'] = '$(ARM_TENANT_ID)'
+            }
+            if (-not [String]::IsNullOrEmpty('$(DEPLOYMENT_SP_ID)')) {
+                $enforcedTokenList['tenantId'] = '$(DEPLOYMENT_SP_ID)'
+            }
+
+            # --------------------- #
+            # Invoke Pester test(s) #
+            # --------------------- #
             Invoke-Pester -Configuration @{
               Run        = @{
                 Container = New-PesterContainer -Path (Join-Path '$(moduleRepoRoot)' 'arm' '.global' 'global.module.tests.ps1') -Data @{
                   moduleFolderPaths = $moduleFolderPaths
-                  enforcedTokenList = @{
-                    subscriptionId    = '${{ parameters.subscriptionId }}'
-                    managementGroupId = '${{ parameters.managementGroupId }}'
-                    tenantId          = '$(ARM_TENANT_ID)'
-                    deploymentSpId    = '$(DEPLOYMENT_SP_ID)'
-                  }
+                  enforcedTokenList = $enforcedTokenList
                 }
               }
               Filter     = @{
@@ -256,6 +268,9 @@ jobs:
               Write-Verbose "- [($moduleFolderPath]" -Verbose
             }
 
+            # --------------------- #
+            # Invoke Pester test(s) #
+            # --------------------- #
             Invoke-Pester -Configuration @{
               Run        = @{
                 Container = New-PesterContainer -Path (Join-Path '$(moduleRepoRoot)' 'arm' '.global' 'global.module.tests.ps1') -Data @{

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -76,6 +76,20 @@ runs:
           Write-Verbose "- [($moduleFolderPath]" -Verbose
         }
 
+        $enforcedTokenList = @{}
+        if (-not [String]::IsNullOrEmpty('${{ env.ARM_SUBSCRIPTION_ID }}')) {
+            $enforcedTokenList['subscriptionId'] = '${{ env.ARM_SUBSCRIPTION_ID }}'
+        }
+        if (-not [String]::IsNullOrEmpty('${{ env.ARM_MGMTGROUP_ID }}')) {
+            $enforcedTokenList['managementGroupId'] = '${{ env.ARM_MGMTGROUP_ID }}'
+        }
+        if (-not [String]::IsNullOrEmpty('${{ env.ARM_TENANT_ID }}')) {
+            $enforcedTokenList['deploymentSpId'] = '${{ env.ARM_TENANT_ID }}'
+        }
+        if (-not [String]::IsNullOrEmpty('${{ env.DEPLOYMENT_SP_ID }}')) {
+            $enforcedTokenList['tenantId'] = '${{ env.DEPLOYMENT_SP_ID }}'
+        }
+
         # --------------------- #
         # Invoke Pester test(s) #
         # --------------------- #
@@ -83,12 +97,7 @@ runs:
           Run        = @{
             Container = New-PesterContainer -Path 'arm/.global/global.module.tests.ps1' -Data @{
               moduleFolderPaths = $moduleFolderPaths
-              enforcedTokenList = @{
-                subscriptionId    = '${{ env.ARM_SUBSCRIPTION_ID }}'
-                managementGroupId = '${{ env.ARM_MGMTGROUP_ID }}'
-                tenantId          = '${{ env.ARM_TENANT_ID }}'
-                deploymentSpId    = '${{ env.DEPLOYMENT_SP_ID }}'
-              }
+              enforcedTokenList = $enforcedTokenList
             }
           }
           Filter     = @{

--- a/utilities/tools/Test-ModuleLocally.ps1
+++ b/utilities/tools/Test-ModuleLocally.ps1
@@ -151,10 +151,10 @@ function Test-ModuleLocally {
             Write-Verbose "Pester Testing Module: $ModuleName"
             try {
                 $enforcedTokenList = @{}
-                if ($AdditionalTokens.ContainsKey('subscriptionId')) {
+                if ($ValidateOrDeployParameters.ContainsKey('subscriptionId')) {
                     $enforcedTokenList['subscriptionId'] = $ValidateOrDeployParameters.SubscriptionId
                 }
-                if ($AdditionalTokens.ContainsKey('managementGroupId')) {
+                if ($ValidateOrDeployParameters.ContainsKey('managementGroupId')) {
                     $enforcedTokenList['managementGroupId'] = $ValidateOrDeployParameters.ManagementGroupId
                 }
                 if ($AdditionalTokens.ContainsKey('deploymentSpId')) {
@@ -168,7 +168,7 @@ function Test-ModuleLocally {
                     Run    = @{
                         Container = New-PesterContainer -Path (Join-Path (Get-Item $PSScriptRoot).Parent.Parent 'arm/.global/global.module.tests.ps1') -Data @{
                             moduleFolderPaths = Split-Path $TemplateFilePath -Parent
-                            enforcedTokenList     = $enforcedTokenList
+                            enforcedTokenList = $enforcedTokenList
                         }
                     }
                     Output = @{


### PR DESCRIPTION
# Description

- Fixed incorrect token reference in local test script
- Made test pipeline more robust for cases where e.g. a managementGroupId was not set in the secrets. Otherwise, tests will fail with misleading error messages

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2FlocalTestsFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
