### PR TITLE
[Fixes] VM - Update NIC IP Address handover

### DIFF
--- a/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
@@ -65,7 +65,7 @@ module networkInterface '../../../Microsoft.Network/networkInterfaces/deploy.bic
       name: !empty(ipConfiguration.name) ? ipConfiguration.name : null
       primary: index == 0
       privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null
-      privateIPAddress: contains(ipConfiguration, 'privateIPAddress') ? (!empty(ipConfiguration.privateIPAddress) ? ipConfiguration.privateIPAddress : null) : null
+      vmIPAddress: contains(ipConfiguration, 'vmIPAddress') ? (!empty(ipConfiguration.vmIPAddress) ? ipConfiguration.vmIPAddress : null) : null
       publicIPAddressResourceId: contains(ipConfiguration, 'pipconfiguration') ? resourceId('Microsoft.Network/publicIPAddresses', '${virtualMachineName}${ipConfiguration.pipconfiguration.publicIpNameSuffix}') : null
       subnetId: ipConfiguration.subnetId
       loadBalancerBackendAddressPools: contains(ipConfiguration, 'loadBalancerBackendAddressPools') ? ipConfiguration.loadBalancerBackendAddressPools : null

--- a/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
@@ -65,7 +65,7 @@ module networkInterface '../../../Microsoft.Network/networkInterfaces/deploy.bic
       name: !empty(ipConfiguration.name) ? ipConfiguration.name : null
       primary: index == 0
       privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null
-      privateIPAddress: contains(ipConfiguration, 'vmIPAddress') ? (!empty(ipConfiguration.vmIPAddress) ? ipConfiguration.vmIPAddress : null) : null
+      privateIPAddress: contains(ipConfiguration, 'privateIPAddress') ? (!empty(ipConfiguration.privateIPAddress) ? ipConfiguration.privateIPAddress : null) : null
       publicIPAddressResourceId: contains(ipConfiguration, 'pipconfiguration') ? resourceId('Microsoft.Network/publicIPAddresses', '${virtualMachineName}${ipConfiguration.pipconfiguration.publicIpNameSuffix}') : null
       subnetId: ipConfiguration.subnetId
       loadBalancerBackendAddressPools: contains(ipConfiguration, 'loadBalancerBackendAddressPools') ? ipConfiguration.loadBalancerBackendAddressPools : null

--- a/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep
@@ -65,7 +65,7 @@ module networkInterface '../../../Microsoft.Network/networkInterfaces/deploy.bic
       name: !empty(ipConfiguration.name) ? ipConfiguration.name : null
       primary: index == 0
       privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null
-      vmIPAddress: contains(ipConfiguration, 'vmIPAddress') ? (!empty(ipConfiguration.vmIPAddress) ? ipConfiguration.vmIPAddress : null) : null
+      privateIPAddress: contains(ipConfiguration, 'privateIPAddress') ? (!empty(ipConfiguration.privateIPAddress) ? ipConfiguration.privateIPAddress : null) : null
       publicIPAddressResourceId: contains(ipConfiguration, 'pipconfiguration') ? resourceId('Microsoft.Network/publicIPAddresses', '${virtualMachineName}${ipConfiguration.pipconfiguration.publicIpNameSuffix}') : null
       subnetId: ipConfiguration.subnetId
       loadBalancerBackendAddressPools: contains(ipConfiguration, 'loadBalancerBackendAddressPools') ? ipConfiguration.loadBalancerBackendAddressPools : null

--- a/modules/Microsoft.Compute/virtualMachines/readme.md
+++ b/modules/Microsoft.Compute/virtualMachines/readme.md
@@ -378,7 +378,7 @@ Comments:
           "name": "ipconfig2",
           "subnetId": "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vNetName>/subnets/<subnetName>",
           "privateIPAllocationMethod": "Static",
-          "vmIPAddress": "10.0.0.9"
+          "privateIPAddress": "10.0.0.9"
         }
       ]
     }
@@ -443,7 +443,7 @@ nicConfigurations: {
           name: 'ipconfig2'
           subnetId: '/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vNetName>/subnets/<subnetName>'
           privateIPAllocationMethod: 'Static'
-          vmIPAddress: '10.0.0.9'
+          privateIPAddress: '10.0.0.9'
         }
       ]
     }

--- a/modules/Microsoft.Network/networkInterfaces/deploy.bicep
+++ b/modules/Microsoft.Network/networkInterfaces/deploy.bicep
@@ -104,7 +104,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-05-01' = {
       properties: {
         primary: index == 0 ? true : false
         privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null
-        privateIPAddress: contains(ipConfiguration, 'vmIPAddress') ? (!empty(ipConfiguration.vmIPAddress) ? ipConfiguration.vmIPAddress : null) : null
+        privateIPAddress: contains(ipConfiguration, 'privateIPAddress') ? (!empty(ipConfiguration.privateIPAddress) ? ipConfiguration.privateIPAddress : null) : null
         publicIPAddress: contains(ipConfiguration, 'publicIPAddressResourceId') ? (ipConfiguration.publicIPAddressResourceId != null ? {
           id: ipConfiguration.publicIPAddressResourceId
         } : null) : null


### PR DESCRIPTION
# Description

Fixes #1676 

The `ipConfiguration.vmIPAddress` property within the Virtual Machine module is sent via a nested bicep resource to the Network Interfaces module using `privateIPAddress`, instead of `vmIPAddress`

I would assume we cannot update the Network Intefaces modules to align to the `privateIPAddress` property (as that would be a break public interface, so I guess the fix is to map the Virtual Machine nested bicep to use `vmIPAddress` throughout.

1st nested layer:
https://github.com/Azure/ResourceModules/blob/be7074418e312a8c6790b2879e2e669cb4e36aad/modules/Microsoft.Compute/virtualMachines/.bicep/nested_networkInterface.bicep#L68

2nd nested layer:
https://github.com/Azure/ResourceModules/blob/be7074418e312a8c6790b2879e2e669cb4e36aad/modules/Microsoft.Network/networkInterfaces/deploy.bicep#L107

### To reproduce

Example Bicep module call below

```Bicep
module vm 'main/modules/Microsoft.Compute/virtualMachines/deploy.bicep' = {
  name: '${deployment().name}_vm'
  params: {
    name: 'name'
    imageReference: {
      publisher: 'zscaler'
      offer: 'zscaler-private-access'
      sku: 'zpa-con-azure'
      version: 'latest'
    }
    vmSize: 'Standard_D4s_v3'
    adminUsername: 'azure-username'
    adminPassword: 'supersecretpassword'
    osType: 'Linux'
    osDisk: {
      diskSizeGB: '16'
      managedDisk: {
        storageAccountType: 'StandardSSD_LRS'
      }
    }
    nicConfigurations: [
      {
        nicSuffix: '-nic-01'
        enableAcceleratedNetworking: true
        ipConfigurations: [
          {
            name: 'ipconfig01'
            subnetId: '/subscriptions/...../subnets/....'
            privateIPAllocationMethod: 'Static'
            vmIPAddress: '192.168.10.10'
          }
        ]
      }
    ]
  }
}
```

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
