### PR TITLE
[Modules] Leave out not supported throughput field in Cosmos

### DIFF
--- a/modules/Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/deploy.bicep
@@ -50,7 +50,7 @@ resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2022-02-15-previ
   name: databaseAccountName
 }
 
-var databaseOptions = contains(databaseAccount.properties.capabilities, 'EnableServerless') ? {} : {
+var databaseOptions = contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? {} : {
   autoscaleSettings: throughput == -1 ? {
     maxThroughput: maxThroughput
   } : null

--- a/modules/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/deploy.bicep
@@ -43,7 +43,7 @@ resource collection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/coll
   name: name
   parent: databaseAccount::mongodbDatabase
   properties: {
-    options: {
+    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? null : {
       throughput: throughput
     }
     resource: {

--- a/modules/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/deploy.bicep
@@ -42,7 +42,7 @@ resource mongodbDatabase 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases
     resource: {
       id: name
     }
-    options: {
+    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? null : {
       throughput: throughput
     }
   }

--- a/modules/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/deploy.bicep
@@ -59,7 +59,7 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         kind: kind
       }
     }
-    options: {
+    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? null : {
       throughput: throughput
     }
   }

--- a/modules/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/sqlDatabases/deploy.bicep
@@ -42,7 +42,7 @@ resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06
     resource: {
       id: name
     }
-    options: {
+    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? null : {
       throughput: throughput
     }
   }


### PR DESCRIPTION
# Description

When CosmosDB is deployed serverless, it is not supported to provide `throughput`.
Therefore a filter was introduced in the options to conditionally provide the property.

```bicep
...
    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' }) ? null : {
      throughput: throughput
    }
...
```

# Type of Change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)
- 
# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
