### PR TITLE
[CI environment] Added subscription context for supporting MG scope service connections

### DIFF
--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -296,7 +296,10 @@ stages:
                 $null = Convert-TokensInFileList @ConvertTokensInputs
 
                 # Get storage account name
-                Set-AzContext -Subscription $(ARM_SUBSCRIPTION_ID)
+                if (-not [String]::IsNullOrEmpty('$(ARM_SUBSCRIPTION_ID)')) {
+                    Write-Verbose 'Setting context to subscription [$(ARM_SUBSCRIPTION_ID)]'
+                    $null = Set-AzContext -Subscription '$(ARM_SUBSCRIPTION_ID)'
+                }
                 $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
                 # Upload files to storage account

--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -296,6 +296,7 @@ stages:
                 $null = Convert-TokensInFileList @ConvertTokensInputs
 
                 # Get storage account name
+                Set-AzContext -Subscription $(ARM_SUBSCRIPTION_ID)
                 $storageAccountParameters = (ConvertFrom-Json (Get-Content -path $parameterFilePath -Raw)).parameters
 
                 # Upload files to storage account


### PR DESCRIPTION


# Description

Adding Set-AzContext support the use of Management Group Scope Service Connections in Azure DevOps. linked to #1708 

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| TBC |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
