### PR TITLE
[Modules] 1154 Add Public IP to Azure Firewall

### DIFF
--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -943,6 +943,9 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/8.aadds.parameters.json
               templateFilePath: $(templateFilePath)
               displayName: AADDS Virtual Network
+            - path: $(dependencyPath)/$(resourceType)/parameters/9.azfw.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Azure Firewall Virtual Network Min
             - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
                 - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
                   templateFilePath: $(templateFilePath)

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -544,7 +544,9 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/fw.parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Firewall Public IP
-
+            - path: $(dependencyPath)/$(resourceType)/parameters/fw.additional.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Firewall Additional Public IP
   - stage: deploy_appi
     displayName: Deploy application insight
     dependsOn:

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -946,6 +946,9 @@ stages:
             - path: $(dependencyPath)/$(resourceType)/parameters/9.azfw.parameters.json
               templateFilePath: $(templateFilePath)
               displayName: Azure Firewall Virtual Network Min
+            - path: $(dependencyPath)/$(resourceType)/parameters/10.azfw.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Azure Firewall Virtual Network Custom Pip
             - ${{ if eq( parameters.deploySqlMiDependencies, true) }}:
                 - path: $(dependencyPath)/$(resourceType)/parameters/6.sqlmi.parameters.json
                   templateFilePath: $(templateFilePath)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 
 Please delete options that are not relevant.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Update to documentation

--- a/.github/workflows/ms.network.azurefirewalls.yml
+++ b/.github/workflows/ms.network.azurefirewalls.yml
@@ -88,6 +88,7 @@ jobs:
       - job_module_pester_validation
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         parameterFilePaths: ${{ fromJSON(needs.job_initialize_pipeline.outputs.parameterFilePaths) }}
     steps:

--- a/.github/workflows/ms.network.azurefirewalls.yml
+++ b/.github/workflows/ms.network.azurefirewalls.yml
@@ -88,7 +88,6 @@ jobs:
       - job_module_pester_validation
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         parameterFilePaths: ${{ fromJSON(needs.job_initialize_pipeline.outputs.parameterFilePaths) }}
     steps:

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -1260,6 +1260,7 @@ jobs:
             '5.aks.parameters.json',
             '7.virtualHubConnection.parameters.json',
             '8.aadds.parameters.json',
+            '9.azfw.parameters.json'
             'parameters.json',
           ]
     steps:

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -752,6 +752,7 @@ jobs:
             'lb.parameters.json',
             'lb.min.parameters.json',
             'fw.parameters.json',
+            'fw.additional.parameters.json'
           ]
     steps:
       - name: 'Checkout'

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -1260,7 +1260,7 @@ jobs:
             '5.aks.parameters.json',
             '7.virtualHubConnection.parameters.json',
             '8.aadds.parameters.json',
-            '9.azfw.parameters.json'
+            '9.azfw.parameters.json',
             'parameters.json',
           ]
     steps:

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -1261,7 +1261,8 @@ jobs:
             '7.virtualHubConnection.parameters.json',
             '8.aadds.parameters.json',
             '9.azfw.parameters.json',
-            'parameters.json',
+            '10.azfw.parameters.json',
+            'parameters.json'
           ]
     steps:
       - name: 'Checkout'

--- a/arm/Microsoft.Network/azureFirewalls/.bicep/nested_publicIPAddress.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/.bicep/nested_publicIPAddress.bicep
@@ -1,0 +1,161 @@
+@description('Required. The name of the Public IP Address')
+param name string
+
+@description('Optional. Resource ID of the Public IP Prefix object. This is only needed if you want your Public IPs created in a PIP Prefix.')
+param publicIPPrefixResourceId string = ''
+
+@description('Optional. The public IP address allocation method. - Static or Dynamic.')
+param publicIPAllocationMethod string = 'Dynamic'
+
+@description('Optional. Zone numbers e.g. 1,2,3.')
+param zones array = [
+  '1'
+  '2'
+  '3'
+]
+
+@description('Optional. Public IP Address sku Name')
+param skuName string = 'Basic'
+
+@description('Optional. Public IP Address pricing tier')
+param skuTier string = 'Regional'
+
+@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
+@minValue(0)
+@maxValue(365)
+param diagnosticLogsRetentionInDays int = 365
+
+@description('Optional. Resource ID of the diagnostic storage account.')
+param diagnosticStorageAccountId string = ''
+
+@description('Optional. Resource identifier of log analytics.')
+param diagnosticWorkspaceId string = ''
+
+@description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
+param diagnosticEventHubAuthorizationRuleId string = ''
+
+@description('Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category.')
+param diagnosticEventHubName string = ''
+
+@allowed([
+  'CanNotDelete'
+  'NotSpecified'
+  'ReadOnly'
+])
+@description('Optional. Specify the type of lock.')
+param lock string = 'NotSpecified'
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'')
+param roleAssignments array = []
+
+@description('Optional. Tags of the resource.')
+param tags object = {}
+
+@description('Optional. The name of logs that will be streamed.')
+@allowed([
+  'DDoSProtectionNotifications'
+  'DDoSMitigationFlowLogs'
+  'DDoSMitigationReports'
+])
+param diagnosticLogCategoriesToEnable array = [
+  'DDoSProtectionNotifications'
+  'DDoSMitigationFlowLogs'
+  'DDoSMitigationReports'
+]
+
+@description('Optional. The name of metrics that will be streamed.')
+@allowed([
+  'AllMetrics'
+])
+param diagnosticMetricsToEnable array = [
+  'AllMetrics'
+]
+
+@description('Optional. The name of the diagnostic setting, if deployed.')
+param diagnosticSettingsName string = '${name}-diagnosticSettings'
+
+var diagnosticsLogs = [for category in diagnosticLogCategoriesToEnable: {
+  category: category
+  enabled: true
+  retentionPolicy: {
+    enabled: true
+    days: diagnosticLogsRetentionInDays
+  }
+}]
+
+var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
+  category: metric
+  timeGrain: null
+  enabled: true
+  retentionPolicy: {
+    enabled: true
+    days: diagnosticLogsRetentionInDays
+  }
+}]
+
+var publicIPPrefix = {
+  id: publicIPPrefixResourceId
+}
+
+resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  properties: {
+    publicIPAddressVersion: 'IPv4'
+    publicIPAllocationMethod: publicIPAllocationMethod
+    publicIPPrefix: !empty(publicIPPrefixResourceId) ? publicIPPrefix : null
+    idleTimeoutInMinutes: 4
+    ipTags: []
+  }
+  zones: length(zones) == 0 ? null : zones
+}
+
+resource publicIpAddress_lock 'Microsoft.Authorization/locks@2017-04-01' = if (lock != 'NotSpecified') {
+  name: '${publicIpAddress.name}-${lock}-lock'
+  properties: {
+    level: lock
+    notes: lock == 'CanNotDelete' ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
+  }
+  scope: publicIpAddress
+}
+
+resource publicIpAddress_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(diagnosticStorageAccountId) || !empty(diagnosticWorkspaceId) || !empty(diagnosticEventHubAuthorizationRuleId) || !empty(diagnosticEventHubName)) {
+  name: diagnosticSettingsName
+  properties: {
+    storageAccountId: !empty(diagnosticStorageAccountId) ? diagnosticStorageAccountId : null
+    workspaceId: !empty(diagnosticWorkspaceId) ? diagnosticWorkspaceId : null
+    eventHubAuthorizationRuleId: !empty(diagnosticEventHubAuthorizationRuleId) ? diagnosticEventHubAuthorizationRuleId : null
+    eventHubName: !empty(diagnosticEventHubName) ? diagnosticEventHubName : null
+    metrics: diagnosticsMetrics
+    logs: diagnosticsLogs
+  }
+  scope: publicIpAddress
+}
+
+module publicIpAddress_rbac 'nested_publicIPAddress_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
+  name: '${deployment().name}-rbac-${index}'
+  params: {
+    description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
+    principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
+    roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
+    resourceId: publicIpAddress.id
+  }
+}]
+
+@description('The resource group the public IP address was deployed into')
+output resourceGroupName string = resourceGroup().name
+
+@description('The name of the public IP address')
+output name string = publicIpAddress.name
+
+@description('The resource ID of the public IP address')
+output resourceId string = publicIpAddress.id

