### PR TITLE
Corrected the @mention of teams + cleanup of owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @modules-maintainers
-
-.azuredevops/** @modules-maintainers
-.github/** @modules-admins
-.pipelines/** @modules-maintainers
+*   @Azure/modules-maintainers


### PR DESCRIPTION
# Description

Fix for `CODEOWNERS` to correctly specify the Azure teams.

Now the @Azure/modules-maintainers will automatically be added to all PRs in the repo.

## Pipeline references

N/A

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
