### PR TITLE
Update casing for IPsec connections

### DIFF
--- a/arm/Microsoft.Network/connections/deploy.bicep
+++ b/arm/Microsoft.Network/connections/deploy.bicep
@@ -96,7 +96,7 @@ resource connection 'Microsoft.Network/connections@2021-05-01' = {
     connectionType: virtualNetworkGatewayConnectionType
     virtualNetworkGateway1: virtualNetworkGateway1
     virtualNetworkGateway2: virtualNetworkGatewayConnectionType == 'Vnet2Vnet' ? virtualNetworkGateway2 : null
-    localNetworkGateway2: virtualNetworkGatewayConnectionType == 'Ipsec' ? localNetworkGateway2 : null
+    localNetworkGateway2: virtualNetworkGatewayConnectionType == 'IPsec' ? localNetworkGateway2 : null
     peer: virtualNetworkGatewayConnectionType == 'ExpressRoute' ? peer : null
     sharedKey: virtualNetworkGatewayConnectionType != 'ExpressRoute' ? vpnSharedKey : null
     usePolicyBasedTrafficSelectors: usePolicyBasedTrafficSelectors


### PR DESCRIPTION
# Description

The case of the condition was wrong, causing the deployment to fail for IPsec connections as the local gateway ID was never included.

Bug #1402

# Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
