### PR TITLE
Updated login in Test-Script to align with Deploy-Script

### DIFF
--- a/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
@@ -115,6 +115,10 @@ function Test-TemplateDeployment {
         #######################
         switch ($deploymentScope) {
             'resourceGroup' {
+                if (-not [String]::IsNullOrEmpty($subscriptionId)) {
+                    Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
+                    $null = Set-AzContext -Subscription $subscriptionId
+                }
                 if (-not (Get-AzResourceGroup -Name $resourceGroupName -ErrorAction 'SilentlyContinue')) {
                     if ($PSCmdlet.ShouldProcess("Resource group [$resourceGroupName] in location [$location]", 'Create')) {
                         New-AzResourceGroup -Name $resourceGroupName -Location $location
@@ -126,9 +130,9 @@ function Test-TemplateDeployment {
                 break
             }
             'subscription' {
-                if ($subscriptionId -and ($Context = Get-AzContext -ListAvailable | Where-Object { $_.Subscription.Id -eq $subscriptionId })) {
-                    Write-Verbose ('Setting context to subscription [{0}]' -f $Context.Subscription.Name)
-                    $null = $Context | Set-AzContext
+                if (-not [String]::IsNullOrEmpty($subscriptionId)) {
+                    Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
+                    $null = Set-AzContext -Subscription $subscriptionId
                 }
                 if ($PSCmdlet.ShouldProcess('Subscription level deployment', 'Test')) {
                     $res = Test-AzSubscriptionDeployment @DeploymentInputs -Location $Location


### PR DESCRIPTION
# Description

- Updated login in Test-Script to align with Deploy-Script
- Ref #1331
- The rational is that the current Get-AzContext only returns a maximum of 25 context objects. If an SP has access to more subscriptions, the login won't work and you may end up deploying into a subscription you did not intent to.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/workflows/AnalysisServices:%20Servers/badge.svg?branch=users%2Falsehr%2FtestscriptUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |
| [![Resources: ResourceGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml/badge.svg?branch=users%2Falsehr%2FtestscriptUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
