### PR TITLE
[Module] Fixed Inconsistent naming of NSGs IDs #1323

### DIFF
--- a/arm/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/arm/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -352,7 +352,7 @@ module virtualMachine_nic '.bicep/nested_networkInterface.bicep' = [for (nicConf
     enableIPForwarding: contains(nicConfiguration, 'enableIPForwarding') ? (!empty(nicConfiguration.enableIPForwarding) ? nicConfiguration.enableIPForwarding : false) : false
     enableAcceleratedNetworking: contains(nicConfiguration, 'enableAcceleratedNetworking') ? nicConfiguration.enableAcceleratedNetworking : true
     dnsServers: contains(nicConfiguration, 'dnsServers') ? (!empty(nicConfiguration.dnsServers) ? nicConfiguration.dnsServers : []) : []
-    networkSecurityGroupId: contains(nicConfiguration, 'nsgId') ? (!empty(nicConfiguration.nsgId) ? nicConfiguration.nsgId : '') : ''
+    networkSecurityGroupId: contains(nicConfiguration, 'networkSecurityGroupId') ? (!empty(nicConfiguration.networkSecurityGroupId) ? nicConfiguration.networkSecurityGroupId : '') : ''
     ipConfigurationArray: nicConfiguration.ipConfigurations
     lock: lock
     diagnosticStorageAccountId: diagnosticStorageAccountId


### PR DESCRIPTION
# Inconsistent naming of NSGs IDs in compute/virtualmachines #1323

>Thank you for your contribution !

NSG parameter is not updated asper the standard, so updated the currect parameter "networkSecurityGroupId" and also conducted the test against the same
