### PR TITLE
Updated the update of the login context to plain subscription ID

### DIFF
--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -217,7 +217,7 @@ function New-DeploymentWithParameterFile {
                         }
                         if (-not (Get-AzResourceGroup -Name $resourceGroupName -ErrorAction 'SilentlyContinue')) {
                             if ($PSCmdlet.ShouldProcess("Resource group [$resourceGroupName] in location [$location]", 'Create')) {
-                                New-AzResourceGroup -Name $resourceGroupName -Location $location
+                                $null = New-AzResourceGroup -Name $resourceGroupName -Location $location
                             }
                         }
                         if ($PSCmdlet.ShouldProcess('Resource group level deployment', 'Create')) {

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -213,7 +213,7 @@ function New-DeploymentWithParameterFile {
                     'resourcegroup' {
                         if (-not [String]::IsNullOrEmpty($subscriptionId)) {
                             Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
-                            Set-AzContext -Subscription $subscriptionId
+                            $null = Set-AzContext -Subscription $subscriptionId
                         }
                         if (-not (Get-AzResourceGroup -Name $resourceGroupName -ErrorAction 'SilentlyContinue')) {
                             if ($PSCmdlet.ShouldProcess("Resource group [$resourceGroupName] in location [$location]", 'Create')) {
@@ -228,7 +228,7 @@ function New-DeploymentWithParameterFile {
                     'subscription' {
                         if (-not [String]::IsNullOrEmpty($subscriptionId)) {
                             Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
-                            Set-AzContext -Subscription $subscriptionId
+                            $null = Set-AzContext -Subscription $subscriptionId
                         }
                         if ($PSCmdlet.ShouldProcess('Subscription level deployment', 'Create')) {
                             $res = New-AzSubscriptionDeployment @DeploymentInputs -Location $location

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -211,11 +211,9 @@ function New-DeploymentWithParameterFile {
             try {
                 switch ($deploymentScope) {
                     'resourcegroup' {
-                        if ($subscriptionId) {
-                            $Context = Get-AzContext -ListAvailable | Where-Object Subscription -Match $subscriptionId
-                            if ($Context) {
-                                $null = $Context | Set-AzContext
-                            }
+                        if (-not [String]::IsNullOrEmpty($subscriptionId)) {
+                            Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
+                            Set-AzContext -Subscription $subscriptionId
                         }
                         if (-not (Get-AzResourceGroup -Name $resourceGroupName -ErrorAction 'SilentlyContinue')) {
                             if ($PSCmdlet.ShouldProcess("Resource group [$resourceGroupName] in location [$location]", 'Create')) {
@@ -228,9 +226,9 @@ function New-DeploymentWithParameterFile {
                         break
                     }
                     'subscription' {
-                        if ($subscriptionId -and ($Context = Get-AzContext -ListAvailable | Where-Object { $_.Subscription.Id -eq $subscriptionId })) {
-                            Write-Verbose ('Setting context to subscription [{0}]' -f $Context.Subscription.Name)
-                            $null = $Context | Set-AzContext
+                        if (-not [String]::IsNullOrEmpty($subscriptionId)) {
+                            Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
+                            Set-AzContext -Subscription $subscriptionId
                         }
                         if ($PSCmdlet.ShouldProcess('Subscription level deployment', 'Create')) {
                             $res = New-AzSubscriptionDeployment @DeploymentInputs -Location $location


### PR DESCRIPTION
# Description

- Updated the update of the login context to plain subscription ID
- The rational is that the current `Get-AzContext` only returns a maximum of 25 context objects. If an SP has access to more subscriptions, the login won't work and you may end up deploying into a subscription you did not intent to.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/workflows/AnalysisServices:%20Servers/badge.svg?branch=users%2Falsehr%2Fcontext)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |
| [![Resources: ResourceGroups](https://github.com/Azure/ResourceModules/workflows/Resources:%20ResourceGroups/badge.svg?branch=users%2Falsehr%2Fcontext)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