--- a/arm/Microsoft.Network/azureFirewalls/.bicep/nested_publicIPAddress_rbac.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/.bicep/nested_publicIPAddress_rbac.bicep
@@ -1,0 +1,61 @@
+@sys.description('Required. The IDs of the prinicpals to assign to role to')
+param principalIds array
+
+@sys.description('Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead')
+param roleDefinitionIdOrName string
+
+@sys.description('Required. The resource ID of the resource to apply the role assignment to')
+param resourceId string
+
+@sys.description('Optional. The principal type of the assigned principal ID.')
+@allowed([
+  'ServicePrincipal'
+  'Group'
+  'User'
+  'ForeignGroup'
+  'Device'
+  ''
+])
+param principalType string = ''
+
+@sys.description('Optional. Description of role assignment')
+param description string = ''
+
+var builtInRoleNames = {
+  'Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  'Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  'Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Avere Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f8fab4f-1852-4a58-a46a-8eaf358af14a')
+  'Avere Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c025889f-8102-4ebf-b32c-fc0c6f0c6bd9')
+  'DevTest Labs User': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '76283e04-6283-4c54-8f91-bcf1374a3c64')
+  'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
+  'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')
+  'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')
+  'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')
+  'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')
+  'Microsoft OneAsset Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fd1bb084-1503-4bd2-99c0-630220046786')
+  'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')
+  'Monitoring Metrics Publisher': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')
+  'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
+  'Reservation Purchaser': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f7b75c60-3036-4b75-91c3-6b41c27c1689')
+  'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')
+  'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
+  'Virtual Machine Administrator Login': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1c0163c0-47e6-4577-8991-ea5c82e286e4')
+  'Virtual Machine Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')
+  'Virtual Machine User Login': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb879df8-f326-4884-b1cf-06f3ad86be52')
+}
+
+resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' existing = {
+  name: last(split(resourceId, '/'))
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2021-04-01-preview' = [for principalId in principalIds: {
+  name: guid(publicIpAddress.name, principalId, roleDefinitionIdOrName)
+  properties: {
+    description: description
+    roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
+    principalId: principalId
+    principalType: !empty(principalType) ? principalType : null
+  }
+  scope: publicIpAddress
+}]

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/addpip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/addpip.parameters.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-fw-min-001"
+        },
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw"
+        },
+        "additionalPublicIpConfigurations": {
+            "value": [
+                {
+                    "name": "ipConfig01",
+                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-additional-fw"
+                }
+            ]
+        }
+    }
+}

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/addpip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/addpip.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-fw-min-001"
+            "value": "<<namePrefix>>-az-fw-add-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw"

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
@@ -10,7 +10,7 @@
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "<<namePrefix>>-az-fw-custompip-001",
+                "name": "custompip",
                 "publicIPPrefixResourceId": "",
                 "publicIPAllocationMethod": "Dynamic",
                 "skuName": "Basic",

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-fw-min-001"
+            "value": "<<namePrefix>>-az-fw-custompip-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw"

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
@@ -10,7 +10,7 @@
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "custompip",
+                "name": "<<namePrefix>>-az-fw-custompip-001",
                 "publicIPPrefixResourceId": "",
                 "publicIPAllocationMethod": "Dynamic",
                 "skuName": "Basic",

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
@@ -10,33 +10,27 @@
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "custompip",
+                "name": "adp-<<namePrefix>>-az-pip-custom-x-fw",
                 "publicIPPrefixResourceId": "",
-                "publicIPAllocationMethod": "Dynamic",
-                "skuName": "Basic",
+                "publicIPAllocationMethod": "Static",
+                "skuName": "Standard",
                 "skuTier": "Regional",
-                "roleAssignments": {
-                    "value": [
-                        {
-                            "roleDefinitionIdOrName": "Reader",
-                            "principalIds": [
-                                "<<deploymentSpId>>"
-                            ]
-                        }
-                    ]
-                },
-                "diagnosticMetricsToEnable": {
-                    "value": [
-                        "AllMetrics"
-                    ]
-                },
-                "diagnosticLogCategoriesToEnable": {
-                    "value": [
-                        "DDoSProtectionNotifications",
-                        "DDoSMitigationFlowLogs",
-                        "DDoSMitigationReports"
-                    ]
-                }
+                "roleAssignments": [
+                    {
+                        "roleDefinitionIdOrName": "Reader",
+                        "principalIds": [
+                            "<<deploymentSpId>>"
+                        ]
+                    }
+                ],
+                "diagnosticMetricsToEnable": [
+                    "AllMetrics"
+                ],
+                "diagnosticLogCategoriesToEnable": [
+                    "DDoSProtectionNotifications",
+                    "DDoSMitigationFlowLogs",
+                    "DDoSMitigationReports"
+                ]
             }
         }
     }

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/custompip.parameters.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-fw-min-001"
+        },
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw"
+        },
+        "publicIPAddressObject": {
+            "value": {
+                "name": "custompip",
+                "publicIPPrefixResourceId": "",
+                "publicIPAllocationMethod": "Dynamic",
+                "skuName": "Basic",
+                "skuTier": "Regional",
+                "roleAssignments": {
+                    "value": [
+                        {
+                            "roleDefinitionIdOrName": "Reader",
+                            "principalIds": [
+                                "<<deploymentSpId>>"
+                            ]
+                        }
+                    ]
+                },
+                "diagnosticMetricsToEnable": {
+                    "value": [
+                        "AllMetrics"
+                    ]
+                },
+                "diagnosticLogCategoriesToEnable": {
+                    "value": [
+                        "DDoSProtectionNotifications",
+                        "DDoSMitigationFlowLogs",
+                        "DDoSMitigationReports"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-afw-x-001"
+        },
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"
+        }
+    }
+}

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-afw-x-001"
+            "value": "<<namePrefix>>-az-fw-x-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
@@ -6,7 +6,7 @@
             "value": "<<namePrefix>>-az-fw-min-001"
         },
         "vNetId": {
-            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-min-azfw"
         }
     }
 }

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/min.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-fw-x-001"
+            "value": "<<namePrefix>>-az-fw-min-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-afw-x-001"
+            "value": "<<namePrefix>>-az-fw-x-001"
         },
         "zones": {
             "value": [

--- a/arm/Microsoft.Network/azureFirewalls/.parameters/parameters.json
+++ b/arm/Microsoft.Network/azureFirewalls/.parameters/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-azfw-x-001"
+            "value": "<<namePrefix>>-az-afw-x-001"
         },
         "zones": {
             "value": [
@@ -12,14 +12,11 @@
                 "3"
             ]
         },
-        "ipConfigurations": {
-            "value": [
-                {
-                    "name": "ipConfig01",
-                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw",
-                    "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw/subnets/AzureFirewallSubnet"
-                }
-            ]
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"
+        },
+        "azureFirewallSubnetPublicIpId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw"
         },
         "applicationRuleCollections": {
             "value": [

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -247,7 +247,7 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
     }
     ipConfigurations: concat([
       //Use existing public ip, new public ip created as in this module, or none if isCreateDefaultPublicIP is false
-      !(empty(azureFirewallSubnetPublicIpId)) ? existingPip : (isCreateDefaultPublicIP ? newPip : noPip)
+      !empty(azureFirewallSubnetPublicIpId) ? existingPip : (isCreateDefaultPublicIP ? newPip : noPip)
     ], additionalPublicIpConfigurations_var)
 
     sku: {

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -15,10 +15,10 @@ param azureSkuName string = 'AZFW_VNet'
 ])
 param azureSkuTier string = 'Standard'
 
-@description('Required. Shared services Virtual Network resource ID. The virtual network id containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable')
+@description('Required. Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable')
 param vNetId string
 
-@description('Optional. The public ip resource id to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet')
+@description('Optional. The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet')
 param azureFirewallSubnetPublicIpId string = ''
 
 @description('Optional. This is to add any additional public ip configurations on top of the public ip with subnet ip configuration')
@@ -132,7 +132,7 @@ var additionalPublicIpConfigurations_var = [for ipConfiguration in additionalPub
 //    publicIPAddress: {
 //      id: null
 //    }
-// because it will complain with the error: 'Value for reference id is missing. Path
+// because it will complain with the error: 'Value for reference ID is missing. Path
 // properties.ipConfigurations[0].properties.publicIpAddress
 // Otherwise, we could simply do
 //    publicIPAddress: {

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -57,10 +57,10 @@ param zones array = [
   '3'
 ]
 
-@description('Optional. Diagnostic Storage Account resource identifier')
+@description('Optional. Diagnostic Storage Account resource identifier.')
 param diagnosticStorageAccountId string = ''
 
-@description('Optional. Log Analytics workspace resource identifier')
+@description('Optional. Log Analytics workspace resource identifier.')
 param diagnosticWorkspaceId string = ''
 
 @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -283,7 +283,7 @@ resource azureFirewall_diagnosticSettings 'Microsoft.Insights/diagnosticSettings
 }
 
 module azureFirewall_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${uniqueString(deployment().name, location)}-afw-rbac-${index}'
+  name: '${uniqueString(deployment().name, location)}-AzFW-Rbac-${index}'
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
@@ -293,28 +293,28 @@ module azureFirewall_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   }
 }]
 
-@description('The resource ID of the Azure firewall')
+@description('The resource ID of the Azure firewall.')
 output resourceId string = azureFirewall.id
 
-@description('The name of the Azure firewall')
+@description('The name of the Azure firewall.')
 output name string = azureFirewall.name
 
-@description('The resource group the Azure firewall was deployed into')
+@description('The resource group the Azure firewall was deployed into.')
 output resourceGroupName string = resourceGroup().name
 
-@description('The private IP of the Azure firewall')
+@description('The private IP of the Azure firewall.')
 output privateIp string = azureFirewall.properties.ipConfigurations[0].properties.privateIPAddress
 
-@description('The private IP of the Azure firewall')
+@description('The public ipconfiguration object for the AzureFirewallSubnet')
 output ipConfAzureFirewallSubnet object = azureFirewall.properties.ipConfigurations[0]
 
