### PR TITLE
[Docs] picture fix: changing to <img>

### DIFF
--- a/docs/wiki/Solution creation.md
+++ b/docs/wiki/Solution creation.md
@@ -356,7 +356,7 @@ The modules provided by this repo can be orchestrated to create more complex inf
 
 ### Repo structure
 
-![RepoStructure](../media/MultiRepoTestFolderStructure.png)
+   <img src="../media/MultiRepoTestFolderStructure.png" alt="Repo Structure">
 
 ### YAML pipeline
 


### PR DESCRIPTION
# Description

picture isn't showing at https://github.com/Azure/ResourceModules/wiki/Solution%20creation#repo-structure

<img width="315" alt="image" src="https://user-images.githubusercontent.com/19261257/168273660-1d8155ba-f62c-419e-9dbd-3c9784587a3a.png">

Could be potentially integrated into #1375 

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
