### PR TITLE
[Fixes] Ensure $profile is always available

### DIFF
--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -197,6 +197,10 @@ function Set-EnvironmentOnAgent {
     }
 
     # MS-hosted agents have pre-installed modules in a specific path. Let's make them discoverable if available.
+    # Always create the $profile if it does not exist (to avoid later need of case handling)
+    if (-not (Test-Path $profile)) {
+        $null = New-Item -Path $profile -Force
+    }
     if ((Test-Path '/usr/share/') -and ((Get-ChildItem -Path '/usr/share/az_*' -Directory).Count -gt 0)) {
         $preInstalledModulePaths = Get-ChildItem -Path '/usr/share/az_*' -Directory
         $maximumVersionPath = '/usr/share/az_{0}' -f (($preInstalledModulePaths | ForEach-Object { ($_ -split 'az_')[1] }) | ForEach-Object { [version]$_ } | Measure-Object -Maximum ).Maximum
@@ -208,9 +212,6 @@ function Set-EnvironmentOnAgent {
             # Set job module path (machine)
             [Environment]::SetEnvironmentVariable('PSModulePath', ('{0};{1}' -f ([Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')), $maximumVersionPath), 'Machine')
             # Set PS-Profile (for non-ps tasks)
-            if (-not (Test-Path $profile)) {
-                $null = New-Item -Path $profile -Force
-            }
             Add-Content -Path $profile -Value "`$env:PSModulePath += `";$maximumVersionPath`""
         } else {
             # Set step module path (process)
@@ -218,9 +219,6 @@ function Set-EnvironmentOnAgent {
             # Set job module path (machine)
             [Environment]::SetEnvironmentVariable('PSModulePath', ('{0}:{1}' -f ([Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')), $maximumVersionPath), 'Machine')
             # Set PS-Profile (for non-ps tasks)
-            if (-not (Test-Path $profile)) {
-                $null = New-Item -Path $profile -Force
-            }
             Add-Content -Path $profile -Value "`$env:PSModulePath += `":$maximumVersionPath`""
         }
     }


### PR DESCRIPTION
# Description

- To resolve an issue for agents that don't have Az-Modules pre-installed (and hence no $profile is setup) we should always create the profile file if not existing. This eases later case handling.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2FprofileFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
