### PR TITLE
[CI Environment] Added test case for parameter description

### DIFF
--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -938,7 +938,7 @@ Describe 'Deployment template tests' -Tag Template {
             foreach ($parameterFileTestCase in $testFileTestCases) {
                 $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
                 $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
-                $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $TemplateFile_RequiredParametersNames }
+                $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $templateFile_RequiredParametersNames }
 
                 $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
                 $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}]' -f ($incorrectParameters -join ', '))

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -921,11 +921,27 @@ Describe 'Deployment template tests' -Tag Template {
             )
 
             foreach ($parameterFileTestCase in $testFileTestCases) {
-                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
-                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
+                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
+                $testFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
 
                 $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
                 $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}]' -f ($missingParameters -join ', '))
+            }
+        }
+
+        It '[<moduleFolderName>] All non-required parameters in template file should not have description that start with "Required."' -TestCases $deploymentFolderTestCases {
+            param (
+                [hashtable[]] $testFileTestCases,
+                [hashtable] $templateContent
+            )
+
+            foreach ($parameterFileTestCase in $testFileTestCases) {
+                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
+                $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+                $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $TemplateFile_RequiredParametersNames }
+
+                $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
+                $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}]' -f ($incorrectParameters -join ', '))
             }
         }
     }

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -936,7 +936,7 @@ Describe 'Deployment template tests' -Tag Template {
             )
 
             foreach ($parameterFileTestCase in $testFileTestCases) {
-                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
+                $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
                 $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
                 $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $TemplateFile_RequiredParametersNames }
 

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -921,8 +921,8 @@ Describe 'Deployment template tests' -Tag Template {
             )
 
             foreach ($parameterFileTestCase in $testFileTestCases) {
-                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
-                $testFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
+                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
 
                 $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
                 $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}]' -f ($missingParameters -join ', '))


### PR DESCRIPTION
# Description

- Added a test to ensure no non-required parameter (no default) has a description that starts with 'Required'.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2F1034_optionalTest)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
