### PR TITLE
[Fixes] SQL - Changed login away from secret as user name is not defined as secure()

### DIFF
--- a/modules/Microsoft.Sql/servers/.test/parameters.json
+++ b/modules/Microsoft.Sql/servers/.test/parameters.json
@@ -9,12 +9,7 @@
             "value": "CanNotDelete"
         },
         "administratorLogin": {
-            "reference": {
-                "keyVault": {
-                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>/providers/Microsoft.KeyVault/vaults/adp-<<namePrefix>>-az-kv-x-001"
-                },
-                "secretName": "administratorLogin"
-            }
+            "value": "adminUserName"
         },
         "administratorLoginPassword": {
             "reference": {

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -388,12 +388,7 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
             "value": "CanNotDelete"
         },
         "administratorLogin": {
-            "reference": {
-                "keyVault": {
-                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/<<resourceGroupName>>/providers/Microsoft.KeyVault/vaults/adp-<<namePrefix>>-az-kv-x-001"
-                },
-                "secretName": "administratorLogin"
-            }
+            "value": "adminUserName"
         },
         "administratorLoginPassword": {
             "reference": {
@@ -505,7 +500,7 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
   params: {
     name: '<<namePrefix>>-az-sqlsrv-x-001'
     lock: 'CanNotDelete'
-    administratorLogin: kv1.getSecret('administratorLogin')
+    administratorLogin: 'adminUserName'
     administratorLoginPassword: kv1.getSecret('administratorLoginPassword')
     location: 'westeurope'
     minimalTlsVersion: '1.2'


### PR DESCRIPTION
# Description

- Changed login away from secret as user name is not defined as secure()

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Sql: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=users%2Falsehr%2F1652_sqlLogin)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
