### PR TITLE
[Modules] Minimum TLS version for SQL server

### DIFF
--- a/modules/Microsoft.Sql/servers/.parameters/parameters.json
+++ b/modules/Microsoft.Sql/servers/.parameters/parameters.json
@@ -27,6 +27,9 @@
         "location": {
             "value": "westeurope"
         },
+        "minimalTlsVersion": {
+            "value": "1.2"
+        },
         "roleAssignments": {
             "value": [
                 {

--- a/modules/Microsoft.Sql/servers/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/deploy.bicep
@@ -46,6 +46,14 @@ param securityAlertPolicies array = []
 @description('Conditional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
 param administrators object = {}
 
+@allowed([
+  '1.0'
+  '1.1'
+  '1.2'
+])
+@description('Optional. Minimal TLS version allowed.')
+param minimalTlsVersion string = '1.2'
+
 @description('Optional. Configuration Details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.')
 param privateEndpoints array = []
 
@@ -90,6 +98,7 @@ resource server 'Microsoft.Sql/servers@2021-05-01-preview' = {
       tenantId: administrators.tenantId
     } : null
     version: '12.0'
+    minimalTlsVersion: minimalTlsVersion
   }
 }
 

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -46,6 +46,7 @@ This module deploys a SQL server.
 | `firewallRules` | _[firewallRules](firewallRules/readme.md)_ array | `[]` |  | The firewall rules to create in the server. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `[, CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `minimalTlsVersion` | string | `'1.2'` | `[1.0, 1.1, 1.2]` | Minimal TLS version allowed. |
 | `privateEndpoints` | array | `[]` |  | Configuration Details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `securityAlertPolicies` | _[securityAlertPolicies](securityAlertPolicies/readme.md)_ array | `[]` |  | The security alert policies to create in the server. |
@@ -405,6 +406,9 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
         "location": {
             "value": "westeurope"
         },
+        "minimalTlsVersion": {
+            "value": "1.2"
+        },
         "roleAssignments": {
             "value": [
                 {
@@ -504,6 +508,7 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     administratorLogin: kv1.getSecret('administratorLogin')
     administratorLoginPassword: kv1.getSecret('administratorLoginPassword')
     location: 'westeurope'
+    minimalTlsVersion: '1.2'
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
         "localTokens": [
             {
                 "name": "namePrefix",
-                "value": "mop",
+                "value": "mtx",
                 "metadata": {
                     "description": "A 3-5 character length string, included in the resources names"
                 }

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
         "localTokens": [
             {
                 "name": "namePrefix",
-                "value": "carml",
+                "value": "mop",
                 "metadata": {
                     "description": "A 3-5 character length string, included in the resources names"
                 }

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
         "localTokens": [
             {
                 "name": "namePrefix",
-                "value": "mtx",
+                "value": "carml",
                 "metadata": {
                     "description": "A 3-5 character length string, included in the resources names"
                 }


### PR DESCRIPTION
# Description

Adding parameter for minimum TLS version for the SQL server resource type. 

This PR closes https://github.com/Azure/ResourceModules/issues/1513. 

## Pipeline references

| Pipeline |
| - |
 [![Sql: Servers](https://github.com/ArielRam99/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=arrami%2FsqlServerMinimumTlsVersion)](https://github.com/ArielRam99/ResourceModules/actions/workflows/ms.sql.servers.yml) 

# Type of Change

- [x] New feature (non-breaking change which adds functionality)


# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code

