### PR TITLE
[Modules] Configure privateDnsZoneGroups on Web PubSub Service

### DIFF
--- a/modules/Microsoft.SignalRService/webPubSub/.test/parameters.json
+++ b/modules/Microsoft.SignalRService/webPubSub/.test/parameters.json
@@ -75,7 +75,12 @@
       "value": [
         {
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints",
-          "service": "webpubsub"
+          "service": "webpubsub",
+          "privateDnsZoneGroups": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com"
+            ]
+          }
         }
       ]
     }

--- a/modules/Microsoft.SignalRService/webPubSub/.test/pe.parameters.json
+++ b/modules/Microsoft.SignalRService/webPubSub/.test/pe.parameters.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "<<namePrefix>>-az-pubsub-pe-001"
+    },
+    "sku": {
+      "value": "Standard_S1"
+    },
+    "privateEndpoints": {
+      "value": [
+        {
+          "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints",
+          "service": "webpubsub",
+          "privateDnsZoneGroups": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/modules/Microsoft.SignalRService/webPubSub/deploy.bicep
+++ b/modules/Microsoft.SignalRService/webPubSub/deploy.bicep
@@ -108,7 +108,6 @@ resource webPubSub 'Microsoft.SignalRService/webPubSub@2021-10-01' = {
     disableAadAuth: disableAadAuth
     disableLocalAuth: disableLocalAuth
     networkACLs: !empty(networkAcls) ? any(networkAcls) : null
-    // publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) ? 'Disabled' : null)
     publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) && empty(networkAcls) ? 'Disabled' : null)
     resourceLogConfiguration: {
       categories: resourceLogConfiguration

--- a/modules/Microsoft.SignalRService/webPubSub/readme.md
+++ b/modules/Microsoft.SignalRService/webPubSub/readme.md
@@ -1,6 +1,6 @@
-# SignalRService `[Microsoft.SignalRService/webPubSub]`
+# Web PubSub Services `[Microsoft.SignalRService/webPubSub]`
 
-This module deploys a Web PubSub resource.
+This module deploys a Web PubSub Service resource.
 
 ## Navigation
 
@@ -425,6 +425,11 @@ module webPubSub './Microsoft.SignalRService/webPubSub/deploy.bicep' = {
     }
     privateEndpoints: [
       {
+        privateDnsZoneGroups: {
+          privateDNSResourceIds: [
+            '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com'
+          ]
+        }
         service: 'webpubsub'
         subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints'
       }
@@ -509,6 +514,11 @@ module webPubSub './Microsoft.SignalRService/webPubSub/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
+          "privateDnsZoneGroups": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com"
+            ]
+          },
           "service": "webpubsub",
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints"
         }

--- a/modules/Microsoft.SignalRService/webPubSub/readme.md
+++ b/modules/Microsoft.SignalRService/webPubSub/readme.md
@@ -24,7 +24,7 @@ This module deploys a Web PubSub Service resource.
 **Required parameters**
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `name` | string | The name of the Web PubSub resource. |
+| `name` | string | The name of the Web PubSub Service resource. |
 
 **Optional parameters**
 | Parameter Name | Type | Default Value | Allowed Values | Description |
@@ -34,14 +34,14 @@ This module deploys a Web PubSub Service resource.
 | `disableAadAuth` | bool | `False` |  | When set as true, connection with AuthType=aad won't work. |
 | `disableLocalAuth` | bool | `True` |  | Disables all authentication methods other than AAD authentication. For security reasons, this value should be set to `true`. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
-| `location` | string | `[resourceGroup().location]` |  | The location for all Web PubSub resources. |
+| `location` | string | `[resourceGroup().location]` |  | The location for the resource. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
-| `networkAcls` | object | `{object}` |  | Networks ACLs, this value contains IPs to whitelist and/or Subnet information. Can only be set if the 'SKU' is not 'Free_F1'. For security reasons, it is recommended to set the DefaultAction Deny. |
+| `networkAcls` | object | `{object}` |  | Networks ACLs, this value contains IPs to allow and/or Subnet information. Can only be set if the 'SKU' is not 'Free_F1'. For security reasons, it is recommended to set the DefaultAction Deny. |
 | `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set. |
 | `resourceLogConfigurationsToEnable` | array | `[ConnectivityLogs, MessagingLogs]` | `[ConnectivityLogs, MessagingLogs]` | Control permission for data plane traffic coming from public networks while private endpoint is enabled. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
-| `sku` | string | `'Standard_S1'` | `[Free_F1, Standard_S1]` | Pricing tier of App Configuration. |
+| `sku` | string | `'Standard_S1'` | `[Free_F1, Standard_S1]` | Pricing tier of the resource. |
 | `systemAssignedIdentity` | bool | `False` |  | Enables system assigned managed identity on the resource. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
 | `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |

--- a/modules/Microsoft.SignalRService/webPubSub/readme.md
+++ b/modules/Microsoft.SignalRService/webPubSub/readme.md
@@ -556,3 +556,72 @@ module webPubSub './Microsoft.SignalRService/webPubSub/deploy.bicep' = {
 
 </details>
 <p>
+
+<h3>Example 3: Pe</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module webPubSub './Microsoft.SignalRService/webPubSub/deploy.bicep' = {
+  name: '${uniqueString(deployment().name)}-webPubSub'
+  params: {
+    // Required parameters
+    name: '<<namePrefix>>-az-pubsub-pe-001'
+    // Non-required parameters
+    privateEndpoints: [
+      {
+        privateDnsZoneGroups: {
+          privateDNSResourceIds: [
+            '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com'
+          ]
+        }
+        service: 'webpubsub'
+        subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints'
+      }
+    ]
+    sku: 'Standard_S1'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "<<namePrefix>>-az-pubsub-pe-001"
+    },
+    // Non-required parameters
+    "privateEndpoints": {
+      "value": [
+        {
+          "privateDnsZoneGroups": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.webpubsub.azure.com"
+            ]
+          },
+          "service": "webpubsub",
+          "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints"
+        }
+      ]
+    },
+    "sku": {
+      "value": "Standard_S1"
+    }
+  }
+}
+```
+
+</details>
+<p>

--- a/modules/Microsoft.SignalRService/webPubSub/version.json
+++ b/modules/Microsoft.SignalRService/webPubSub/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.5"
+    "version": "0.6"
 }


### PR DESCRIPTION
# Description

Closes #1695 

- Adding private DNS zone group id to associate the private endpoint with a private DNS zone.
- Updating publicNetworkAccess implementation to be disabled by default only if:
   - no explicit value is passed
   - private endpoint parameter is not empty
   - network acls parameter is empty
   This is needed to allow both private endpoint and firewall rules to be applied on the same resource (i.e. set network access to selected networks only)
- Updating main test to deploy both pe and network acls (to test that public network access stays enabled).
- Adding pe test to deploy pe alone (to test that public network access gets disabled).
- Updating parameter description and deployment name typos

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![SignalR Service: Web PubSub](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml/badge.svg?branch=users%2Ferikag%2F1695-webpubsub-pe)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
