### PR TITLE
Fixed pipeline name parsing in Register-AzureDevOpsPipeline.ps1

### DIFF
--- a/utilities/tools/AzureDevOps/Register-AzureDevOpsPipeline.ps1
+++ b/utilities/tools/AzureDevOps/Register-AzureDevOpsPipeline.ps1
@@ -155,7 +155,8 @@ function Register-AzureDevOpsPipeline {
 
     $pipelinesArray = @()
     foreach ($localPipelinePath in $localPipelinePaths) {
-        $pipelineName = (Get-Content -Path $localPipelinePath)[0].Split('name:')[1].Replace("'", '').Trim()
+        $line = (Get-Content -Path $localPipelinePath)[0]
+        $pipelineName = ($line -split 'name:')[1].Replace("'", '').Trim()
         $pipelinesArray += @{
             ProjectName      = $ProjectName
             SourceRepository = $SourceRepository


### PR DESCRIPTION

# Description

Fixed pipeline name parsing in Register-AzureDevOpsPipeline.ps1, previous version was not working in windows. It always returned an empty string.

## Pipeline references
N/A


# Type of Change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] My code follows the style guidelines of this project
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation (readme)
- [ X ] I did format my code
