### PR TITLE
[Modules] Update PolicySet Definition Name limit to 64

### DIFF
--- a/arm/Microsoft.Authorization/policySetDefinitions/deploy.bicep
+++ b/arm/Microsoft.Authorization/policySetDefinitions/deploy.bicep
@@ -1,6 +1,6 @@
 targetScope = 'managementGroup'
 
-@sys.description('Required. Specifies the name of the policy Set Definition (Initiative). Maximum length is 24 characters for management group scope and 64 characters for subscription scope.')
+@sys.description('Required. Specifies the name of the policy Set Definition (Initiative).')
 @maxLength(64)
 param name string
 

--- a/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/deploy.bicep
+++ b/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/deploy.bicep
@@ -1,6 +1,6 @@
 targetScope = 'managementGroup'
 
-@sys.description('Required. Specifies the name of the policy Set Definition (Initiative). Maximum length is 64 characters for management group scope.')
+@sys.description('Required. Specifies the name of the policy Set Definition (Initiative).')
 @maxLength(64)
 param name string
 

--- a/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/deploy.bicep
+++ b/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/deploy.bicep
@@ -1,7 +1,7 @@
 targetScope = 'managementGroup'
 
-@sys.description('Required. Specifies the name of the policy Set Definition (Initiative). Maximum length is 24 characters for management group scope.')
-@maxLength(24)
+@sys.description('Required. Specifies the name of the policy Set Definition (Initiative). Maximum length is 64 characters for management group scope.')
+@maxLength(64)
 param name string
 
 @sys.description('Optional. The display name of the Set Definition (Initiative). Maximum length is 128 characters.')

--- a/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/readme.md
+++ b/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/readme.md
@@ -19,7 +19,7 @@ With this module you can create policy set definitions on a management group lev
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | Specifies the name of the policy Set Definition (Initiative). Maximum length is 64 characters for management group scope. |
+| `name` | string | Specifies the name of the policy Set Definition (Initiative). |
 | `policyDefinitions` | array | The array of Policy definitions object to include for this policy set. Each object must include the Policy definition ID, and optionally other properties like parameters. |
 
 **Optional parameters**

--- a/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/readme.md
+++ b/arm/Microsoft.Authorization/policySetDefinitions/managementGroup/readme.md
@@ -19,7 +19,7 @@ With this module you can create policy set definitions on a management group lev
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | Specifies the name of the policy Set Definition (Initiative). Maximum length is 24 characters for management group scope. |
+| `name` | string | Specifies the name of the policy Set Definition (Initiative). Maximum length is 64 characters for management group scope. |
 | `policyDefinitions` | array | The array of Policy definitions object to include for this policy set. Each object must include the Policy definition ID, and optionally other properties like parameters. |
 
 **Optional parameters**

--- a/arm/Microsoft.Authorization/policySetDefinitions/readme.md
+++ b/arm/Microsoft.Authorization/policySetDefinitions/readme.md
@@ -22,7 +22,7 @@ With this module you can create policy set definitions across the management gro
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | Specifies the name of the policy Set Definition (Initiative). Maximum length is 24 characters for management group scope and 64 characters for subscription scope. |
+| `name` | string | Specifies the name of the policy Set Definition (Initiative). |
 | `policyDefinitions` | array | The array of Policy definitions object to include for this policy set. Each object must include the Policy definition ID, and optionally other properties like parameters. |
 
 **Optional parameters**


### PR DESCRIPTION
# Description

There is no limit of 24 for the PolicySet Definitions. This limit is only for the assignments. It's documented wrong in the official docs. Currently working on getting this fixed also.
https://github.com/MicrosoftDocs/azure-docs/pull/93870

CARML should not prevent the creation of names longer than 24 and shorter than 64

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
