### PR TITLE
Fixed location output test for global resources

### DIFF
--- a/arm/.global/global.module.tests.ps1
+++ b/arm/.global/global.module.tests.ps1
@@ -719,7 +719,7 @@ Describe 'Deployment template tests' -Tag Template {
             $primaryResourceType = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/arm/')[1]
             $primaryResourceTypeResource = $templateContent.resources | Where-Object { $_.type -eq $primaryResourceType }
 
-            if ($primaryResourceTypeResource.keys -contains 'location') {
+            if ($primaryResourceTypeResource.keys -contains 'location' -and $primaryResourceTypeResource.location -ne 'global') {
                 # If the main resource has a location property, an output should be returned too
                 $outputs.keys | Should -Contain 'location'
 


### PR DESCRIPTION
# Description

Fixed the location output test for global resources.

## Pipeline references

| Pipeline |
| - |
| [![Network: TrafficManagerProfiles](https://github.com/MrRoundRobin/AzureResourceModules/actions/workflows/ms.network.trafficmanagerprofiles.yml/badge.svg?branch=users%2Fromuell%2Ffix_test_location)](https://github.com/MrRoundRobin/AzureResourceModules/actions/workflows/ms.network.trafficmanagerprofiles.yml) |

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
