### PR TITLE
[CI environment] Set Az Context in Removal Stage in ADO

### DIFF
--- a/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
+++ b/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
@@ -359,6 +359,7 @@ jobs:
                       DeploymentName    = '$(deploymentName)'
                       TemplateFilePath  = $templateFilePath
                       ResourceGroupName = '${{ parameters.resourceGroupName }}'
+                      subscriptionId       = '${{ parameters.subscriptionId }}'
                       ManagementGroupId = '${{ parameters.managementGroupId }}'
                       Verbose           = $true
                   }

--- a/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
+++ b/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
@@ -359,7 +359,7 @@ jobs:
                       DeploymentName    = '$(deploymentName)'
                       TemplateFilePath  = $templateFilePath
                       ResourceGroupName = '${{ parameters.resourceGroupName }}'
-                      subscriptionId       = '${{ parameters.subscriptionId }}'
+                      subscriptionId    = '${{ parameters.subscriptionId }}'
                       ManagementGroupId = '${{ parameters.managementGroupId }}'
                       Verbose           = $true
                   }

--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -37,6 +37,9 @@ function Initialize-DeploymentRemoval {
         [string] $ResourceGroupName,
 
         [Parameter(Mandatory = $false)]
+        [string] $subscriptionId,
+
+        [Parameter(Mandatory = $false)]
         [string] $ManagementGroupId
     )
 
@@ -47,6 +50,12 @@ function Initialize-DeploymentRemoval {
     }
 
     process {
+
+        if (-not [String]::IsNullOrEmpty($subscriptionId)) {
+            Write-Verbose ('Setting context to subscription [{0}]' -f $subscriptionId)
+            $null = Set-AzContext -Subscription $subscriptionId
+        }
+
         $moduleName = Split-Path (Split-Path $templateFilePath -Parent) -LeafBase
 
         # The initial sequence is a general order-recommendation


### PR DESCRIPTION
# Description
If the used ServiceConnection in ADO has access to more than one subscription. It can use the wrong as default and doesn't find the deployments to remove. Therefore the Context will be set accordingly to the subscription.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Build Status](https://dev.azure.com/seseichtMSFT/CARLM-SeSeicht/_apis/build/status/SeSeicht.ResourceModules?branchName=fix%2FRemovalContext)](https://dev.azure.com/seseichtMSFT/CARLM-SeSeicht/_build/latest?definitionId=310&branchName=fix%2FRemovalContext) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
