### PR TITLE
allowed User assigned identity deployments

### DIFF
--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/mg.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/mg.parameters.json
@@ -41,7 +41,7 @@
         },
         "notScopes": {
             "value": [
-                "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg"
+                "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>"
             ]
         },
         "identity": {

--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/mg.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/mg.parameters.json
@@ -41,7 +41,7 @@
         },
         "notScopes": {
             "value": [
-                "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>"
+                "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg"
             ]
         },
         "identity": {

--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.min.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.min.parameters.json
@@ -12,7 +12,7 @@
             "value": "<<subscriptionId>>"
         },
         "resourceGroupName": {
-            "value": "<<resourceGroupName>>"
+            "value": "validation-rg"
         }
     }
 }

--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.parameters.json
@@ -41,14 +41,14 @@
         },
         "notScopes": {
             "value": [
-                "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>/providers/Microsoft.KeyVault/vaults/adp-<<namePrefix>>-az-kv-x-001"
+                "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.KeyVault/vaults/adp-<<namePrefix>>-az-kv-x-001"
             ]
         },
         "identity": {
             "value": "UserAssigned"
         },
         "userAssignedIdentityId": {
-            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/<<resourceGroupName>>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001"
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001"
         },
         "roleDefinitionIds": {
             "value": [
@@ -59,7 +59,7 @@
             "value": "<<subscriptionId>>"
         },
         "resourceGroupName": {
-            "value": "<<resourceGroupName>>"
+            "value": "validation-rg"
         }
     }
 }

