### PR TITLE
Fixed ApplicationGateway pipeline deployment by updating the keyvault reference.

### DIFF
--- a/arm/Microsoft.Network/applicationGateways/.parameters/parameters.json
+++ b/arm/Microsoft.Network/applicationGateways/.parameters/parameters.json
@@ -330,7 +330,7 @@
                 {
                     "name": "<<namePrefix>>-az-apgw-x-001-ssl-certificate",
                     "properties": {
-                        "keyVaultSecretId": "https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate02/40b9b1a7a69e48cfa1e36f24b97b8799"
+                        "keyVaultSecretId": "https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate"
                     }
                 }
             ]

--- a/arm/Microsoft.Network/applicationGateways/readme.md
+++ b/arm/Microsoft.Network/applicationGateways/readme.md
@@ -561,7 +561,7 @@ userAssignedIdentities: {
                 {
                     "name": "<<namePrefix>>-az-apgw-x-001-ssl-certificate",
                     "properties": {
-                        "keyVaultSecretId": "https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate02/40b9b1a7a69e48cfa1e36f24b97b8799"
+                        "keyVaultSecretId": "https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate"
                     }
                 }
             ]
@@ -905,7 +905,7 @@ module applicationGateways './Microsoft.Network/applicationGateways/deploy.bicep
       {
         name: '<<namePrefix>>-az-apgw-x-001-ssl-certificate'
         properties: {
-          keyVaultSecretId: 'https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate02/40b9b1a7a69e48cfa1e36f24b97b8799'
+          keyVaultSecretId: 'https://adp-<<namePrefix>>-az-kv-x-001.vault.azure.net/secrets/applicationGatewaySslCertificate'
         }
       }
     ]


### PR DESCRIPTION
# Description

I could only find the **applicationGatewaySslCertificate** in the platform deployment so I am assuming that the **applicationGatewaySslCertificate02** reference for the appgateway deployment is wrong (or maybe manually/locally created).   

Also suggesting to remove the version numbering as this will make it more generic? Or is this needed for some reason maybe? The deployment pipeline works fine for me after this change (with the standard platform dependencies deployment).
 
## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
