### PR TITLE
[Modules] OperationalInsights add etag parameter to SavedSearches

### DIFF
--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -201,7 +201,6 @@ module logAnalyticsWorkspace_savedSearches 'savedSearches/deploy.bicep' = [for (
   params: {
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
     name: '${savedSearch.name}${uniqueString(deployment().name)}'
-    etag: savedSearch.etag
     displayName: savedSearch.displayName
     category: savedSearch.category
     query: savedSearch.query

--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -201,6 +201,7 @@ module logAnalyticsWorkspace_savedSearches 'savedSearches/deploy.bicep' = [for (
   params: {
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
     name: '${savedSearch.name}${uniqueString(deployment().name)}'
+    etag: savedSearch.etag
     displayName: savedSearch.displayName
     category: savedSearch.category
     query: savedSearch.query

--- a/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/deploy.bicep
@@ -201,6 +201,7 @@ module logAnalyticsWorkspace_savedSearches 'savedSearches/deploy.bicep' = [for (
   params: {
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
     name: '${savedSearch.name}${uniqueString(deployment().name)}'
+    etag: contains(savedSearch, 'eTag') ? savedSearch.etag : '*'
     displayName: savedSearch.displayName
     category: savedSearch.category
     query: savedSearch.query

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
@@ -16,7 +16,7 @@ param query string
 @description('Optional. Tags to configure in the resource.')
 param tags array = []
 
-@description('Optional. The function alias if query serves as a function..')
+@description('Optional. The function alias if query serves as a function.')
 param functionAlias string = ''
 
 @description('Optional. The optional function parameters if query serves as a function. Value should be in the following format: "param-name1:type1 = default_value1, param-name2:type2 = default_value2". For more examples and proper syntax please refer to /azure/kusto/query/functions/user-defined-functions.')
@@ -25,7 +25,7 @@ param functionParameters string = ''
 @description('Optional. The version number of the query language.')
 param version int = 2
 
-@description('Optional. The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag')
+@description('Optional. The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag'.)
 param etag string = '*'
 
 @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
@@ -25,6 +25,9 @@ param functionParameters string = ''
 @description('Optional. The version number of the query language.')
 param version int = 2
 
+@description('Optional. The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag')
+param etag string = '*'
+
 @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')
 param enableDefaultTelemetry bool = true
 
@@ -47,7 +50,9 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existin
 resource savedSearch 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' = {
   name: name
   parent: workspace
+  //etag: etag // According to API, the variable should be here, but it doesn't work here.
   properties: {
+    etag: etag
     tags: tags
     displayName: displayName
     category: category

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/deploy.bicep
@@ -25,7 +25,7 @@ param functionParameters string = ''
 @description('Optional. The version number of the query language.')
 param version int = 2
 
-@description('Optional. The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag'.)
+@description('Optional. The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag.')
 param etag string = '*'
 
 @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
@@ -33,8 +33,8 @@ This template deploys a saved search for a Log Analytics workspace.
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` | Enable telemetry via the Customer Usage Attribution ID (GUID). |
-| `etag` | string | `'*'` | The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag |
-| `functionAlias` | string | `''` | The function alias if query serves as a function.. |
+| `etag` | string | `'*'` | The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag. |
+| `functionAlias` | string | `''` | The function alias if query serves as a function. |
 | `functionParameters` | string | `''` | The optional function parameters if query serves as a function. Value should be in the following format: "param-name1:type1 = default_value1, param-name2:type2 = default_value2". For more examples and proper syntax please refer to /azure/kusto/query/functions/user-defined-functions. |
 | `tags` | array | `[]` | Tags to configure in the resource. |
 | `version` | int | `2` | The version number of the query language. |

--- a/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
+++ b/arm/Microsoft.OperationalInsights/workspaces/savedSearches/readme.md
@@ -33,6 +33,7 @@ This template deploys a saved search for a Log Analytics workspace.
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` | Enable telemetry via the Customer Usage Attribution ID (GUID). |
+| `etag` | string | `'*'` | The ETag of the saved search. To override an existing saved search, use "*" or specify the current Etag |
 | `functionAlias` | string | `''` | The function alias if query serves as a function.. |
 | `functionParameters` | string | `''` | The optional function parameters if query serves as a function. Value should be in the following format: "param-name1:type1 = default_value1, param-name2:type2 = default_value2". For more examples and proper syntax please refer to /azure/kusto/query/functions/user-defined-functions. |
 | `tags` | array | `[]` | Tags to configure in the resource. |


### PR DESCRIPTION
# Description

>Thank you for your contribution !

Without etag parameter savedsearches cannot be overwritten. Set it to `*` to override the existing etag

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
|[![Build Status](https://dev.azure.com/seseichtMSFT/CARLM-SeSeicht/_apis/build/status/OperationalInsights%20-%20Workspaces?branchName=users%2Fseseicht%2FoperationalInsightFix)](https://dev.azure.com/seseichtMSFT/CARLM-SeSeicht/_build/latest?definitionId=313&branchName=users%2Fseseicht%2FoperationalInsightFix) |

# Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