-@description('List of Application Rule Collections')
+@description('List of Application Rule Collections.')
 output applicationRuleCollections array = applicationRuleCollections
 
-@description('List of Network Rule Collections')
+@description('List of Network Rule Collections.')
 output networkRuleCollections array = networkRuleCollections
 
-@description('Collection of NAT rule collections used by Azure Firewall')
+@description('Collection of NAT rule collections used by Azure Firewall.')
 output natRuleCollections array = natRuleCollections
 
 @description('The location the resource was deployed into.')

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -15,16 +15,16 @@ param azureSkuName string = 'AZFW_VNet'
 ])
 param azureSkuTier string = 'Standard'
 
-@description('Required. Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable')
+@description('Required. Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable.')
 param vNetId string
 
-@description('Optional. The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet')
+@description('Optional. The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet.')
 param azureFirewallSubnetPublicIpId string = ''
 
-@description('Optional. This is to add any additional public ip configurations on top of the public ip with subnet ip configuration')
+@description('Optional. This is to add any additional public ip configurations on top of the public ip with subnet ip configuration.')
 param additionalPublicIpConfigurations array = []
 
-@description('Optional. Specifies if a public ip should be created by default if one is not provided')
+@description('Optional. Specifies if a public ip should be created by default if one is not provided.')
 param isCreateDefaultPublicIP bool = true
 
 @description('Optional. Specifies the properties of the public IP to create and be used by Azure Firewall. If it\'s not provided and publicIPAddressId is empty, a \'-pip\' suffix will be appended to the Firewall\'s name.')
@@ -85,7 +85,7 @@ param location string = resourceGroup().location
 @description('Optional. Specify the type of lock.')
 param lock string = 'NotSpecified'
 
-@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'')
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
 param roleAssignments array = []
 
 @description('Optional. Tags of the Azure Firewall resource.')
@@ -142,10 +142,18 @@ var existingPip = {
   }
 }
 var newPip = {
-  publicIPAddress: {
+  publicIPAddress: (empty(azureFirewallSubnetPublicIpId) && isCreateDefaultPublicIP) ? {
     id: publicIPAddress.outputs.resourceId
-  }
+  } : null
 }
+
+var ipConfigurations = concat([
+  {
+    name: 'IpConfAzureFirewallSubnet'
+    //Use existing public ip, new public ip created in this module, or none if isCreateDefaultPublicIP is false
+    properties: union(subnet_var, !empty(azureFirewallSubnetPublicIpId) ? existingPip : {}, (isCreateDefaultPublicIP ? newPip : {}))
+  }
+], additionalPublicIpConfigurations_var)
 
 // ----------------------------------------------------------------------------
 
@@ -226,14 +234,7 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
     firewallPolicy: empty(firewallPolicyId) ? null : {
       id: firewallPolicyId
     }
-    ipConfigurations: concat([
-      {
-        name: 'IpConfAzureFirewallSubnet'
-        //Use existing public ip, new public ip created in this module, or none if isCreateDefaultPublicIP is false
-        properties: !empty(azureFirewallSubnetPublicIpId) ? union(subnet_var, existingPip) : (isCreateDefaultPublicIP ? union(subnet_var, newPip) : subnet_var)
-      }
-    ], additionalPublicIpConfigurations_var)
-
+    ipConfigurations: ipConfigurations
     sku: {
       name: azureSkuName
       tier: azureSkuTier
@@ -289,7 +290,7 @@ output resourceGroupName string = resourceGroup().name
 @description('The private IP of the Azure firewall.')
 output privateIp string = azureFirewall.properties.ipConfigurations[0].properties.privateIPAddress
 
-@description('The public ipconfiguration object for the AzureFirewallSubnet')
+@description('The public ipconfiguration object for the AzureFirewallSubnet.')
 output ipConfAzureFirewallSubnet object = azureFirewall.properties.ipConfigurations[0]
 
 @description('List of Application Rule Collections.')

--- a/arm/Microsoft.Network/azureFirewalls/deploy.bicep
+++ b/arm/Microsoft.Network/azureFirewalls/deploy.bicep
@@ -15,6 +15,21 @@ param azureSkuName string = 'AZFW_VNet'
 ])
 param azureSkuTier string = 'Standard'
 
+@description('Required. Shared services Virtual Network resource ID. The virtual network id containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable')
+param vNetId string
+
+@description('Optional. The public ip resource id to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet')
+param azureFirewallSubnetPublicIpId string = ''
+
+@description('Optional. This is to add any additional public ip configurations on top of the public ip with subnet ip configuration')
+param additionalPublicIpConfigurations array = []
+
+@description('Optional. Specifies if a public ip should be created by default if one is not provided')
+param isCreateDefaultPublicIP bool = true
+
+@description('Optional. Specifies the properties of the public IP to create and be used by Azure Firewall. If it\'s not provided and publicIPAddressId is empty, a \'-pip\' suffix will be appended to the Firewall\'s name.')
+param publicIPAddressObject object = {}
+
 @description('Optional. Collection of application rule collections used by Azure Firewall.')
 param applicationRuleCollections array = []
 
@@ -23,9 +38,6 @@ param networkRuleCollections array = []
 
 @description('Optional. Collection of NAT rule collections used by Azure Firewall.')
 param natRuleCollections array = []
-
-@description('Required. List of IP Configurations.')
-param ipConfigurations array
 
 @description('Optional. Resource ID of the Firewall Policy that should be attached.')
 param firewallPolicyId string = ''
@@ -45,10 +57,10 @@ param zones array = [
   '3'
 ]
 
-@description('Optional. Diagnostic Storage Account resource identifier.')
+@description('Optional. Diagnostic Storage Account resource identifier')
 param diagnosticStorageAccountId string = ''
 
-@description('Optional. Log Analytics workspace resource identifier.')
+@description('Optional. Log Analytics workspace resource identifier')
 param diagnosticWorkspaceId string = ''
 
 @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
@@ -73,7 +85,7 @@ param location string = resourceGroup().location
 @description('Optional. Specify the type of lock.')
 param lock string = 'NotSpecified'
 
-@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'')
 param roleAssignments array = []
 
 @description('Optional. Tags of the Azure Firewall resource.')
@@ -102,20 +114,59 @@ param diagnosticMetricsToEnable array = [
   'AllMetrics'
 ]
 
