### PR TITLE
[Modules] MongoDB: Removed throughput if database is deployed serverless #1571

### DIFF
--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
@@ -44,7 +44,7 @@ resource collection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/coll
   parent: databaseAccount::mongodbDatabase
   properties: {
     options: {
-      throughput: throughput
+      throughput: contains(databaseAccount.properties.capabilities, 'EnableServerless') ? null : throughput
     }
     resource: {
       id: name

--- a/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
+++ b/arm/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
@@ -43,7 +43,7 @@ resource mongodbDatabase 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases
       id: name
     }
     options: {
-      throughput: throughput
+      throughput: contains(databaseAccount.properties.capabilities, 'EnableServerless') ? null : throughput
     }
   }
 }


### PR DESCRIPTION
# Description

Based on PR #1571 by @itpropro 

- Replaced `thoughput` parameter with `null`, if the database capabilities contain `EnableServerless`.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![DocumentDB: DatabaseAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Fitpropro%2FfixMongo)](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
