### PR TITLE
Align ADO removeDeployment default input parameter 

### DIFF
--- a/.azuredevops/modulePipelines/ms.apimanagement.service.yml
+++ b/.azuredevops/modulePipelines/ms.apimanagement.service.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Soft-delete prevents re-deployment
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.cognitiveservices.accounts.yml
+++ b/.azuredevops/modulePipelines/ms.cognitiveservices.accounts.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Soft-delete prevents re-deployment
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.insights.diagnosticsettings.yml
+++ b/.azuredevops/modulePipelines/ms.insights.diagnosticsettings.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Needs custom removals script
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.keyvault.vaults.yml
+++ b/.azuredevops/modulePipelines/ms.keyvault.vaults.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Soft-delete prevents re-deployment
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.kubernetesconfiguration.extensions.yml
+++ b/.azuredevops/modulePipelines/ms.kubernetesconfiguration.extensions.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.kubernetesconfiguration.fluxconfigurations.yml
+++ b/.azuredevops/modulePipelines/ms.kubernetesconfiguration.fluxconfigurations.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false
+    default: true
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean

--- a/.azuredevops/modulePipelines/ms.network.networkwatchers.yml
+++ b/.azuredevops/modulePipelines/ms.network.networkwatchers.yml
@@ -4,7 +4,7 @@ parameters:
   - name: removeDeployment
     displayName: Remove deployed module
     type: boolean
-    default: false # Required as a dependency + Only one Network Watcher can exist in the same location. If removed, a default would be created in a dedicated RG
+    default: false # Only one Network Watcher can exist in the same location. If removed, a default would be created in a dedicated RG
   - name: prerelease
     displayName: Publish prerelease module
     type: boolean


### PR DESCRIPTION
# Description

Update `removeDeployment` default parameter for ADO pipelines still disabling removal for modules with soft deletion.

![image](https://user-images.githubusercontent.com/56914614/165155433-038d6e27-3e3a-499c-8f9d-fe44937c1c24.png)

![image](https://user-images.githubusercontent.com/56914614/165155701-9a427559-db30-41dd-9ced-cb6cb7465ba7.png)


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Build Status](https://dev.azure.com/servicescode/infra-as-code-source/_apis/build/status/CARML-Modules/KeyVault%20-%20Vaults?branchName=users%2Ferikag%2Falign-ado-removal)](https://dev.azure.com/servicescode/infra-as-code-source/_build/latest?definitionId=2195&branchName=users%2Ferikag%2Falign-ado-removal) |

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
