### PR TITLE
[Modules] Adds zoneRedundant property to serverfarms module

### DIFF
--- a/modules/Microsoft.Web/serverfarms/deploy.bicep
+++ b/modules/Microsoft.Web/serverfarms/deploy.bicep
@@ -87,6 +87,9 @@ param diagnosticMetricsToEnable array = [
   'AllMetrics'
 ]
 
+@description('Optional. When true, this App Service Plan will perform availability zone balancing.')
+param zoneRedundant bool = false
+
 // =========== //
 // Variables   //
 // =========== //
@@ -131,6 +134,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2021-02-01' = {
     reserved: serverOS == 'Linux'
     targetWorkerCount: targetWorkerCount
     targetWorkerSizeId: targetWorkerSize
+    zoneRedundant: zoneRedundant
   }
 }
 

--- a/modules/Microsoft.Web/serverfarms/readme.md
+++ b/modules/Microsoft.Web/serverfarms/readme.md
@@ -49,7 +49,7 @@ This module deploys an app service plan.
 | `targetWorkerCount` | int | `0` |  | Scaling worker count. |
 | `targetWorkerSize` | int | `0` | `[0, 1, 2]` | The instance size of the hosting plan (small, medium, or large). |
 | `workerTierName` | string | `''` |  | Target worker tier assigned to the App Service plan. |
-
+| `zoneRedundant` | bool | `false` |  | When true, this App Service Plan will perform availability zone balancing. |
 
 ### Parameter Usage: `sku`
 
@@ -241,6 +241,7 @@ module serverfarms './Microsoft.Web/serverfarms/deploy.bicep' = {
         roleDefinitionIdOrName: 'Reader'
       }
     ]
+    zoneRedundant: true
   }
 }
 ```
@@ -298,7 +299,8 @@ module serverfarms './Microsoft.Web/serverfarms/deploy.bicep' = {
           "roleDefinitionIdOrName": "Reader"
         }
       ]
-    }
+    },
+    "zoneRedundant": true
   }
 }
 ```


### PR DESCRIPTION
# Description

Adds `zoneRedundant` property to **Microsoft.Web/serverfarms** module.

Partially fixes #1105.

# Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
