### PR TITLE
[Bug Fix] Updated helper to reference the new script for cross reference

### DIFF
--- a/utilities/pipelines/staticValidation/helper/helper.psm1
+++ b/utilities/pipelines/staticValidation/helper/helper.psm1
@@ -6,6 +6,7 @@ $repoRootPath = (Get-Item $PSScriptRoot).Parent.Parent.Parent.Parent.FullName
 . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-NestedResourceList.ps1')
 . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-ScopeOfTemplateFile.ps1')
 . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-ModuleTestFileList.ps1')
+. (Join-Path $repoRootPath 'utilities' 'tools' 'Get-CrossReferencedModuleList.ps1')
 
 ####################################
 #   Load test-specific functions   #


### PR DESCRIPTION
# Description

The pester script was not able to use the new 'cross reference' script as it was not defined in the helper. This fixes the issue

| Pipeline |
| - |
|[![Network: ApplicationSecurityGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
