### PR TITLE
[RBAC]: Switched from resource name to resource ID

### DIFF
--- a/arm/Microsoft.AAD/DomainServices/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.AAD/DomainServices/.bicep/nested_rbac.bicep
@@ -59,7 +59,7 @@ resource AzureADDS 'Microsoft.AAD/DomainServices@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(AzureADDS.name, principalId, roleDefinitionIdOrName)
+  name: guid(AzureADDS.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.AnalysisServices/servers/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource server 'Microsoft.AnalysisServices/servers@2017-08-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(server.name, principalId, roleDefinitionIdOrName)
+  name: guid(server.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ApiManagement/service/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource service 'Microsoft.ApiManagement/service@2020-12-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(service.name, principalId, roleDefinitionIdOrName)
+  name: guid(service.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Automation/automationAccounts/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2020-01-13-p
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(automationAccount.name, principalId, roleDefinitionIdOrName)
+  name: guid(automationAccount.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.CognitiveServices/accounts/.bicep/nested_rbac.bicep
@@ -59,7 +59,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2017-04-18' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(account.name, principalId, roleDefinitionIdOrName)
+  name: guid(account.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/availabilitySets/.bicep/nested_rbac.bicep
@@ -50,7 +50,7 @@ resource availabilitySet 'Microsoft.Compute/availabilitySets@2021-04-01' existin
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(availabilitySet.name, principalId, roleDefinitionIdOrName)
+  name: guid(availabilitySet.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/diskEncryptionSets/.bicep/nested_rbac.bicep
@@ -48,7 +48,7 @@ resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2020-12-01' exi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(diskEncryptionSet.name, principalId, roleDefinitionIdOrName)
+  name: guid(diskEncryptionSet.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/disks/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource disk 'Microsoft.Compute/disks@2021-08-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(disk.name, principalId, roleDefinitionIdOrName)
+  name: guid(disk.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource gallery 'Microsoft.Compute/galleries@2020-09-30' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(gallery.name, principalId, roleDefinitionIdOrName)
+  name: guid(gallery.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/galleries/images/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource galleryImage 'Microsoft.Compute/galleries/images@2020-09-30' existing =
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(galleryImage.name, principalId, roleDefinitionIdOrName)
+  name: guid(galleryImage.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/images/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource image 'Microsoft.Compute/images@2021-04-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(image.name, principalId, roleDefinitionIdOrName)
+  name: guid(image.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/proximityPlacementGroups/.bicep/nested_rbac.bicep
@@ -48,7 +48,7 @@ resource proximityPlacementGroup 'Microsoft.Compute/proximityPlacementGroups@202
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(proximityPlacementGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(proximityPlacementGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachineScaleSets/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-04-01' existing = 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(vmss.name, principalId, roleDefinitionIdOrName)
+  name: guid(vmss.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_publicIPAddress_rbac.bicep
@@ -50,7 +50,7 @@ resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' existi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(publicIpAddress.name, principalId, roleDefinitionIdOrName)
+  name: guid(publicIpAddress.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface_rbac.bicep
@@ -50,7 +50,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-03-01' exist
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(networkInterface.name, principalId, roleDefinitionIdOrName)
+  name: guid(networkInterface.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/.bicep/nested_rbac.bicep
@@ -50,7 +50,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-07-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(virtualMachine.name, principalId, roleDefinitionIdOrName)
+  name: guid(virtualMachine.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerRegistry/registries/.bicep/nested_rbac.bicep
@@ -51,7 +51,7 @@ resource registry 'Microsoft.ContainerRegistry/registries@2021-09-01' existing =
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(registry.name, principalId, roleDefinitionIdOrName)
+  name: guid(registry.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ContainerService/managedClusters/.bicep/nested_rbac.bicep
@@ -51,7 +51,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2021-07-01' 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(managedCluster.name, principalId, roleDefinitionIdOrName)
+  name: guid(managedCluster.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DataFactory/factories/.bicep/nested_rbac.bicep
@@ -43,7 +43,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(dataFactory.name, principalId, roleDefinitionIdOrName)
+  name: guid(dataFactory.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Databricks/workspaces/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource workspace 'Microsoft.Databricks/workspaces@2018-04-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(workspace.name, principalId, roleDefinitionIdOrName)
+  name: guid(workspace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/applicationgroups/.bicep/nested_rbac.bicep
@@ -50,7 +50,7 @@ resource appGroup 'Microsoft.DesktopVirtualization/applicationgroups@2021-07-12'
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(appGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(appGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/hostpools/.bicep/nested_rbac.bicep
@@ -51,7 +51,7 @@ resource hostPool 'Microsoft.DesktopVirtualization/hostpools@2021-07-12' existin
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(hostPool.name, principalId, roleDefinitionIdOrName)
+  name: guid(hostPool.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/scalingplans/.bicep/nested_rbac.bicep
@@ -51,7 +51,7 @@ resource hostPool 'Microsoft.DesktopVirtualization/hostpools@2021-07-12' existin
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(hostPool.name, principalId, roleDefinitionIdOrName)
+  name: guid(hostPool.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DesktopVirtualization/workspaces/.bicep/nested_rbac.bicep
@@ -47,7 +47,7 @@ resource workspace 'Microsoft.DesktopVirtualization/workspaces@2021-07-12' exist
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(workspace.name, principalId, roleDefinitionIdOrName)
+  name: guid(workspace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' exis
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(databaseAccount.name, principalId, roleDefinitionIdOrName)
+  name: guid(databaseAccount.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/systemTopics/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource systemTopic 'Microsoft.EventGrid/systemTopics@2021-12-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(systemTopic.name, principalId, roleDefinitionIdOrName)
+  name: guid(systemTopic.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventGrid/topics/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource eventGrid 'Microsoft.EventGrid/topics@2020-06-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(eventGrid.name, principalId, roleDefinitionIdOrName)
+  name: guid(eventGrid.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.EventHub/namespaces/.bicep/nested_rbac.bicep
@@ -47,7 +47,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2017-04-01' existing =
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(eventHubNamespace.name, principalId, roleDefinitionIdOrName)
+  name: guid(eventHubNamespace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.HealthBot/healthBots/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource healthBot 'Microsoft.HealthBot/healthBots@2021-06-10' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(healthBot.name, principalId, roleDefinitionIdOrName)
+  name: guid(healthBot.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/actionGroups/.bicep/nested_rbac.bicep
@@ -43,7 +43,7 @@ resource actionGroup 'microsoft.insights/actionGroups@2019-06-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(actionGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(actionGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/activityLogAlerts/.bicep/nested_rbac.bicep
@@ -43,7 +43,7 @@ resource activityLogAlert 'Microsoft.Insights/activityLogAlerts@2020-10-01' exis
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(activityLogAlert.name, principalId, roleDefinitionIdOrName)
+  name: guid(activityLogAlert.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/components/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(appInsights.name, principalId, roleDefinitionIdOrName)
+  name: guid(appInsights.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/metricAlerts/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(metricAlert.name, principalId, roleDefinitionIdOrName)
+  name: guid(metricAlert.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/privateLinkScopes/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource privateLinkScope 'Microsoft.Insights/privateLinkScopes@2019-10-17-previ
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(privateLinkScope.name, principalId, roleDefinitionIdOrName)
+  name: guid(privateLinkScope.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Insights/scheduledQueryRules/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource queryAlert 'microsoft.insights/scheduledQueryRules@2018-04-16' existing
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(queryAlert.name, principalId, roleDefinitionIdOrName)
+  name: guid(queryAlert.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/.bicep/nested_rbac.bicep
@@ -51,7 +51,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(keyVault.name, principalId, roleDefinitionIdOrName)
+  name: guid(keyVault.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/keys/.bicep/nested_rbac.bicep
@@ -50,7 +50,7 @@ resource key 'Microsoft.KeyVault/vaults/keys@2021-06-01-preview' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(key.name, principalId, roleDefinitionIdOrName)
+  name: guid(key.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.KeyVault/vaults/secrets/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(secret.name, principalId, roleDefinitionIdOrName)
+  name: guid(secret.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Logic/workflows/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource logicApp 'Microsoft.Logic/workflows@2019-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(logicApp.name, principalId, roleDefinitionIdOrName)
+  name: guid(logicApp.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.MachineLearningServices/workspaces/.bicep/nested_rbac.bicep
@@ -43,7 +43,7 @@ resource workspace 'Microsoft.MachineLearningServices/workspaces@2021-04-01' exi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(workspace.name, principalId, roleDefinitionIdOrName)
+  name: guid(workspace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ManagedIdentity/userAssignedIdentities/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource userMsi 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' e
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(userMsi.name, principalId, roleDefinitionIdOrName)
+  name: guid(userMsi.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2021-04-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(netAppAccount.name, principalId, roleDefinitionIdOrName)
+  name: guid(netAppAccount.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource capacityPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2021-04-01'
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(capacityPool.name, principalId, roleDefinitionIdOrName)
+  name: guid(capacityPool.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2021-04-0
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(volume.name, principalId, roleDefinitionIdOrName)
+  name: guid(volume.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationGateways/.bicep/nested_rbac.bicep
@@ -50,7 +50,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-05-01' e
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(applicationGateway.name, principalId, roleDefinitionIdOrName)
+  name: guid(applicationGateway.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/applicationSecurityGroups/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(applicationSecurityGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(applicationSecurityGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' existing = 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(azureFirewall.name, principalId, roleDefinitionIdOrName)
+  name: guid(azureFirewall.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_publicIPAddress_rbac.bicep
@@ -50,7 +50,7 @@ resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' existi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(publicIpAddress.name, principalId, roleDefinitionIdOrName)
+  name: guid(publicIpAddress.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/bastionHosts/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource azureBastion 'Microsoft.Network/bastionHosts@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(azureBastion.name, principalId, roleDefinitionIdOrName)
+  name: guid(azureBastion.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ddosProtectionPlans/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource ddosProtectionPlan 'Microsoft.Network/ddosProtectionPlans@2021-05-01' e
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(ddosProtectionPlan.name, principalId, roleDefinitionIdOrName)
+  name: guid(ddosProtectionPlan.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/expressRouteCircuits/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource expressRouteCircuits 'Microsoft.Network/expressRouteCircuits@2021-05-01
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(expressRouteCircuits.name, principalId, roleDefinitionIdOrName)
+  name: guid(expressRouteCircuits.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/frontDoors/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource frontDoor 'Microsoft.Network/frontDoors@2020-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(frontDoor.name, principalId, roleDefinitionIdOrName)
+  name: guid(frontDoor.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/ipGroups/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource ipGroup 'Microsoft.Network/ipGroups@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(ipGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(ipGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/loadBalancers/.bicep/nested_rbac.bicep
@@ -48,7 +48,7 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(loadBalancer.name, principalId, roleDefinitionIdOrName)
+  name: guid(loadBalancer.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/localNetworkGateways/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2021-08-01'
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(localNetworkGateway.name, principalId, roleDefinitionIdOrName)
+  name: guid(localNetworkGateway.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/natGateways/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource natGateway 'Microsoft.Network/natGateways@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(natGateway.name, principalId, roleDefinitionIdOrName)
+  name: guid(natGateway.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkSecurityGroups/.bicep/nested_rbac.bicep
@@ -47,7 +47,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-05-0
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(networkSecurityGroup.name, principalId, roleDefinitionIdOrName)
+  name: guid(networkSecurityGroup.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/networkWatchers/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource networkWatcher 'Microsoft.Network/networkWatchers@2021-05-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(networkWatcher.name, principalId, roleDefinitionIdOrName)
+  name: guid(networkWatcher.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateDnsZones/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2018-09-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(privateDnsZone.name, principalId, roleDefinitionIdOrName)
+  name: guid(privateDnsZone.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/privateEndpoints/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2021-05-01' existin
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(privateEndpoint.name, principalId, roleDefinitionIdOrName)
+  name: guid(privateEndpoint.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPAddresses/.bicep/nested_rbac.bicep
@@ -48,7 +48,7 @@ resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' existi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(publicIpAddress.name, principalId, roleDefinitionIdOrName)
+  name: guid(publicIpAddress.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/publicIPPrefixes/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource publicIpPrefix 'Microsoft.Network/publicIPPrefixes@2021-05-01' existing
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(publicIpPrefix.name, principalId, roleDefinitionIdOrName)
+  name: guid(publicIpPrefix.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/routeTables/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource routeTable 'Microsoft.Network/routeTables@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(routeTable.name, principalId, roleDefinitionIdOrName)
+  name: guid(routeTable.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/trafficmanagerprofiles/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource trafficmanagerprofile 'Microsoft.Network/trafficmanagerprofiles@2018-08
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(trafficmanagerprofile.name, principalId, roleDefinitionIdOrName)
+  name: guid(trafficmanagerprofile.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworkGateways/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2021-05
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(virtualNetworkGateway.name, principalId, roleDefinitionIdOrName)
+  name: guid(virtualNetworkGateway.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/.bicep/nested_rbac.bicep
@@ -59,7 +59,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(virtualNetwork.name, principalId, roleDefinitionIdOrName)
+  name: guid(virtualNetwork.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/virtualNetworks/subnets/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualNetworks/subnets/.bicep/nested_rbac.bicep
@@ -59,7 +59,7 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-03-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(subnet.name, principalId, roleDefinitionIdOrName)
+  name: guid(subnet.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/virtualWans/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource virtualWan 'Microsoft.Network/virtualWans@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(virtualWan.name, principalId, roleDefinitionIdOrName)
+  name: guid(virtualWan.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Network/vpnSites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Network/vpnSites/.bicep/nested_rbac.bicep
@@ -27,7 +27,7 @@ resource vpnSite 'Microsoft.Network/vpnSites@2021-05-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(vpnSite.name, principalId, roleDefinitionIdOrName)
+  name: guid(vpnSite.id, principalId, roleDefinitionIdOrName)
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId

--- a/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(logAnalyticsWorkspace.name, principalId, roleDefinitionIdOrName)
+  name: guid(logAnalyticsWorkspace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.RecoveryServices/vaults/.bicep/nested_rbac.bicep
@@ -49,7 +49,7 @@ resource rsv 'Microsoft.RecoveryServices/vaults@2021-12-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(rsv.name, principalId, roleDefinitionIdOrName)
+  name: guid(rsv.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2021-06-01-preview' existing
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(namespace.name, principalId, roleDefinitionIdOrName)
+  name: guid(namespace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/queues/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource queue 'Microsoft.ServiceBus/namespaces/queues@2021-06-01-preview' exist
 }
 
 resource roleAssigment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(queue.name, principalId, roleDefinitionIdOrName)
+  name: guid(queue.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceBus/namespaces/topics/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource topic 'Microsoft.ServiceBus/namespaces/topics@2021-06-01-preview' exist
 }
 
 resource roleAssigment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(topic.name, principalId, roleDefinitionIdOrName)
+  name: guid(topic.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.ServiceFabric/clusters/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource serviceFabricCluster 'Microsoft.ServiceFabric/clusters@2021-06-01' exis
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for principalId in principalIds: {
-  name: guid(serviceFabricCluster.name, principalId, roleDefinitionIdOrName)
+  name: guid(serviceFabricCluster.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/managedInstances/.bicep/nested_rbac.bicep
@@ -45,7 +45,7 @@ resource managedInstance 'Microsoft.Sql/managedInstances@2020-08-01-preview' exi
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(managedInstance.name, principalId, roleDefinitionIdOrName)
+  name: guid(managedInstance.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Sql/servers/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource server 'Microsoft.Sql/servers@2020-02-02-preview' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(server.name, principalId, roleDefinitionIdOrName)
+  name: guid(server.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/.bicep/nested_rbac.bicep
@@ -69,7 +69,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(storageAccount.name, principalId, roleDefinitionIdOrName)
+  name: guid(storageAccount.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/blobServices/containers/.bicep/nested_rbac.bicep
@@ -60,7 +60,7 @@ resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@20
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(container.name, principalId, roleDefinitionIdOrName)
+  name: guid(container.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/fileServices/shares/.bicep/nested_rbac.bicep
@@ -69,7 +69,7 @@ resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2019-0
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(fileShare.name, principalId, roleDefinitionIdOrName)
+  name: guid(fileShare.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Storage/storageAccounts/queueServices/queues/.bicep/nested_rbac.bicep
@@ -66,7 +66,7 @@ resource queue 'Microsoft.Storage/storageAccounts/queueServices/queues@2019-06-0
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(queue.name, principalId, roleDefinitionIdOrName)
+  name: guid(queue.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Synapse/privateLinkHubs/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource privateLinkHub 'Microsoft.Synapse/privateLinkHubs@2021-06-01' existing 
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(privateLinkHub.name, principalId, roleDefinitionIdOrName)
+  name: guid(privateLinkHub.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.VirtualMachineImages/imageTemplates/.bicep/nested_rbac.bicep
@@ -42,7 +42,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2020-02-14
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(imageTemplate.name, principalId, roleDefinitionIdOrName)
+  name: guid(imageTemplate.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/connections/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource connection 'Microsoft.Web/connections@2016-06-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(connection.name, principalId, roleDefinitionIdOrName)
+  name: guid(connection.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/hostingEnvironments/.bicep/nested_rbac.bicep
@@ -43,7 +43,7 @@ resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2021-02-01' ex
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(appServiceEnvironment.name, principalId, roleDefinitionIdOrName)
+  name: guid(appServiceEnvironment.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/serverfarms/.bicep/nested_rbac.bicep
@@ -46,7 +46,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2021-02-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(appServicePlan.name, principalId, roleDefinitionIdOrName)
+  name: guid(appServicePlan.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/sites/.bicep/nested_rbac.bicep
@@ -44,7 +44,7 @@ resource app 'Microsoft.Web/sites@2020-12-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(app.name, principalId, roleDefinitionIdOrName)
+  name: guid(app.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/arm/Microsoft.Web/staticSites/.bicep/nested_rbac.bicep
+++ b/arm/Microsoft.Web/staticSites/.bicep/nested_rbac.bicep
@@ -24,7 +24,7 @@ resource staticSite 'Microsoft.Web/staticSites@2021-02-01' existing = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(staticSite.name, principalId, roleDefinitionIdOrName)
+  name: guid(staticSite.id, principalId, roleDefinitionIdOrName)
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId

--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -203,7 +203,7 @@ resource <mainResource> '<mainResourceProviderNamespace>/<resourceType>@<resourc
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
-  name: guid(<mainResource>.name, principalId, roleDefinitionIdOrName)
+  name: guid(<mainResource>.id, principalId, roleDefinitionIdOrName)
   properties: {
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId


### PR DESCRIPTION
# Description

- Swichted 'resource name' reference in RBAC deployment name to resource ID

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/workflows/AnalysisServices:%20Servers/badge.svg?branch=users%2Falsehr%2F1351_rbacID)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)|

# Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
