### PR TITLE
[Utilities] Added utility to bulk-run pipelines for a given branch

### DIFF
--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -66,7 +66,7 @@ runs:
         # Otherwise retrieve default values
         else {
           # Load used functions
-          . "$env:GITHUB_ACTION_PATH/scripts/Get-WorkflowDefaultInput.ps1"
+          . "$env:GITHUB_ACTION_PATH/scripts/Get-GitHubWorkflowDefaultInput.ps1"
 
           $functionInput = @{
             workflowPath = '${{ inputs.workflowPath }}'
@@ -75,7 +75,7 @@ runs:
           Write-Verbose "Invoke task with" -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          $workflowParameters = Get-WorkflowDefaultInput @functionInput -Verbose
+          $workflowParameters = Get-GitHubWorkflowDefaultInput @functionInput -Verbose
           $removeDeployment = $workflowParameters.removeDeployment
         }
 

--- a/docs/wiki/Contribution guide - Validate module locally.md
+++ b/docs/wiki/Contribution guide - Validate module locally.md
@@ -11,7 +11,7 @@ Use this script to test a module from your PC locally, without a CI environment.
 ---
 # Location
 
-You can find the script under [`/utilities/tools/Test-ModuleLocally.ps1`](https://github.com/Azure/ResourceModules/blob/main/utilities/tools//Test-ModuleLocally.ps1)
+You can find the script under [`/utilities/tools/Test-ModuleLocally.ps1`](https://github.com/Azure/ResourceModules/blob/main/utilities/tools/Test-ModuleLocally.ps1)
 
 # How it works
 

--- a/docs/wiki/Contribution guide - Validate module on scale.md
+++ b/docs/wiki/Contribution guide - Validate module on scale.md
@@ -20,7 +20,7 @@ The most important parameter is the 'Environment' you want to run the pipelines 
 Upon triggering, the utility will:
 1. Fetch all pipelines in the target environment & filter them down to, by default, module pipelines.
 1. Trigger these pipelines for the provided targeted branch (e.g. `main`)
-1. Return the formatted status badges for the just triggered pipelines
+1. Return the formatted status badges for the pipelines that were triggered.
 
 # How to use it
 

--- a/docs/wiki/Contribution guide - Validate module on scale.md
+++ b/docs/wiki/Contribution guide - Validate module on scale.md
@@ -18,7 +18,7 @@ You can find the script under [`/utilities/tools/Invoke-PipelinesForBranch.ps1`]
 The most important parameter is the 'Environment' you want to run the pipelines for, that is, either GitHub or Azure DevOps. Depending on your choice you'll have to provide a Personal Access Token that grants the permissions to read & trigger pipelines in the desired environment.
 
 Upon triggering, the utility will:
-1. Fetch all pipelines in the target environment & filter them down to, by default, module pipelines.
+1. Fetch all pipelines in the target environment and filter them down to module pipelines by default.
 1. Trigger these pipelines for the provided targeted branch (e.g. `main`)
 1. Return the formatted status badges for the pipelines that were triggered.
 

--- a/docs/wiki/Contribution guide - Validate module on scale.md
+++ b/docs/wiki/Contribution guide - Validate module on scale.md
@@ -1,4 +1,4 @@
-Use this script to test a branch across multiple modules using the CI environment. As the script will trigger the pipelines as you would in the CI environment, both static & deployment tests are executed.
+Use this script to tests multiple modules with a given branch, using the CI environment. The script will start the pipelines in the CI environment causing both static & deployment tests to run.
 
 ---
 

--- a/docs/wiki/Contribution guide - Validate module on scale.md
+++ b/docs/wiki/Contribution guide - Validate module on scale.md
@@ -1,0 +1,28 @@
+Use this script to test a branch across multiple modules using the CI environment. As the script will trigger the pipelines as you would in the CI environment, both static & deployment tests are executed.
+
+---
+
+### _Navigation_
+
+- [Location](#location)
+- [How it works](#how-it-works)
+- [How to use it](#how-to-use-it)
+
+---
+# Location
+
+You can find the script under [`/utilities/tools/Invoke-PipelinesForBranch.ps1`](https://github.com/Azure/ResourceModules/blob/main/utilities/tools/Invoke-PipelinesForBranch.ps1)
+
+# How it works
+
+The most important parameter is the 'Environment' you want to run the pipelines for, that is, either GitHub or Azure DevOps. Depending on your choice you'll have to provide a Personal Access Token that grants the permissions to read & trigger pipelines in the desired environment.
+
+Upon triggering, the utility will:
+1. Fetch all pipelines in the target environment & filter them down to, by default, module pipelines.
+1. Trigger these pipelines for the provided targeted branch (e.g. `main`)
+1. Return the formatted status badges for the just triggered pipelines
+
+# How to use it
+
+For details on how to use the function, please refer to the script's local documentation.
+> **Note:** The script must be loaded ('*dot-sourced*') before the function can be invoked.

--- a/docs/wiki/Contribution guide.md
+++ b/docs/wiki/Contribution guide.md
@@ -8,4 +8,5 @@ This section provides the step-by-step process we suggest to follow for contribu
 - [Generate module Readme](./Contribution%20guide%20-%20Generate%20module%20Readme)
 - [Get formatted RBAC roles](./Contribution%20guide%20-%20Get%20formatted%20RBAC%20roles)
 - [Validate module locally](./Contribution%20guide%20-%20Validate%20module%20locally)
+- [Validate modules on scale](./Contribution%20guide%20-%20Validate%20module%20on%20scale)
 ---

--- a/utilities/pipelines/sharedScripts/Get-GitHubWorkflowDefaultInput.ps1
+++ b/utilities/pipelines/sharedScripts/Get-GitHubWorkflowDefaultInput.ps1
@@ -9,11 +9,11 @@ Retrieve input parameter default values for a specified workflow. Return hashtab
 Mandatory. The path to the github workflow file.
 
 .EXAMPLE
-Get-WorkflowDefaultInput -workflowPath 'path/to/workflow' -verbose
+Get-GitHubWorkflowDefaultInput -workflowPath 'path/to/workflow' -verbose
 
 Retrieve input parameter default values for the 'path/to/workflow' workflow.
 #>
-function Get-WorkflowDefaultInput {
+function Get-GitHubWorkflowDefaultInput {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -1,0 +1,258 @@
+﻿#region helper functions
+
+<#
+.SYNOPSIS
+Invoke a given GitHub workflow
+
+.DESCRIPTION
+Long description
+
+.PARAMETER PersonalAccessToken
+Mandatory. The GitHub PAT to leverage when interacting with the GitHub API.
+
+.PARAMETER GitHubRepositoryOwner
+Mandatory. The repository's organization.
+
+.PARAMETER GitHubRepositoryName
+Mandatory. The name of the repository to trigger the workflows in.
+
+.PARAMETER WorkflowFileName
+Mandatory. The name of the workflow to trigger
+
+.PARAMETER TargetBranch
+Optional. The branch to trigger the pipeline for.
+
+.EXAMPLE
+Invoke-GitHubWorkflow -PersonalAccessToken '<Placeholder>' -GitHubRepositoryOwner 'Azure' -GitHubRepositoryName 'ResourceModules' -WorkflowFileName 'ms.analysisservices.servers.yml' -TargetBranch 'main'
+
+Trigger the workflow 'ms.analysisservices.servers.yml' with branch 'main' in repository 'Azure/ResourceModules'.
+#>
+function Invoke-GitHubWorkflow {
+
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $PersonalAccessToken,
+
+        [Parameter(Mandatory = $true)]
+        [string] $GitHubRepositoryOwner,
+
+        [Parameter(Mandatory = $true)]
+        [string] $GitHubRepositoryName,
+
+        [Parameter(Mandatory = $true)]
+        [string] $WorkflowFilePath,
+
+        [Parameter(Mandatory = $false)]
+        [string] $TargetBranch = 'main'
+    )
+
+    # Load used function
+    . (Join-Path (Split-Path $PSScriptRoot -Parent) 'pipelines' 'sharedScripts' 'Get-GitHubWorkflowDefaultInput.ps1')
+
+    $workflowFileName = Split-Path $WorkflowFilePath -Leaf
+    $workflowParameters = Get-GitHubWorkflowDefaultInput -workflowPath $WorkflowFilePath -Verbose
+    $removeDeploymentFlag = $workflowParameters.removeDeployment
+
+    $requestInputObject = @{
+        Method  = 'POST'
+        Uri     = "https://api.github.com/repos/$GitHubRepositoryOwner/$GitHubRepositoryName/actions/workflows/$workflowFileName/dispatches"
+        Headers = @{
+            Authorization = "Bearer $PersonalAccessToken"
+        }
+        Body    = @{
+            ref    = $TargetBranch
+            inputs = @{
+                prerelease       = 'false'
+                removeDeployment = $removeDeploymentFlag
+            }
+        } | ConvertTo-Json
+    }
+    if ($PSCmdlet.ShouldProcess("GitHub workflow [$workflowFileName] for branch [$TargetBranch]", 'Invoke')) {
+        $response = Invoke-RestMethod @requestInputObject
+
+        if ($response) {
+            Write-Error "Request failed. Reponse: [$response]"
+            return $false
+        }
+    }
+
+    return $true
+}
+
+<#
+.SYNOPSIS
+Get a list of all GitHub module workflows
+
+.DESCRIPTION
+Get a list of all GitHub module workflows. Does not return all properties but only the relevant ones.
+
+.PARAMETER PersonalAccessToken
+Mandatory. The GitHub PAT to leverage when interacting with the GitHub API.
+
+.PARAMETER GitHubRepositoryOwner
+Mandatory. The repository's organization.
+
+.PARAMETER GitHubRepositoryName
+Mandatory. The name of the repository to fetch the workflows from.
+
+.PARAMETER Filter
+Optional. A filter to apply when fetching the workflows. By default we fetch all module workflows (ms.*).
+
+.EXAMPLE
+Get-GitHubModuleWorkflowList -PersonalAccessToken '<Placeholder>' -GitHubRepositoryOwner 'Azure' -GitHubRepositoryName 'ResourceModules'
+
+Get all module workflows from repository 'Azure/ResourceModules'
+#>
+function Get-GitHubModuleWorkflowList {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $PersonalAccessToken,
+
+        [Parameter(Mandatory = $true)]
+        [string] $GitHubRepositoryOwner,
+
+        [Parameter(Mandatory = $true)]
+        [string] $GitHubRepositoryName,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Filter = 'ms.*'
+    )
+
+    $allWorkflows = @()
+    $page = 1
+    do {
+        $requestInputObject = @{
+            Method  = 'GET'
+            Uri     = "https://api.github.com/repos/$GitHubRepositoryOwner/$GitHubRepositoryName/actions/workflows?per_page=100&page=$page"
+            Headers = @{
+                Authorization = "Bearer $PersonalAccessToken"
+            }
+        }
+        $response = Invoke-RestMethod @requestInputObject
+
+        if (-not $response.workflows) {
+            Write-Error "Request failed. Reponse: [$response]"
+        }
+
+        $allWorkflows += $response.workflows | Select-Object -Property @('id', 'name', 'path', 'badge_url') | Where-Object { (Split-Path $_.path -Leaf) -like $Filter }
+
+        $expectedPages = [math]::ceiling($response.total_count / 100)
+        $page++
+    } while ($page -le $expectedPages)
+
+    return $allWorkflows
+}
+#endregion
+
+function Invoke-PipelinesForBranch {
+
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $PersonalAccessToken,
+
+        [Parameter(Mandatory = $true)]
+        [string] $TargetBranch,
+
+        [Parameter(Mandatory = $false)]
+        [string] $PipelineFilter = 'ms.*',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('GitHub', 'AzureDevOps')]
+        [string] $Environment = 'GitHub',
+
+        [Parameter(Mandatory = $false)]
+        [bool] $GeneratePipelineBadges = $true,
+
+        [Parameter(Mandatory = $false)]
+        [string] $RepositoryRoot = (Split-Path (Split-Path $PSScriptRoot -Parent)),
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'GitHub')]
+        [string] $GitHubRepositoryOwner = 'Azure',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'GitHub')]
+        [string] $GitHubRepositoryName = 'ResourceModules',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
+        [string] $AzureDevOpsOrganizationName = 'ResourceModules',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
+        [string] $AzureDevOpsProjectName = 'ResourceModules',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
+        [string] $AzureDevOpsPipelineFolderPath = 'CARML-Modules'
+    )
+
+    if ($Environment -eq 'GitHub') {
+
+        $baseInputObject = @{
+            PersonalAccessToken   = $PersonalAccessToken
+            GitHubRepositoryOwner = $GitHubRepositoryOwner
+            GitHubRepositoryName  = $GitHubRepositoryName
+        }
+
+        # List all workflows
+        $workflows = Get-GitHubModuleWorkflowList @baseInputObject -Filter $PipelineFilter
+
+        $gitHubWorkflowBadges = [System.Collections.ArrayList]@()
+
+        # Invoke workflows for target branch
+        foreach ($workflow in $workflows) {
+
+            $workflowName = $workflow.name
+            $workflowFilePath = $workflow.path
+            $WorkflowFileName = Split-Path $Workflow.path -Leaf
+
+            if ($PSCmdlet.ShouldProcess("GitHub workflow [$WorkflowFileName] for branch [$TargetBranch]", 'Invoke')) {
+                $null = Invoke-GitHubWorkflow @baseInputObject -TargetBranch $TargetBranch -WorkflowFilePath (Join-Path $RepositoryRoot $workflowFilePath)
+            }
+
+            # Generate pipeline badges
+            if ($GeneratePipelineBadges) {
+                $encodedBranch = [System.Web.HttpUtility]::UrlEncode($TargetBranch)
+                $workflowUrl = "https://github.com/$GitHubRepositoryOwner/$GitHubRepositoryName/actions/workflows/$workflowFileName"
+
+                $gitHubWorkflowBadges += "[![$workflowName]($workflowUrl/badge.svg?branch=$encodedBranch)]($workflowUrl)"
+            }
+
+        }
+
+        if ($gitHubWorkflowBadges.Count -gt 0) {
+            Write-Verbose 'GitHub Workflow Badges' -Verbose
+            Write-Verbose '======================' -Verbose
+            Write-Verbose ($gitHubWorkflowBadges | Sort-Object | Out-String) -Verbose
+        }
+    }
+
+    if ($Environment -eq 'AzureDevOps') {
+
+        Write-Verbose "Log into Azure DevOps project $OrganizationName/$AzureDevOpsProjectName with a PAT"
+        $azureDevOpsOrgUrl = "https://dev.azure.com/$AzureDevOpsOrganizationName/"
+        $PersonalAccessToken | az devops login
+
+        Write-Verbose "Set default Azure DevOps configuration to [$AzureDevOpsOrganizationName/$AzureDevOpsProjectName]"
+        az devops configure --defaults organization=$orgUazureDevOpsOrgUrlrl project=$AzureDevOpsProjectName --use-git-aliases $true
+
+        Write-Verbose "Get and list all Azure Pipelines in $PipelineTargetPath"
+        $azurePipelines = az pipelines list --organization $azureDevOpsOrgUrl --project $AzureDevOpsProjectName --folder-path $AzureDevOpsPipelineFolderPath | ConvertFrom-Json | Sort-Object name
+
+        # List all pipelines
+        # Filter to only module pipelines
+        # Invoke pipelines for target branch
+
+        # Generate pipeline badges
+        if ($GeneratePipelineBadges) {
+
+            $encodedBranch = [System.Web.HttpUtility]::UrlEncode($TargetBranch)
+            $workflowUrl = "https://dev.azure.com/$AzureDevOpsOrganizationName/$AzureDevOpsProjectName/_apis/build/status/$AzureDevOpsPipelineFolderPath/{0}?branchName=$encodedBranch"
+
+            $gitHubWorkflowBadges += "[![$workflowName]($workflowUrl/badge.svg?branch=$encodedBranch)]($workflowUrl)"
+
+
+            # [![Build Status](https://dev.azure.com/servicescode/infra-as-code-source/_apis/build/status/CARML-Modules/AnalysisServices%20-%20Servers?branchName=issue%2F1127)](https://dev.azure.com/servicescode/infra-as-code-source/_build/latest?definitionId=2156&branchName=issue%2F1127)
+        }
+    }
+}

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -194,12 +194,12 @@ function Invoke-PipelinesForBranch {
             GitHubRepositoryName  = $GitHubRepositoryName
         }
 
-        # List all workflows
+        Write-Verbose 'Fetching current GitHub workflows' -Verbose
         $workflows = Get-GitHubModuleWorkflowList @baseInputObject -Filter $PipelineFilter
 
         $gitHubWorkflowBadges = [System.Collections.ArrayList]@()
 
-        # Invoke workflows for target branch
+        Write-Verbose "Triggering GitHub workflows for branch [$TargetBranch]" -Verbose
         foreach ($workflow in $workflows) {
 
             $workflowName = $workflow.name
@@ -241,7 +241,6 @@ function Invoke-PipelinesForBranch {
         $azurePipelines = az pipelines list --organization $azureDevOpsOrgUrl --project $AzureDevOpsProjectName --folder-path $AzureDevOpsPipelineFolderPath | ConvertFrom-Json
 
         Write-Verbose 'Fetching details' # Required as we need the original file path for filtering (which is only available when fetching the pipeline directly)
-
         $detailedAzurePipelines = $azurePipelines | ForEach-Object -ThrottleLimit 10 -Parallel {
             Write-Verbose ('Fetching detailed information for pipeline [{0}]' -f $PSItem.name)
             az pipelines show --organization $USING:azureDevOpsOrgUrl --project $USING:AzureDevOpsProjectName --id $PSItem.id | ConvertFrom-Json
@@ -251,7 +250,7 @@ function Invoke-PipelinesForBranch {
 
         $azureDevOpsPipelineBadges = [System.Collections.ArrayList]@()
 
-        # Invoke pipelines for target branch
+        Write-Verbose "Triggering Azure DevOps pipelines for branch [$TargetBranch]" -Verbose
         foreach ($modulePipeline in $modulePipelines) {
 
 

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -289,7 +289,7 @@ function Invoke-PipelinesForBranch {
         az devops configure --defaults organization=$azureDevOpsOrgUrl project=$AzureDevOpsProjectName --use-git-aliases $true
 
         Write-Verbose "Get and list all [$AzureDevOpsOrganizationName/$AzureDevOpsProjectName] Azure DevOps pipelines in folder [$AzureDevOpsPipelineFolderPath]"
-        $azurePipelines = az pipelines list --organization $azureDevOpsOrgUrl --project $AzureDevOpsProjectName --folder-path $AzureDevOpsPipelineFolderPath | ConvertFrom-Json
+        $azurePipelines = az pipelines list --folder-path $AzureDevOpsPipelineFolderPath | ConvertFrom-Json
 
         Write-Verbose 'Fetching details' # Required as we need the original file path for filtering (which is only available when fetching the pipeline directly)
         $detailedAzurePipelines = $azurePipelines | ForEach-Object -ThrottleLimit 10 -Parallel {
@@ -305,7 +305,7 @@ function Invoke-PipelinesForBranch {
         foreach ($modulePipeline in $modulePipelines) {
 
 
-            if ($PSCmdlet.ShouldProcess("GitHub workflow [$WorkflowFileName] for branch [$TargetBranch]", 'Invoke')) {
+            if ($PSCmdlet.ShouldProcess(('GitHub workflow [{0}] for branch [{1}]' -f $modulePipeline.name, $TargetBranch), 'Invoke')) {
                 $null = az pipelines run --branch $TargetBranch --id $modulePipeline.id
             }
 

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -286,7 +286,7 @@ function Invoke-PipelinesForBranch {
         $PersonalAccessToken | az devops login
 
         # Set default Azure DevOps configuration (to not continously specify it on every command)
-        az devops configure --defaults organization=$orgUazureDevOpsOrgUrlrl project=$AzureDevOpsProjectName --use-git-aliases $true
+        az devops configure --defaults organization=$azureDevOpsOrgUrl project=$AzureDevOpsProjectName --use-git-aliases $true
 
         Write-Verbose "Get and list all [$AzureDevOpsOrganizationName/$AzureDevOpsProjectName] Azure DevOps pipelines in folder [$AzureDevOpsPipelineFolderPath]"
         $azurePipelines = az pipelines list --organization $azureDevOpsOrgUrl --project $AzureDevOpsProjectName --folder-path $AzureDevOpsPipelineFolderPath | ConvertFrom-Json

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -147,6 +147,57 @@ function Get-GitHubModuleWorkflowList {
 }
 #endregion
 
+<#
+.SYNOPSIS
+Trigger all pipelines for either Azure DevOps or GitHub
+
+.DESCRIPTION
+Trigger all pipelines for either Azure DevOps or GitHub. By default, pipelines are filtered to CARML module pipelines.
+Note, for Azure DevOps you'll need the 'azure-devops' extension: `az extension add --upgrade -n azure-devops`
+
+.PARAMETER PersonalAccessToken
+Mandatory. The PAT to use to interact with either GitHub / Azure DevOps.
+
+.PARAMETER TargetBranch
+Mandatory. The branch to run the pipelines for (e.g. `main`).
+
+.PARAMETER PipelineFilter
+Optional. The pipeline files to filter down to. By default only files with a name that starts with 'ms.*' are considered. E.g. 'ms.network*'.
+
+.PARAMETER Environment
+Optional. The environment to run the pipelines for. By default it's GitHub.
+
+.PARAMETER GeneratePipelineBadges
+Optional. Generate pipeline status badges for the given pipeline configuration.
+
+.PARAMETER RepositoryRoot
+Optional. The root of the repository. Used to load related functions in their folder path.
+
+.PARAMETER GitHubRepositoryOwner
+Optional. The GitHub organization to run the workfows in. Required if the chosen environment is `GitHub`. Defaults to 'Azure'.
+
+.PARAMETER GitHubRepositoryName
+Optional. The GitHub repository to run the workfows in. Required if the chosen environment is `GitHub`. Defaults to 'ResourceModules'.
+
+.PARAMETER AzureDevOpsOrganizationName
+Optional. The Azure DevOps organization to run the pipelines in. Required if the chosen environment is `AzureDevOps`.
+
+.PARAMETER AzureDevOpsProjectName
+Optional. The Azure DevOps project to run the pipelines in. Required if the chosen environment is `AzureDevOps`.
+
+.PARAMETER AzureDevOpsPipelineFolderPath
+Optional. The folder in Azure DevOps the pipelines are registerd in. Required if the chosen environment is `AzureDevOps`. Defaults to 'CARML-Modules'.
+
+.EXAMPLE
+Invoke-PipelinesForBranch -PAT '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'GitHub' -PipelineFilter 'ms.network.*'
+
+Run all GitHub workflows that start with 'ms.network.*' using branch 'feature/branch'. Also returns all GitHub status badges.
+
+.EXAMPLE
+Invoke-PipelinesForBranch -PAT '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'AzureDevOps'  -PipelineFilter 'ms.network.*' -AzureDevOpsOrganizationName 'contoso' -AzureDevOpsProjectName 'Sanchez' -AzureDevOpsPipelineFolderPath 'CARML-Modules'
+
+Run all Azure DevOps pipelines that start with 'ms.network.*' using branch 'feature/branch'. Also returns all Azure DevOps pipeline status badges.
+#>
 function Invoke-PipelinesForBranch {
 
     [CmdletBinding(SupportsShouldProcess)]
@@ -177,10 +228,10 @@ function Invoke-PipelinesForBranch {
         [string] $GitHubRepositoryName = 'ResourceModules',
 
         [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
-        [string] $AzureDevOpsOrganizationName = 'ResourceModules',
+        [string] $AzureDevOpsOrganizationName = '',
 
         [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
-        [string] $AzureDevOpsProjectName = 'ResourceModules',
+        [string] $AzureDevOpsProjectName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'AzureDevOps')]
         [string] $AzureDevOpsPipelineFolderPath = 'CARML-Modules'

--- a/utilities/tools/Invoke-PipelinesForBranch.ps1
+++ b/utilities/tools/Invoke-PipelinesForBranch.ps1
@@ -189,12 +189,12 @@ Optional. The Azure DevOps project to run the pipelines in. Required if the chos
 Optional. The folder in Azure DevOps the pipelines are registerd in. Required if the chosen environment is `AzureDevOps`. Defaults to 'CARML-Modules'.
 
 .EXAMPLE
-Invoke-PipelinesForBranch -PAT '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'GitHub' -PipelineFilter 'ms.network.*'
+Invoke-PipelinesForBranch -PersonalAccessToken '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'GitHub' -PipelineFilter 'ms.network.*'
 
 Run all GitHub workflows that start with 'ms.network.*' using branch 'feature/branch'. Also returns all GitHub status badges.
 
 .EXAMPLE
-Invoke-PipelinesForBranch -PAT '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'AzureDevOps'  -PipelineFilter 'ms.network.*' -AzureDevOpsOrganizationName 'contoso' -AzureDevOpsProjectName 'Sanchez' -AzureDevOpsPipelineFolderPath 'CARML-Modules'
+Invoke-PipelinesForBranch -PersonalAccessToken '<Placeholder>' -TargetBranch 'feature/branch' -Environment 'AzureDevOps'  -PipelineFilter 'ms.network.*' -AzureDevOpsOrganizationName 'contoso' -AzureDevOpsProjectName 'Sanchez' -AzureDevOpsPipelineFolderPath 'CARML-Modules'
 
 Run all Azure DevOps pipelines that start with 'ms.network.*' using branch 'feature/branch'. Also returns all Azure DevOps pipeline status badges.
 #>


### PR DESCRIPTION
# Description

- Moved the GitHub-Workflow Inputs script to `sharedScripts` in order to leverage it also in the new function
- The function allows you to filter which pipelines you want to run
- It optionally returns also the pipeline badges for all runs

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