--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/rg.parameters.json
@@ -45,7 +45,10 @@
             ]
         },
         "identity": {
-            "value": "SystemAssigned"
+            "value": "UserAssigned"
+        },
+        "userAssignedIdentityId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/<<resourceGroupName>>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001"
         },
         "roleDefinitionIds": {
             "value": [

--- a/arm/Microsoft.Authorization/policyAssignments/.parameters/sub.parameters.json
+++ b/arm/Microsoft.Authorization/policyAssignments/.parameters/sub.parameters.json
@@ -45,7 +45,10 @@
             ]
         },
         "identity": {
-            "value": "SystemAssigned"
+            "value": "UserAssigned"
+        },
+        "userAssignedIdentityId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-<<namePrefix>>-az-msi-x-001"
         },
         "roleDefinitionIds": {
             "value": [

--- a/arm/Microsoft.Authorization/policyAssignments/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/deploy.bicep
@@ -19,9 +19,13 @@ param parameters object = {}
 @sys.description('Optional. The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning \'Modify\' policy definitions.')
 @allowed([
   'SystemAssigned'
+  'UserAssigned'
   'None'
 ])
 param identity string = 'SystemAssigned'
+
+@sys.description('Optional. The Resource ID for the user assigned identity to assign to the policy assignment.')
+param userAssignedIdentityId string = ''
 
 @sys.description('Required. The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition')
 param roleDefinitionIds array = []
@@ -80,6 +84,7 @@ module policyAssignment_mg 'managementGroup/deploy.bicep' = if (empty(subscripti
     description: !empty(description) ? description : ''
     parameters: !empty(parameters) ? parameters : {}
     identity: identity
+    userAssignedIdentityId: userAssignedIdentityId
     roleDefinitionIds: !empty(roleDefinitionIds) ? roleDefinitionIds : []
     metadata: !empty(metadata) ? metadata : {}
     nonComplianceMessage: !empty(nonComplianceMessage) ? nonComplianceMessage : ''
@@ -101,6 +106,7 @@ module policyAssignment_sub 'subscription/deploy.bicep' = if (!empty(subscriptio
     description: !empty(description) ? description : ''
     parameters: !empty(parameters) ? parameters : {}
     identity: identity
+    userAssignedIdentityId: userAssignedIdentityId
     roleDefinitionIds: !empty(roleDefinitionIds) ? roleDefinitionIds : []
     metadata: !empty(metadata) ? metadata : {}
     nonComplianceMessage: !empty(nonComplianceMessage) ? nonComplianceMessage : ''
@@ -122,6 +128,7 @@ module policyAssignment_rg 'resourceGroup/deploy.bicep' = if (!empty(resourceGro
     description: !empty(description) ? description : ''
     parameters: !empty(parameters) ? parameters : {}
     identity: identity
+    userAssignedIdentityId: userAssignedIdentityId
     roleDefinitionIds: !empty(roleDefinitionIds) ? roleDefinitionIds : []
     metadata: !empty(metadata) ? metadata : {}
     nonComplianceMessage: !empty(nonComplianceMessage) ? nonComplianceMessage : ''

--- a/arm/Microsoft.Authorization/policyAssignments/managementGroup/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/managementGroup/deploy.bicep
@@ -20,9 +20,13 @@ param parameters object = {}
 @sys.description('Optional. The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning \'Modify\' policy definitions.')
 @allowed([
   'SystemAssigned'
+  'UserAssigned'
   'None'
 ])
 param identity string = 'SystemAssigned'
+
+@sys.description('Optional. The Resource ID for the user assigned identity to assign to the policy assignment.')
+param userAssignedIdentityId string = ''
 
 @sys.description('Required. The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition')
 param roleDefinitionIds array = []
@@ -58,6 +62,11 @@ param enableDefaultTelemetry bool = true
 
 var identity_var = identity == 'SystemAssigned' ? {
   type: identity
+} : identity == 'UserAssigned' ? {
+  type: identity
+  userAssignedIdentities: {
+    '${userAssignedIdentityId}': {}
+  }
 } : null
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
@@ -89,7 +98,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
   identity: identity_var
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity != 'None') {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity == 'SystemAssigned') {
   name: guid(managementGroupId, roleDefinitionId, location, name)
   properties: {
     roleDefinitionId: roleDefinitionId

--- a/arm/Microsoft.Authorization/policyAssignments/managementGroup/readme.md
+++ b/arm/Microsoft.Authorization/policyAssignments/managementGroup/readme.md
@@ -31,13 +31,14 @@ With this module you can perform policy assignments on a management group level.
 | `displayName` | string | `''` |  | The display name of the policy assignment. Maximum length is 128 characters. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `enforcementMode` | string | `'Default'` | `[Default, DoNotEnforce]` | The policy assignment enforcement mode. Possible values are Default and DoNotEnforce. - Default or DoNotEnforce |
-| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
+| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, UserAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
 | `location` | string | `[deployment().location]` |  | Location for all resources. |
 | `managementGroupId` | string | `[managementGroup().name]` |  | The Target Scope for the Policy. The name of the management group for the policy assignment. If not provided, will use the current scope for deployment. |
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessage` | string | `''` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
+| `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
 
 
 ## Outputs

--- a/arm/Microsoft.Authorization/policyAssignments/readme.md
+++ b/arm/Microsoft.Authorization/policyAssignments/readme.md
@@ -32,7 +32,7 @@ With this module you can perform policy assignments across the management group,
 | `displayName` | string | `''` |  | The display name of the policy assignment. Maximum length is 128 characters. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `enforcementMode` | string | `'Default'` | `[Default, DoNotEnforce]` | The policy assignment enforcement mode. Possible values are Default and DoNotEnforce. - Default or DoNotEnforce |
-| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
+| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, UserAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
 | `location` | string | `[deployment().location]` |  | Location for all resources. |
 | `managementGroupId` | string | `[managementGroup().name]` |  | The Target Scope for the Policy. The name of the management group for the policy assignment. If not provided, will use the current scope for deployment. |
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
@@ -41,6 +41,7 @@ With this module you can perform policy assignments across the management group,
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
 | `resourceGroupName` | string | `''` |  | The Target Scope for the Policy. The name of the resource group for the policy assignment |
 | `subscriptionId` | string | `''` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment |
+| `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
 
 
 ### Parameter Usage: `managementGroupId`

--- a/arm/Microsoft.Authorization/policyAssignments/resourceGroup/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/resourceGroup/deploy.bicep
@@ -20,9 +20,13 @@ param parameters object = {}
 @sys.description('Optional. The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning \'Modify\' policy definitions.')
 @allowed([
   'SystemAssigned'
+  'UserAssigned'
   'None'
 ])
 param identity string = 'SystemAssigned'
+
+@sys.description('Optional. The Resource ID for the user assigned identity to assign to the policy assignment.')
+param userAssignedIdentityId string = ''
 
 @sys.description('Required. The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition')
 param roleDefinitionIds array = []
@@ -73,6 +77,11 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
 
 var identity_var = identity == 'SystemAssigned' ? {
   type: identity
+} : identity == 'UserAssigned' ? {
+  type: identity
+  userAssignedIdentities: {
+    '${userAssignedIdentityId}': {}
+  }
 } : null
 
 resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = {
@@ -91,7 +100,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
   identity: identity_var
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity != 'None') {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity == 'SystemAssigned') {
   name: guid(subscriptionId, resourceGroupName, roleDefinitionId, location, name)
   properties: {
     roleDefinitionId: roleDefinitionId

--- a/arm/Microsoft.Authorization/policyAssignments/resourceGroup/readme.md
+++ b/arm/Microsoft.Authorization/policyAssignments/resourceGroup/readme.md
@@ -31,7 +31,7 @@ With this module you can perform policy assignments on a resource group level
 | `displayName` | string | `''` |  | The display name of the policy assignment. Maximum length is 128 characters. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `enforcementMode` | string | `'Default'` | `[Default, DoNotEnforce]` | The policy assignment enforcement mode. Possible values are Default and DoNotEnforce. - Default or DoNotEnforce |
-| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
+| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, UserAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessage` | string | `''` |  | The messages that describe why a resource is non-compliant with the policy. |
@@ -39,6 +39,7 @@ With this module you can perform policy assignments on a resource group level
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
 | `resourceGroupName` | string | `[resourceGroup().name]` |  | The Target Scope for the Policy. The name of the resource group for the policy assignment. If not provided, will use the current scope for deployment. |
 | `subscriptionId` | string | `[subscription().subscriptionId]` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment. |
+| `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
 
 
 ## Outputs

--- a/arm/Microsoft.Authorization/policyAssignments/subscription/deploy.bicep
+++ b/arm/Microsoft.Authorization/policyAssignments/subscription/deploy.bicep
@@ -20,9 +20,13 @@ param parameters object = {}
 @sys.description('Optional. The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning \'Modify\' policy definitions.')
 @allowed([
   'SystemAssigned'
+  'UserAssigned'
   'None'
 ])
 param identity string = 'SystemAssigned'
+
+@sys.description('Optional. The Resource ID for the user assigned identity to assign to the policy assignment.')
+param userAssignedIdentityId string = ''
 
 @sys.description('Required. The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition')
 param roleDefinitionIds array = []
@@ -58,6 +62,11 @@ param enableDefaultTelemetry bool = true
 
 var identity_var = identity == 'SystemAssigned' ? {
   type: identity
+} : identity == 'UserAssigned' ? {
+  type: identity
+  userAssignedIdentities: {
+    '${userAssignedIdentityId}': {}
+  }
 } : null
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
@@ -89,7 +98,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
   identity: identity_var
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity != 'None') {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && identity == 'SystemAssigned') {
   name: guid(subscriptionId, roleDefinitionId, location, name)
   properties: {
     roleDefinitionId: roleDefinitionId

--- a/arm/Microsoft.Authorization/policyAssignments/subscription/readme.md
+++ b/arm/Microsoft.Authorization/policyAssignments/subscription/readme.md
@@ -31,13 +31,14 @@ With this module you can perform policy assignments on a subscription level.
 | `displayName` | string | `''` |  | The display name of the policy assignment. Maximum length is 128 characters. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `enforcementMode` | string | `'Default'` | `[Default, DoNotEnforce]` | The policy assignment enforcement mode. Possible values are Default and DoNotEnforce. - Default or DoNotEnforce |
-| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
+| `identity` | string | `'SystemAssigned'` | `[SystemAssigned, UserAssigned, None]` | The managed identity associated with the policy assignment. Policy assignments must include a resource identity when assigning 'Modify' policy definitions. |
 | `location` | string | `[deployment().location]` |  | Location for all resources. |
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessage` | string | `''` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
 | `subscriptionId` | string | `[subscription().subscriptionId]` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment. |
+| `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
 
 
 ## Outputs


### PR DESCRIPTION
# Description

Closes #1360 

Enables User assigned identity support for a policy assignment.

Note: This will not trigger the 'role assignment' resource creation object as it is assumed that a user identity will have the permissions required to modify resources. Hence the role assignment will only run if the policy is using a system assigned identity.


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline | Run |
| - | - |
| policy assignment |[![Authorization: PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Fahmad%2FpolicyAssignment_UMI)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml) |


# Type of Change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
