### PR TITLE
PsRule GitHub action workflow

### DIFF
--- a/.github/workflows/psRule.yml
+++ b/.github/workflows/psRule.yml
@@ -1,0 +1,27 @@
+name: PsRule - Analyze templates
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  analyze_arm:
+    name: Analyze templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Analyze Azure resources using PSRule for Azure
+      - name: Analyze Azure template files
+        uses: microsoft/ps-rule@v2.2.0
+        with:
+          modules: PSRule.Rules.Azure,PSRule.Monitor
+          ## Publish Report to an Azure Log Analytics Workspace
+          conventions: Monitor.LogAnalytics.Import
+        env:
+          # Define environment variables using GitHub encrypted secrets
+          PSRULE_CONFIGURATION_MONITOR_WORKSPACE_ID: ${{ secrets.MONITOR_WORKSPACE_ID }}
+          PSRULE_CONFIGURATION_MONITOR_WORKSPACE_KEY: ${{ secrets.MONITOR_WORKSPACE_KEY }}

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -1,0 +1,36 @@
+#
+# PSRule configuration
+#
+
+# Please see the documentation for all configuration options:
+# https://microsoft.github.io/PSRule/
+configuration:
+  AZURE_BICEP_FILE_EXPANSION: true
+
+input:
+  pathIgnore:
+    - '.vscode/'
+    - '*.md'
+    - '*.Designer.cs'
+    - '*.resx'
+    - '*.sln'
+    - '*.txt'
+    - '*.html'
+    - '*.ico'
+
+    ## Exclude modules but not tests - because the main.bicep files
+    ## don't contain all the parameters to build and test the templates
+    - 'deployments/**/*.bicep'
+    - 'resources/**/*.bicep'
+    - 'resources/**/metadata.json'
+    - '!resources/**/*.tests.bicep'
+    - 'resources/**/template.json'
+
+rule:
+  exclude:
+    - Azure.Template.LocationDefault
+    - Azure.SQL.AAD
+
+output:
+  culture:
+    - en-US


### PR DESCRIPTION
# Description

This code is not meant to be merged back into the ResourceModules repository. This fork is for a demo being prepared for the GeekReady conference. 

This PR adds a PS Rule IAC scan for the Bicep modules and published the results to a Log Analytics workspace. This data can then be visualised with an Azure Workbook to track IAC ratings against the WAF pillars. 
