### PR TITLE
[Bugfix] Added missing output to tags module

### DIFF
--- a/arm/Microsoft.Resources/tags/deploy.bicep
+++ b/arm/Microsoft.Resources/tags/deploy.bicep
@@ -56,3 +56,6 @@ output name string = (!empty(resourceGroupName) && !empty(subscriptionId)) ? tag
 
 @description('The applied tags.')
 output tags object = (!empty(resourceGroupName) && !empty(subscriptionId)) ? tags_rg.outputs.tags : tags_sub.outputs.tags
+
+@description('The resource ID of the applied tags.')
+output resourceId string = (!empty(resourceGroupName) && !empty(subscriptionId)) ? tags_rg.outputs.resourceId : tags_sub.outputs.resourceId

--- a/arm/Microsoft.Resources/tags/readme.md
+++ b/arm/Microsoft.Resources/tags/readme.md
@@ -49,4 +49,5 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `name` | string | The name of the tags resource. |
+| `resourceId` | string | The resource ID of the applied tags. |
 | `tags` | object | The applied tags. |

--- a/arm/Microsoft.Resources/tags/resourceGroups/deploy.bicep
+++ b/arm/Microsoft.Resources/tags/resourceGroups/deploy.bicep
@@ -38,8 +38,8 @@ resource tag 'Microsoft.Resources/tags@2019-10-01' = {
 @description('The name of the tags resource.')
 output name string = tag.name
 
-@description('The resourceId of the resource group the tags were applied to.')
-output resourceId string = resourceGroup().id
+@description('The resource ID of the applied tags.')
+output resourceId string = tag.id
 
 @description('The name of the resource group the tags were applied to.')
 output resourceGroupName string = resourceGroup().name

--- a/arm/Microsoft.Resources/tags/resourceGroups/readme.md
+++ b/arm/Microsoft.Resources/tags/resourceGroups/readme.md
@@ -48,5 +48,5 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | :-- | :-- | :-- |
 | `name` | string | The name of the tags resource. |
 | `resourceGroupName` | string | The name of the resource group the tags were applied to. |
-| `resourceId` | string | The resourceId of the resource group the tags were applied to. |
+| `resourceId` | string | The resource ID of the applied tags. |
 | `tags` | object | The applied tags. |

--- a/arm/Microsoft.Resources/tags/subscriptions/deploy.bicep
+++ b/arm/Microsoft.Resources/tags/subscriptions/deploy.bicep
@@ -46,3 +46,6 @@ output name string = tag.name
 
 @description('The applied tags.')
 output tags object = newTags
+
+@description('The resource ID of the applied tags.')
+output resourceId string = tag.id

--- a/arm/Microsoft.Resources/tags/subscriptions/readme.md
+++ b/arm/Microsoft.Resources/tags/subscriptions/readme.md
@@ -48,4 +48,5 @@ Tag names and tag values can be provided as needed. A tag can be left without a 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
 | `name` | string | The name of the tags resource. |
+| `resourceId` | string | The resource ID of the applied tags. |
 | `tags` | object | The applied tags. |


### PR DESCRIPTION
# Description

- Added missing output to tags module

For example
```
Outputs                 : 
                          Name             Type                       Value
                          ===============  =========================  ==========
                          name             String                     "default"
                          tags             Object                     {"Test":"Yes","TestToo":"No"}
                          resourceId       String                     "/subscriptions/a7439831-1cd9-435d-a091-4aa863c96556/providers/Microsoft.Resources/tags/default"
```

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Resources: Tags](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml/badge.svg?branch=users%2Falsehr%2FtagsFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