-var ipConfigurations_var = [for ipConfiguration in ipConfigurations: {
+@description('Optional. The name of the diagnostic setting, if deployed.')
+param diagnosticSettingsName string = '${name}-diagnosticSettings'
+
+var additionalPublicIpConfigurations_var = [for ipConfiguration in additionalPublicIpConfigurations: {
   name: ipConfiguration.name
   properties: {
     publicIPAddress: contains(ipConfiguration, 'publicIPAddressResourceId') ? {
       id: ipConfiguration.publicIPAddressResourceId
     } : null
-    subnet: contains(ipConfiguration, 'subnetResourceId') ? {
-      id: ipConfiguration.subnetResourceId
-    } : null
   }
 }]
 
-@description('Optional. The name of the diagnostic setting, if deployed.')
-param diagnosticSettingsName string = '${name}-diagnosticSettings'
+// ----------------------------------------------------------------------------
+// The reason we need to create a separate ipConfigurations object for each
+// scenario is because you cannot pass in
+//    publicIPAddress: {
+//      id: null
+//    }
+// because it will complain with the error: 'Value for reference id is missing. Path
+// properties.ipConfigurations[0].properties.publicIpAddress
+// Otherwise, we could simply do
+//    publicIPAddress: {
+//      id: !(empty(azureFirewallSubnetPublicIpId)) ? azureFirewallSubnetPublicIpId : (isCreateDefaultPublicIP ? publicIPAddress.outputs.resourceId : null)
+//    }
+var subnet_var = {
+  id: '${vNetId}/subnets/AzureFirewallSubnet' // The subnet name must be AzureFirewallSubnet
+}
+var ipConfSubnetName = 'IpConfAzureFirewallSubnet'
+var existingPip = {
+  name: ipConfSubnetName
+  properties: {
+    subnet: subnet_var
+    publicIPAddress: {
+      id: azureFirewallSubnetPublicIpId
+    }
+  }
+}
+var newPip = {
+  name: ipConfSubnetName
+  properties: {
+    subnet: subnet_var
+    publicIPAddress: {
+      id: publicIPAddress.outputs.resourceId
+    }
+  }
+}
+var noPip = {
+  name: ipConfSubnetName
+  properties: {
+    subnet: subnet_var
+  }
+}
+// ----------------------------------------------------------------------------
 
 var diagnosticsLogs = [for category in diagnosticLogCategoriesToEnable: {
   category: category
@@ -148,6 +199,42 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
+// create a public ip address if one is not provided and the flag is true
+module publicIPAddress '.bicep/nested_publicIPAddress.bicep' = if (empty(azureFirewallSubnetPublicIpId) && isCreateDefaultPublicIP) {
+  name: '${uniqueString(deployment().name, location)}-Firewall-PIP'
+  params: {
+    name: contains(publicIPAddressObject, 'name') ? (!(empty(publicIPAddressObject.name)) ? publicIPAddressObject.name : '${name}-pip') : '${name}-pip'
+    publicIPPrefixResourceId: contains(publicIPAddressObject, 'publicIPPrefixResourceId') ? (!(empty(publicIPAddressObject.publicIPPrefixResourceId)) ? publicIPAddressObject.publicIPPrefixResourceId : '') : ''
+    publicIPAllocationMethod: contains(publicIPAddressObject, 'publicIPAllocationMethod') ? (!(empty(publicIPAddressObject.publicIPAllocationMethod)) ? publicIPAddressObject.publicIPAllocationMethod : 'Static') : 'Static'
+    skuName: contains(publicIPAddressObject, 'skuName') ? (!(empty(publicIPAddressObject.skuName)) ? publicIPAddressObject.skuName : 'Standard') : 'Standard'
+    skuTier: contains(publicIPAddressObject, 'skuTier') ? (!(empty(publicIPAddressObject.skuTier)) ? publicIPAddressObject.skuTier : 'Regional') : 'Regional'
+    roleAssignments: contains(publicIPAddressObject, 'roleAssignments') ? (!empty(publicIPAddressObject.roleAssignments) ? publicIPAddressObject.roleAssignments : []) : []
+    diagnosticMetricsToEnable: contains(publicIPAddressObject, 'diagnosticMetricsToEnable') ? (!(empty(publicIPAddressObject.diagnosticMetricsToEnable)) ? publicIPAddressObject.diagnosticMetricsToEnable : [
+      'AllMetrics'
+    ]) : [
+      'AllMetrics'
+    ]
+    diagnosticLogCategoriesToEnable: contains(publicIPAddressObject, 'diagnosticLogCategoriesToEnable') ? (!(empty(publicIPAddressObject.diagnosticLogCategoriesToEnable)) ? publicIPAddressObject.diagnosticLogCategoriesToEnable : [
+      'DDoSProtectionNotifications'
+      'DDoSMitigationFlowLogs'
+      'DDoSMitigationReports'
+    ]) : [
+      'DDoSProtectionNotifications'
+      'DDoSMitigationFlowLogs'
+      'DDoSMitigationReports'
+    ]
+    location: location
+    diagnosticStorageAccountId: diagnosticStorageAccountId
+    diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
+    diagnosticWorkspaceId: diagnosticWorkspaceId
+    diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
+    diagnosticEventHubName: diagnosticEventHubName
+    lock: lock
+    tags: tags
+    zones: zones
+  }
+}
+
 resource azureFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
   name: name
   location: location
@@ -158,7 +245,11 @@ resource azureFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
     firewallPolicy: empty(firewallPolicyId) ? null : {
       id: firewallPolicyId
     }
-    ipConfigurations: ipConfigurations_var
+    ipConfigurations: concat([
+      //Use existing public ip, new public ip created as in this module, or none if isCreateDefaultPublicIP is false
+      !(empty(azureFirewallSubnetPublicIpId)) ? existingPip : (isCreateDefaultPublicIP ? newPip : noPip)
+    ], additionalPublicIpConfigurations_var)
+
     sku: {
       name: azureSkuName
       tier: azureSkuTier
@@ -192,7 +283,7 @@ resource azureFirewall_diagnosticSettings 'Microsoft.Insights/diagnosticSettings
 }
 
 module azureFirewall_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${uniqueString(deployment().name, location)}-AzFW-Rbac-${index}'
+  name: '${uniqueString(deployment().name, location)}-afw-rbac-${index}'
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds
@@ -202,25 +293,28 @@ module azureFirewall_rbac '.bicep/nested_rbac.bicep' = [for (roleAssignment, ind
   }
 }]
 
-@description('The resource ID of the Azure firewall.')
+@description('The resource ID of the Azure firewall')
 output resourceId string = azureFirewall.id
 
-@description('The name of the Azure firewall.')
+@description('The name of the Azure firewall')
 output name string = azureFirewall.name
 
-@description('The resource group the Azure firewall was deployed into.')
+@description('The resource group the Azure firewall was deployed into')
 output resourceGroupName string = resourceGroup().name
 
-@description('The private IP of the Azure firewall.')
+@description('The private IP of the Azure firewall')
 output privateIp string = azureFirewall.properties.ipConfigurations[0].properties.privateIPAddress
 
-@description('List of Application Rule Collections.')
+@description('The private IP of the Azure firewall')
+output ipConfAzureFirewallSubnet object = azureFirewall.properties.ipConfigurations[0]
+
+@description('List of Application Rule Collections')
 output applicationRuleCollections array = applicationRuleCollections
 
-@description('List of Network Rule Collections.')
+@description('List of Network Rule Collections')
 output networkRuleCollections array = networkRuleCollections
 
-@description('Collection of NAT rule collections used by Azure Firewall.')
+@description('Collection of NAT rule collections used by Azure Firewall')
 output natRuleCollections array = natRuleCollections
 
 @description('The location the resource was deployed into.')

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -6,9 +6,8 @@ This module deploys a firewall.
 
 - [Resource types](#Resource-types)
 - [Parameters](#Parameters)
-- [Outputs](#Outputs)
 - [Considerations](#Considerations)
-- [Deployment examples](#Deployment-examples)
+- [Outputs](#Outputs)
 
 ## Resource types
 

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -8,24 +8,29 @@ This module deploys a firewall.
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Considerations](#Considerations)
+<<<<<<< HEAD
 - [Deployment examples](#Deployment-examples)
+=======
+- [Template references](#Template-references)
+>>>>>>> 440c784db (update azure firewall for PIP use cases)
 
 ## Resource types
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
-| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
-| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
+| `Microsoft.Authorization/locks` | 2017-04-01 |
+| `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
+| `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
+| `Microsoft.Network/azureFirewalls` | 2021-05-01 |
+| `Microsoft.Network/publicIPAddresses` | 2021-05-01 |
 
 ## Parameters
 
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `ipConfigurations` | array | List of IP Configurations. |
 | `name` | string | Name of the Azure Firewall. |
+| `vNetId` | string | Shared services Virtual Network resource ID |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
@@ -39,15 +44,17 @@ This module deploys a firewall.
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
 | `diagnosticMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | The name of metrics that will be streamed. |
 | `diagnosticSettingsName` | string | `[format('{0}-diagnosticSettings', parameters('name'))]` |  | The name of the diagnostic setting, if deployed. |
-| `diagnosticStorageAccountId` | string | `''` |  | Diagnostic Storage Account resource identifier. |
-| `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier. |
+| `diagnosticStorageAccountId` | string | `''` |  | Diagnostic Storage Account resource identifier |
+| `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `firewallPolicyId` | string | `''` |  | Resource ID of the Firewall Policy that should be attached. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `natRuleCollections` | array | `[]` |  | Collection of NAT rule collections used by Azure Firewall. |
 | `networkRuleCollections` | array | `[]` |  | Collection of network rule collections used by Azure Firewall. |
-| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+| `publicIPAddressId` | string | `''` |  | Specifies the resource ID of the existing public IP to be leveraged by Azure Firewall. If not provided, an Azure Public IP will be created |
+| `publicIPAddressObject` | object | `{object}` |  | Specifies the properties of the public IP to create and be used by Azure Firewall. If it's not provided and publicIPAddressId is empty, a '-pip' suffix will be appended to the Firewall's name. |
+| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Tags of the Azure Firewall resource. |
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
@@ -157,20 +164,20 @@ tags: {
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `applicationRuleCollections` | array | List of Application Rule Collections. |
-| `location` | string | The location the resource was deployed into. |
-| `name` | string | The name of the Azure firewall. |
-| `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall. |
-| `networkRuleCollections` | array | List of Network Rule Collections. |
-| `privateIp` | string | The private IP of the Azure firewall. |
-| `resourceGroupName` | string | The resource group the Azure firewall was deployed into. |
-| `resourceId` | string | The resource ID of the Azure firewall. |
+| `applicationRuleCollections` | array | List of Application Rule Collections |
+| `name` | string | The name of the Azure firewall |
+| `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall |
+| `networkRuleCollections` | array | List of Network Rule Collections |
+| `privateIp` | string | The private IP of the Azure firewall |
+| `resourceGroupName` | string | The resource group the Azure firewall was deployed into |
+| `resourceId` | string | The resource ID of the Azure firewall |
 
 ## Considerations
 
 The `applicationRuleCollections` parameter accepts a JSON Array of AzureFirewallApplicationRule objects.
 The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetworkRuleCollection objects.
 
+<<<<<<< HEAD
 ## Deployment examples
 
 <h3>Example 1</h3>
@@ -440,3 +447,12 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
 
 </details>
 <p>
+=======
+## Template references
+
+- [Azurefirewalls](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls)
+- [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
+- [Locks](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks)
+- [Publicipaddresses](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses)
+- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
+>>>>>>> 440c784db (update azure firewall for PIP use cases)

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -379,7 +379,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "<<namePrefix>>-az-fw-custompip-001",
+                "name": "custompip",
                 "publicIPPrefixResourceId": "",
                 "publicIPAllocationMethod": "Dynamic",
                 "skuName": "Basic",
@@ -426,7 +426,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
     name: '<<namePrefix>>-az-fw-custompip-001'
     vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw'
     publicIPAddressObject: {
-      name: '<<namePrefix>>-az-fw-custompip-001'
+      name: 'custompip'
       publicIPPrefixResourceId: ''
       publicIPAllocationMethod: 'Dynamic'
       skuName: 'Basic'

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -62,6 +62,63 @@ This module deploys a firewall.
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
 
+### Parameter Usage: `additionalPublicIpConfigurations`
+
+Create additional public ip configurations from existing public ips
+
+```json
+        "additionalPublicIpConfigurations": {
+            "value": [
+                {
+                    "name": "ipConfig01",
+                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-01"
+                },
+                {
+                    "name": "ipConfig02",
+                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-02"
+                }
+            ]
+        }
+```
+
+### Parameter Usage: `publicIPAddressObject`
+
+The Public IP Address object to create as part of the module. This will be created if `isCreateDefaultPublicIP` is true (which it is by default). If not provided, the name and other configurations will be set by default.
+
+```json
+        "publicIPAddressObject": {
+            "value": {
+                "name": "mypip",
+                "publicIPPrefixResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPPrefixes/myprefix",
+                "publicIPAllocationMethod": "Dynamic",
+                "skuName": "Basic",
+                "skuTier": "Regional",
+                "roleAssignments": {
+                    "value": [
+                        {
+                            "roleDefinitionIdOrName": "Reader",
+                            "principalIds": [
+                                "<<deploymentSpId>>"
+                            ]
+                        }
+                    ]
+                },
+                "diagnosticMetricsToEnable": {
+                    "value": [
+                        "AllMetrics"
+                    ]
+                },
+                "diagnosticLogCategoriesToEnable": {
+                    "value": [
+                        "DDoSProtectionNotifications",
+                        "DDoSMitigationFlowLogs",
+                        "DDoSMitigationReports"
+                    ]
+                }
+            }
+        }
+
+```
 
 ### Parameter Usage: `roleAssignments`
 

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -9,21 +9,24 @@ This module deploys a firewall.
 - [Outputs](#Outputs)
 - [Considerations](#Considerations)
 <<<<<<< HEAD
+<<<<<<< HEAD
 - [Deployment examples](#Deployment-examples)
 =======
 - [Template references](#Template-references)
 >>>>>>> 440c784db (update azure firewall for PIP use cases)
+=======
+>>>>>>> 6c0f1f644 (remove template reference and regenerate readme)
 
 ## Resource types
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
-| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments) |
-| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
-| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
-| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses) |
+| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates) |
 
 ## Parameters
 
@@ -47,8 +50,8 @@ This module deploys a firewall.
 | `diagnosticLogsRetentionInDays` | int | `365` |  | Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
 | `diagnosticMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | The name of metrics that will be streamed. |
 | `diagnosticSettingsName` | string | `[format('{0}-diagnosticSettings', parameters('name'))]` |  | The name of the diagnostic setting, if deployed. |
-| `diagnosticStorageAccountId` | string | `''` |  | Diagnostic Storage Account resource identifier |
-| `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier |
+| `diagnosticStorageAccountId` | string | `''` |  | Diagnostic Storage Account resource identifier. |
+| `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `firewallPolicyId` | string | `''` |  | Resource ID of the Firewall Policy that should be attached. |
 | `isCreateDefaultPublicIP` | bool | `True` |  | Specifies if a public ip should be created by default if one is not provided |
@@ -239,6 +242,7 @@ tags: {
 
 The `applicationRuleCollections` parameter accepts a JSON Array of AzureFirewallApplicationRule objects.
 The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetworkRuleCollection objects.
+<<<<<<< HEAD
 
 <<<<<<< HEAD
 ## Deployment examples
@@ -519,3 +523,5 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
 - [Publicipaddresses](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses)
 - [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
 >>>>>>> 440c784db (update azure firewall for PIP use cases)
+=======
+>>>>>>> 6c0f1f644 (remove template reference and regenerate readme)

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -116,33 +116,27 @@ The Public IP Address object to create as part of the module. This will be creat
 ```json
 "publicIPAddressObject": {
     "value": {
-        "name": "mypip",
-        "publicIPPrefixResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPPrefixes/myprefix",
-        "publicIPAllocationMethod": "Dynamic",
-        "skuName": "Basic",
+        "name": "adp-<<namePrefix>>-az-pip-custom-x-fw",
+        "publicIPPrefixResourceId": "",
+        "publicIPAllocationMethod": "Static",
+        "skuName": "Standard",
         "skuTier": "Regional",
-        "roleAssignments": {
-            "value": [
-                {
-                    "roleDefinitionIdOrName": "Reader",
-                    "principalIds": [
-                        "<<deploymentSpId>>"
-                    ]
-                }
-            ]
-        },
-        "diagnosticMetricsToEnable": {
-            "value": [
-                "AllMetrics"
-            ]
-        },
-        "diagnosticLogCategoriesToEnable": {
-            "value": [
-                "DDoSProtectionNotifications",
-                "DDoSMitigationFlowLogs",
-                "DDoSMitigationReports"
-            ]
-        }
+        "roleAssignments": [
+            {
+                "roleDefinitionIdOrName": "Reader",
+                "principalIds": [
+                    "<<deploymentSpId>>"
+                ]
+            }
+        ],
+        "diagnosticMetricsToEnable": [
+            "AllMetrics"
+        ],
+        "diagnosticLogCategoriesToEnable": [
+            "DDoSProtectionNotifications",
+            "DDoSMitigationFlowLogs",
+            "DDoSMitigationReports"
+        ]
     }
 }
 ```
@@ -379,33 +373,27 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "custompip",
+                "name": "adp-<<namePrefix>>-az-pip-custom-x-fw",
                 "publicIPPrefixResourceId": "",
-                "publicIPAllocationMethod": "Dynamic",
-                "skuName": "Basic",
+                "publicIPAllocationMethod": "Static",
+                "skuName": "Standard",
                 "skuTier": "Regional",
-                "roleAssignments": {
-                    "value": [
-                        {
-                            "roleDefinitionIdOrName": "Reader",
-                            "principalIds": [
-                                "<<deploymentSpId>>"
-                            ]
-                        }
-                    ]
-                },
-                "diagnosticMetricsToEnable": {
-                    "value": [
-                        "AllMetrics"
-                    ]
-                },
-                "diagnosticLogCategoriesToEnable": {
-                    "value": [
-                        "DDoSProtectionNotifications",
-                        "DDoSMitigationFlowLogs",
-                        "DDoSMitigationReports"
-                    ]
-                }
+                "roleAssignments": [
+                    {
+                        "roleDefinitionIdOrName": "Reader",
+                        "principalIds": [
+                            "<<deploymentSpId>>"
+                        ]
+                    }
+                ],
+                "diagnosticMetricsToEnable": [
+                    "AllMetrics"
+                ],
+                "diagnosticLogCategoriesToEnable": [
+                    "DDoSProtectionNotifications",
+                    "DDoSMitigationFlowLogs",
+                    "DDoSMitigationReports"
+                ]
             }
         }
     }
@@ -426,33 +414,27 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
     name: '<<namePrefix>>-az-fw-custompip-001'
     vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw'
     publicIPAddressObject: {
-      name: 'custompip'
+      name: 'adp-<<namePrefix>>-az-pip-custom-x-fw'
       publicIPPrefixResourceId: ''
-      publicIPAllocationMethod: 'Dynamic'
-      skuName: 'Basic'
+      publicIPAllocationMethod: 'Static'
+      skuName: 'Standard'
       skuTier: 'Regional'
-      roleAssignments: {
-        value: [
-          {
-            roleDefinitionIdOrName: 'Reader'
-            principalIds: [
-              '<<deploymentSpId>>'
-            ]
-          }
-        ]
-      }
-      diagnosticMetricsToEnable: {
-        value: [
-          'AllMetrics'
-        ]
-      }
-      diagnosticLogCategoriesToEnable: {
-        value: [
-          'DDoSProtectionNotifications'
-          'DDoSMitigationFlowLogs'
-          'DDoSMitigationReports'
-        ]
-      }
+      roleAssignments: [
+        {
+          roleDefinitionIdOrName: 'Reader'
+          principalIds: [
+            '<<deploymentSpId>>'
+          ]
+        }
+      ]
+      diagnosticMetricsToEnable: [
+        'AllMetrics'
+      ]
+      diagnosticLogCategoriesToEnable: [
+        'DDoSProtectionNotifications'
+        'DDoSMitigationFlowLogs'
+        'DDoSMitigationReports'
+      ]
     }
   }
 ```

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -318,7 +318,7 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-fw-min-001"
+            "value": "<<namePrefix>>-az-fw-add-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw"
@@ -346,7 +346,7 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
 module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-azureFirewalls'
   params: {
-    name: '<<namePrefix>>-az-fw-min-001'
+    name: '<<namePrefix>>-az-fw-add-001'
     vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw'
     additionalPublicIpConfigurations: [
       {
@@ -372,14 +372,14 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-fw-min-001"
+            "value": "<<namePrefix>>-az-fw-custompip-001"
         },
         "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw"
         },
         "publicIPAddressObject": {
             "value": {
-                "name": "custompip",
+                "name": "<<namePrefix>>-az-fw-custompip-001",
                 "publicIPPrefixResourceId": "",
                 "publicIPAllocationMethod": "Dynamic",
                 "skuName": "Basic",
@@ -423,10 +423,10 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
 module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-azureFirewalls'
   params: {
-    name: '<<namePrefix>>-az-fw-min-001'
+    name: '<<namePrefix>>-az-fw-custompip-001'
     vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw'
     publicIPAddressObject: {
-      name: 'custompip'
+      name: '<<namePrefix>>-az-fw-custompip-001'
       publicIPPrefixResourceId: ''
       publicIPAllocationMethod: 'Dynamic'
       skuName: 'Basic'

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -31,14 +31,14 @@ This module deploys a firewall.
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
 | `name` | string | Name of the Azure Firewall. |
-| `vNetId` | string | Shared services Virtual Network resource ID. The virtual network id containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable |
+| `vNetId` | string | Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `additionalPublicIpConfigurations` | array | `[]` |  | This is to add any additional public ip configurations on top of the public ip with subnet ip configuration |
 | `applicationRuleCollections` | array | `[]` |  | Collection of application rule collections used by Azure Firewall. |
-| `azureFirewallSubnetPublicIpId` | string | `''` |  | The public ip resource id to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet |
+| `azureFirewallSubnetPublicIpId` | string | `''` |  | The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet |
 | `azureSkuName` | string | `'AZFW_VNet'` | `[AZFW_VNet, AZFW_Hub]` | Name of an Azure Firewall SKU. |
 | `azureSkuTier` | string | `'Standard'` | `[Standard, Premium]` | Tier of an Azure Firewall. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -6,30 +6,35 @@ This module deploys a firewall.
 
 - [Resource types](#Resource-types)
 - [Parameters](#Parameters)
-- [Considerations](#Considerations)
 - [Outputs](#Outputs)
+- [Considerations](#Considerations)
+- [Deployment examples](#Deployment-examples)
 
 ## Resource types
 
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
+| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses) |
 
 ## Parameters
 
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `ipConfigurations` | array | List of IP Configurations. |
 | `name` | string | Name of the Azure Firewall. |
+| `vNetId` | string | Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable. |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `additionalPublicIpConfigurations` | array | `[]` |  | This is to add any additional public ip configurations on top of the public ip with subnet ip configuration. |
 | `applicationRuleCollections` | array | `[]` |  | Collection of application rule collections used by Azure Firewall. |
+| `azureFirewallSubnetPublicIpId` | string | `''` |  | The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet. |
 | `azureSkuName` | string | `'AZFW_VNet'` | `[AZFW_VNet, AZFW_Hub]` | Name of an Azure Firewall SKU. |
 | `azureSkuTier` | string | `'Standard'` | `[Standard, Premium]` | Tier of an Azure Firewall. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
@@ -42,14 +47,141 @@ This module deploys a firewall.
 | `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `firewallPolicyId` | string | `''` |  | Resource ID of the Firewall Policy that should be attached. |
+| `isCreateDefaultPublicIP` | bool | `True` |  | Specifies if a public ip should be created by default if one is not provided. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `natRuleCollections` | array | `[]` |  | Collection of NAT rule collections used by Azure Firewall. |
 | `networkRuleCollections` | array | `[]` |  | Collection of network rule collections used by Azure Firewall. |
+| `publicIPAddressObject` | object | `{object}` |  | Specifies the properties of the public IP to create and be used by Azure Firewall. If it's not provided and publicIPAddressId is empty, a '-pip' suffix will be appended to the Firewall's name. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `tags` | object | `{object}` |  | Tags of the Azure Firewall resource. |
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
+
+### Parameter Usage: `additionalPublicIpConfigurations`
+
+Create additional public ip configurations from existing public ips
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"additionalPublicIpConfigurations": {
+    "value": [
+        {
+            "name": "ipConfig01",
+            "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-01"
+        },
+        {
+            "name": "ipConfig02",
+            "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-02"
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+additionalPublicIpConfigurations: [
+    {
+        name: 'ipConfig01'
+        publicIPAddressResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-01'
+    }
+    {
+        name: 'ipConfig02'
+        publicIPAddressResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-02'
+    }
+]
+```
+
+</details>
+
+
+### Parameter Usage: `publicIPAddressObject`
+
+The Public IP Address object to create as part of the module. This will be created if `isCreateDefaultPublicIP` is true (which it is by default). If not provided, the name and other configurations will be set by default.
+
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"publicIPAddressObject": {
+    "value": {
+        "name": "mypip",
+        "publicIPPrefixResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPPrefixes/myprefix",
+        "publicIPAllocationMethod": "Dynamic",
+        "skuName": "Basic",
+        "skuTier": "Regional",
+        "roleAssignments": {
+            "value": [
+                {
+                    "roleDefinitionIdOrName": "Reader",
+                    "principalIds": [
+                        "<<deploymentSpId>>"
+                    ]
+                }
+            ]
+        },
+        "diagnosticMetricsToEnable": {
+            "value": [
+                "AllMetrics"
+            ]
+        },
+        "diagnosticLogCategoriesToEnable": {
+            "value": [
+                "DDoSProtectionNotifications",
+                "DDoSMitigationFlowLogs",
+                "DDoSMitigationReports"
+            ]
+        }
+    }
+}
+```
+
+</details>
+
+
+
+<details>
+
+<summary>Bicep format</summary>
+
+
+```bicep
+publicIPAddressObject: {
+    name: 'mypip'
+    publicIPPrefixResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPPrefixes/myprefix'
+    publicIPAllocationMethod: 'Dynamic'
+    skuName: 'Basic'
+    skuTier: 'Regional'
+    roleAssignments: [
+        {
+            roleDefinitionIdOrName: 'Reader'
+            principalIds: [
+                '<<deploymentSpId>>'
+            ]
+        }
+    ]
+    diagnosticMetricsToEnable: [
+        'AllMetrics'
+    ]
+    diagnosticLogCategoriesToEnable: [
+        'DDoSProtectionNotifications'
+        'DDoSMitigationFlowLogs'
+        'DDoSMitigationReports'
+    ]
+}
+```
+
+</details>
 
 
 ### Parameter Usage: `roleAssignments`
@@ -157,6 +289,7 @@ tags: {
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `applicationRuleCollections` | array | List of Application Rule Collections. |
+| `ipConfAzureFirewallSubnet` | object | The public ipconfiguration object for the AzureFirewallSubnet. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the Azure firewall. |
 | `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall. |
@@ -184,7 +317,47 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
     "contentVersion": "1.0.0.0",
     "parameters": {
         "name": {
-            "value": "<<namePrefix>>-az-azfw-x-001"
+            "value": "<<namePrefix>>-az-fw-min-001"
+        },
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-min-azfw"
+        }
+    }
+}
+
+```
+
+</details>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
+  name: '${uniqueString(deployment().name)}-azureFirewalls'
+  params: {
+    name: '<<namePrefix>>-az-fw-min-001'
+    vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-min-azfw'
+  }
+```
+
+</details>
+<p>
+
+<h3>Example 2</h3>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-fw-x-001"
         },
         "zones": {
             "value": [
@@ -193,14 +366,11 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
                 "3"
             ]
         },
-        "ipConfigurations": {
-            "value": [
-                {
-                    "name": "ipConfig01",
-                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw",
-                    "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw/subnets/AzureFirewallSubnet"
-                }
-            ]
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw"
+        },
+        "azureFirewallSubnetPublicIpId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw"
         },
         "applicationRuleCollections": {
             "value": [
@@ -327,19 +497,14 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
 module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-azureFirewalls'
   params: {
-    name: '<<namePrefix>>-az-azfw-x-001'
+    name: '<<namePrefix>>-az-fw-x-001'
     zones: [
       '1'
       '2'
       '3'
     ]
-    ipConfigurations: [
-      {
-        name: 'ipConfig01'
-        publicIPAddressResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw'
-        subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw/subnets/AzureFirewallSubnet'
-      }
-    ]
+    vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-azfw'
+    azureFirewallSubnetPublicIpId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw'
     applicationRuleCollections: [
       {
         name: 'allow-app-rules'

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -21,12 +21,12 @@ This module deploys a firewall.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates) |
-| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
-| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
-| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates) |
-| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates) |
-| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments) |
+| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
+| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
+| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
+| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses) |
 
 ## Parameters
 

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -225,15 +225,15 @@ tags: {
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `applicationRuleCollections` | array | List of Application Rule Collections |
-| `ipConfAzureFirewallSubnet` | object | The private IP of the Azure firewall |
+| `applicationRuleCollections` | array | List of Application Rule Collections. |
+| `ipConfAzureFirewallSubnet` | object | The public ipconfiguration object for the AzureFirewallSubnet |
 | `location` | string | The location the resource was deployed into. |
-| `name` | string | The name of the Azure firewall |
-| `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall |
-| `networkRuleCollections` | array | List of Network Rule Collections |
-| `privateIp` | string | The private IP of the Azure firewall |
-| `resourceGroupName` | string | The resource group the Azure firewall was deployed into |
-| `resourceId` | string | The resource ID of the Azure firewall |
+| `name` | string | The name of the Azure firewall. |
+| `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall. |
+| `networkRuleCollections` | array | List of Network Rule Collections. |
+| `privateIp` | string | The private IP of the Azure firewall. |
+| `resourceGroupName` | string | The resource group the Azure firewall was deployed into. |
+| `resourceId` | string | The resource ID of the Azure firewall. |
 
 ## Considerations
 

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -8,40 +8,29 @@ This module deploys a firewall.
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Considerations](#Considerations)
-<<<<<<< HEAD
-<<<<<<< HEAD
 - [Deployment examples](#Deployment-examples)
-=======
-- [Template references](#Template-references)
->>>>>>> 440c784db (update azure firewall for PIP use cases)
-=======
->>>>>>> 6c0f1f644 (remove template reference and regenerate readme)
 
 ## Resource types
 
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
-| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
-| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses) |
 
 ## Parameters
 
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
+| `ipConfigurations` | array | List of IP Configurations. |
 | `name` | string | Name of the Azure Firewall. |
-| `vNetId` | string | Shared services Virtual Network resource ID. The virtual network ID containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
-| `additionalPublicIpConfigurations` | array | `[]` |  | This is to add any additional public ip configurations on top of the public ip with subnet ip configuration |
 | `applicationRuleCollections` | array | `[]` |  | Collection of application rule collections used by Azure Firewall. |
-| `azureFirewallSubnetPublicIpId` | string | `''` |  | The public ip resource ID to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet |
 | `azureSkuName` | string | `'AZFW_VNet'` | `[AZFW_VNet, AZFW_Hub]` | Name of an Azure Firewall SKU. |
 | `azureSkuTier` | string | `'Standard'` | `[Standard, Premium]` | Tier of an Azure Firewall. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
@@ -54,75 +43,15 @@ This module deploys a firewall.
 | `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `firewallPolicyId` | string | `''` |  | Resource ID of the Firewall Policy that should be attached. |
-| `isCreateDefaultPublicIP` | bool | `True` |  | Specifies if a public ip should be created by default if one is not provided |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `natRuleCollections` | array | `[]` |  | Collection of NAT rule collections used by Azure Firewall. |
 | `networkRuleCollections` | array | `[]` |  | Collection of network rule collections used by Azure Firewall. |
-| `publicIPAddressObject` | object | `{object}` |  | Specifies the properties of the public IP to create and be used by Azure Firewall. If it's not provided and publicIPAddressId is empty, a '-pip' suffix will be appended to the Firewall's name. |
-| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
+| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `tags` | object | `{object}` |  | Tags of the Azure Firewall resource. |
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
 
-
-### Parameter Usage: `additionalPublicIpConfigurations`
-
-Create additional public ip configurations from existing public ips
-
-```json
-        "additionalPublicIpConfigurations": {
-            "value": [
-                {
-                    "name": "ipConfig01",
-                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-01"
-                },
-                {
-                    "name": "ipConfig02",
-                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-x-fw-02"
-                }
-            ]
-        }
-```
-
-### Parameter Usage: `publicIPAddressObject`
-
-The Public IP Address object to create as part of the module. This will be created if `isCreateDefaultPublicIP` is true (which it is by default). If not provided, the name and other configurations will be set by default.
-
-```json
-        "publicIPAddressObject": {
-            "value": {
-                "name": "mypip",
-                "publicIPPrefixResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPPrefixes/myprefix",
-                "publicIPAllocationMethod": "Dynamic",
-                "skuName": "Basic",
-                "skuTier": "Regional",
-                "roleAssignments": {
-                    "value": [
-                        {
-                            "roleDefinitionIdOrName": "Reader",
-                            "principalIds": [
-                                "<<deploymentSpId>>"
-                            ]
-                        }
-                    ]
-                },
-                "diagnosticMetricsToEnable": {
-                    "value": [
-                        "AllMetrics"
-                    ]
-                },
-                "diagnosticLogCategoriesToEnable": {
-                    "value": [
-                        "DDoSProtectionNotifications",
-                        "DDoSMitigationFlowLogs",
-                        "DDoSMitigationReports"
-                    ]
-                }
-            }
-        }
-
-```
 
 ### Parameter Usage: `roleAssignments`
 
@@ -229,7 +158,6 @@ tags: {
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `applicationRuleCollections` | array | List of Application Rule Collections. |
-| `ipConfAzureFirewallSubnet` | object | The public ipconfiguration object for the AzureFirewallSubnet |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the Azure firewall. |
 | `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall. |
@@ -242,9 +170,7 @@ tags: {
 
 The `applicationRuleCollections` parameter accepts a JSON Array of AzureFirewallApplicationRule objects.
 The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetworkRuleCollection objects.
-<<<<<<< HEAD
 
-<<<<<<< HEAD
 ## Deployment examples
 
 <h3>Example 1</h3>
@@ -514,14 +440,3 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
 
 </details>
 <p>
-=======
-## Template references
-
-- [Azurefirewalls](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls)
-- [Diagnosticsettings](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)
-- [Locks](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks)
-- [Publicipaddresses](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses)
-- [Roleassignments](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments)
->>>>>>> 440c784db (update azure firewall for PIP use cases)
-=======
->>>>>>> 6c0f1f644 (remove template reference and regenerate readme)

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -62,6 +62,7 @@ This module deploys a firewall.
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
 
+
 ### Parameter Usage: `additionalPublicIpConfigurations`
 
 Create additional public ip configurations from existing public ips

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -18,11 +18,12 @@ This module deploys a firewall.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | 2017-04-01 |
-| `Microsoft.Authorization/roleAssignments` | 2021-04-01-preview |
-| `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview |
-| `Microsoft.Network/azureFirewalls` | 2021-05-01 |
-| `Microsoft.Network/publicIPAddresses` | 2021-05-01 |
+| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2021-04-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/roleAssignments) |
+| `Microsoft.Authorization/roleAssignments` | [2020-10-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-10-01-preview/roleAssignments) |
+| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
+| `Microsoft.Network/azureFirewalls` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/azureFirewalls) |
+| `Microsoft.Network/publicIPAddresses` | [2021-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-05-01/publicIPAddresses) |
 
 ## Parameters
 
@@ -30,12 +31,14 @@ This module deploys a firewall.
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
 | `name` | string | Name of the Azure Firewall. |
-| `vNetId` | string | Shared services Virtual Network resource ID |
+| `vNetId` | string | Shared services Virtual Network resource ID. The virtual network id containing AzureFirewallSubnet. If a public ip is not provided, then the public ip that is created as part of this module will be applied with the subnet provided in this variable |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `additionalPublicIpConfigurations` | array | `[]` |  | This is to add any additional public ip configurations on top of the public ip with subnet ip configuration |
 | `applicationRuleCollections` | array | `[]` |  | Collection of application rule collections used by Azure Firewall. |
+| `azureFirewallSubnetPublicIpId` | string | `''` |  | The public ip resource id to associate to the AzureFirewallSubnet. If empty, then the public ip that is created as part of this module will be applied to the AzureFirewallSubnet |
 | `azureSkuName` | string | `'AZFW_VNet'` | `[AZFW_VNet, AZFW_Hub]` | Name of an Azure Firewall SKU. |
 | `azureSkuTier` | string | `'Standard'` | `[Standard, Premium]` | Tier of an Azure Firewall. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
@@ -48,11 +51,11 @@ This module deploys a firewall.
 | `diagnosticWorkspaceId` | string | `''` |  | Log Analytics workspace resource identifier |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `firewallPolicyId` | string | `''` |  | Resource ID of the Firewall Policy that should be attached. |
+| `isCreateDefaultPublicIP` | bool | `True` |  | Specifies if a public ip should be created by default if one is not provided |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `'NotSpecified'` | `[CanNotDelete, NotSpecified, ReadOnly]` | Specify the type of lock. |
 | `natRuleCollections` | array | `[]` |  | Collection of NAT rule collections used by Azure Firewall. |
 | `networkRuleCollections` | array | `[]` |  | Collection of network rule collections used by Azure Firewall. |
-| `publicIPAddressId` | string | `''` |  | Specifies the resource ID of the existing public IP to be leveraged by Azure Firewall. If not provided, an Azure Public IP will be created |
 | `publicIPAddressObject` | object | `{object}` |  | Specifies the properties of the public IP to create and be used by Azure Firewall. If it's not provided and publicIPAddressId is empty, a '-pip' suffix will be appended to the Firewall's name. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11' |
 | `tags` | object | `{object}` |  | Tags of the Azure Firewall resource. |
@@ -165,6 +168,8 @@ tags: {
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `applicationRuleCollections` | array | List of Application Rule Collections |
+| `ipConfAzureFirewallSubnet` | object | The private IP of the Azure firewall |
+| `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the Azure firewall |
 | `natRuleCollections` | array | Collection of NAT rule collections used by Azure Firewall |
 | `networkRuleCollections` | array | List of Network Rule Collections |

--- a/arm/Microsoft.Network/azureFirewalls/readme.md
+++ b/arm/Microsoft.Network/azureFirewalls/readme.md
@@ -58,6 +58,7 @@ This module deploys a firewall.
 | `threatIntelMode` | string | `'Deny'` | `[Alert, Deny, Off]` | The operation mode for Threat Intel. |
 | `zones` | array | `[1, 2, 3]` |  | Zone numbers e.g. 1,2,3. |
 
+
 ### Parameter Usage: `additionalPublicIpConfigurations`
 
 Create additional public ip configurations from existing public ips
@@ -320,6 +321,160 @@ The `networkRuleCollections` parameter accepts a JSON Array of AzureFirewallNetw
             "value": "<<namePrefix>>-az-fw-min-001"
         },
         "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw"
+        },
+        "additionalPublicIpConfigurations": {
+            "value": [
+                {
+                    "name": "ipConfig01",
+                    "publicIPAddressResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-additional-fw"
+                }
+            ]
+        }
+    }
+}
+
+```
+
+</details>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
+  name: '${uniqueString(deployment().name)}-azureFirewalls'
+  params: {
+    name: '<<namePrefix>>-az-fw-min-001'
+    vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-add-azfw'
+    additionalPublicIpConfigurations: [
+      {
+        name: 'ipConfig01'
+        publicIPAddressResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/publicIPAddresses/adp-<<namePrefix>>-az-pip-additional-fw'
+      }
+    ]
+  }
+```
+
+</details>
+<p>
+
+<h3>Example 2</h3>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-fw-min-001"
+        },
+        "vNetId": {
+            "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw"
+        },
+        "publicIPAddressObject": {
+            "value": {
+                "name": "custompip",
+                "publicIPPrefixResourceId": "",
+                "publicIPAllocationMethod": "Dynamic",
+                "skuName": "Basic",
+                "skuTier": "Regional",
+                "roleAssignments": {
+                    "value": [
+                        {
+                            "roleDefinitionIdOrName": "Reader",
+                            "principalIds": [
+                                "<<deploymentSpId>>"
+                            ]
+                        }
+                    ]
+                },
+                "diagnosticMetricsToEnable": {
+                    "value": [
+                        "AllMetrics"
+                    ]
+                },
+                "diagnosticLogCategoriesToEnable": {
+                    "value": [
+                        "DDoSProtectionNotifications",
+                        "DDoSMitigationFlowLogs",
+                        "DDoSMitigationReports"
+                    ]
+                }
+            }
+        }
+    }
+}
+
+```
+
+</details>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
+  name: '${uniqueString(deployment().name)}-azureFirewalls'
+  params: {
+    name: '<<namePrefix>>-az-fw-min-001'
+    vNetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-custompip-azfw'
+    publicIPAddressObject: {
+      name: 'custompip'
+      publicIPPrefixResourceId: ''
+      publicIPAllocationMethod: 'Dynamic'
+      skuName: 'Basic'
+      skuTier: 'Regional'
+      roleAssignments: {
+        value: [
+          {
+            roleDefinitionIdOrName: 'Reader'
+            principalIds: [
+              '<<deploymentSpId>>'
+            ]
+          }
+        ]
+      }
+      diagnosticMetricsToEnable: {
+        value: [
+          'AllMetrics'
+        ]
+      }
+      diagnosticLogCategoriesToEnable: {
+        value: [
+          'DDoSProtectionNotifications'
+          'DDoSMitigationFlowLogs'
+          'DDoSMitigationReports'
+        ]
+      }
+    }
+  }
+```
+
+</details>
+<p>
+
+<h3>Example 3</h3>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "<<namePrefix>>-az-fw-min-001"
+        },
+        "vNetId": {
             "value": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-min-azfw"
         }
     }
@@ -345,7 +500,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
 </details>
 <p>
 
-<h3>Example 2</h3>
+<h3>Example 4</h3>
 
 <details>
 

--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -515,7 +515,7 @@ While exceptions might be needed, the following guidance should be followed as m
 
 # ReadMe
 
-Each module must come with a ReadMe markdown file that outlines what the module contains and 'how' it can be used.
+Each module must come with a ReadMe Markdown file that outlines what the module contains and 'how' it can be used.
 Its primary components are in order:
 - A title with a reference to the primary resource in Start Case followed by the primary resource namespace e.g. <code>Key Vaults `[Microsoft.KeyVault/vaults]`</code>.
 - A short description
@@ -526,13 +526,13 @@ Its primary components are in order:
 - A **Template references** section listing relevant resources [Azure resource reference](https://docs.microsoft.com/en-us/azure/templates).
 
 Note the following recommendations:
-- Refer to [Generate module Readme](./Contribution%20guide%20-%20Generate%20module%20Readme) for creating from scratch or updating the module ReadMe markdown file.
+- Refer to [Generate module Readme](./Contribution%20guide%20-%20Generate%20module%20Readme) for creating from scratch or updating the module ReadMe Markdown file.
 - It is not recommended to describe how to use child resources in the parent readme file (for example 'How to define a [container] entry for the [storage account]'). Instead it is recommended to reference the child resource's ReadMe instead (for example 'container/readme.md').
 
 # Parameter files
 
 Parameter files in CARML leverage the common `deploymentParameters.json` schema for ARM deployments. As parameters are usually specific to their corresponding template, we have only very few general recommendations:
-- Parameter file names should ideally relate to the content they deploy. For example, a parameter file `min.parameters.json` should be chosen for a parameter file that contains only the minimum set of parameter to deploy the module.
+- Parameter filenames should ideally relate to the content they deploy. For example, a parameter file `min.parameters.json` should be chosen for a parameter file that contains only the minimum set of parameter to deploy the module.
 - Likewise, the `name` parameter we have in most modules should give some indication of the file it was deployed with. For example, a `min.parameters.json` parameter file for the virtual network module may have a `name` property with the value `sxx-az-vnet-min-001` where `min` relates to the prefix of the parameter file itself.
 - A module should have as many parameter files as it needs to evaluate all parts of the module's functionality.
 - Sensitive data should not be stored inside the parameter file but rather be injected by the use of tokens, as described in the [Token replacement](./The%20CI%20environment%20-%20Token%20replacement) section, or via a [key vault reference](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/key-vault-parameter?tabs=azure-cli#reference-secrets-with-static-id).

--- a/utilities/pipelines/dependencies/Microsoft.Network/publicIPAddresses/parameters/fw.additional.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/publicIPAddresses/parameters/fw.additional.parameters.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "adp-<<namePrefix>>-az-pip-additional-fw"
+        },
+        "skuName": {
+            "value": "Standard"
+        },
+        "publicIPAllocationMethod": {
+            "value": "Static"
+        },
+        "zones": {
+            "value": [
+                "1",
+                "2",
+                "3"
+            ]
+        }
+    }
+}

--- a/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/10.azfw.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/10.azfw.parameters.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "adp-<<namePrefix>>-az-vnet-custompip-azfw"
+    },
+    "addressPrefixes": {
+      "value": [
+        "10.4.0.0/16"
+      ]
+    },
+    "subnets": {
+      "value": [
+        {
+          "name": "AzureFirewallSubnet",
+          "addressPrefix": "10.4.4.0/24"
+        }
+      ]
+    }
+  }
+}

--- a/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/10.azfw.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/10.azfw.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "name": {
-      "value": "adp-<<namePrefix>>-az-vnet-custompip-azfw"
+      "value": "adp-<<namePrefix>>-az-vnet-add-azfw"
     },
     "addressPrefixes": {
       "value": [

--- a/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/11.azfw.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/11.azfw.parameters.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "adp-<<namePrefix>>-az-vnet-custompip-azfw"
+    },
+    "addressPrefixes": {
+      "value": [
+        "10.4.0.0/16"
+      ]
+    },
+    "subnets": {
+      "value": [
+        {
+          "name": "AzureFirewallSubnet",
+          "addressPrefix": "10.4.4.0/24"
+        }
+      ]
+    }
+  }
+}

--- a/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/9.azfw.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/9.azfw.parameters.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "adp-<<namePrefix>>-az-vnet-min-azfw"
+    },
+    "addressPrefixes": {
+      "value": [
+        "10.4.0.0/16"
+      ]
+    },
+    "subnets": {
+      "value": [
+        {
+          "name": "AzureFirewallSubnet",
+          "addressPrefix": "10.4.4.0/24"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Description

The work completes a portion of #1154 in which I added logic to create a public ip if one is not provided for Azure Firewall. Based on feedback from the team from reviewing #1328, the older PR of this work, I also added functionality to allow the user to revoke creating a default public ip through a boolean parameter. I copied a portion of the logic from arm\Microsoft.Network\bastionHosts\deploy.bicep. 
I also introduced a min.parameters.json file for just azurefirewall - which is a portion of this task #401 



# Type of Change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update (Wiki)

> This is a breaking change because I deleted the ipconfigurations parameter and separated it out into vnetId parameter, publicIpAddressId, and/or publicIPAddressObject

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
Checking this box after checking #401 has not been started
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
