### PR TITLE
[Fixes] Resource removal stage attempts to remove dependency resources

### DIFF
--- a/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
+++ b/.azuredevops/pipelineTemplates/jobs.validateModuleDeployment.yml
@@ -180,7 +180,18 @@ jobs:
 
             Write-Verbose "Convert Tokens Input:`n $($ConvertTokensInputs | ConvertTo-Json -Depth 10)" -Verbose
 
-            # Invoke Token Replacement Functionality
+            # Invoke Token Replacement Functionality [For Module]
+            $null = Convert-TokensInFileList @ConvertTokensInputs
+
+            # Get target files for modules dependencies
+            $DependencyParameterFilePaths = [System.Collections.ArrayList]@()
+            $DependencyParameterFolders = Get-ChildItem -Path (Join-Path '$(System.DefaultWorkingDirectory)' 'utilities' 'pipelines' 'dependencies') -Recurse -Filter 'parameters' -Directory
+            foreach ($FolderPath in $DependencyParameterFolders.FullName) {
+                $DependencyParameterFilePaths += Get-ChildItem -Path $FolderPath -Recurse -Filter '*.json'
+            }
+            $ConvertTokensInputs.FilePathList = $DependencyParameterFilePaths
+
+            # Invoke Token Replacement Functionality [For Dependencies]
             $null = Convert-TokensInFileList @ConvertTokensInputs
 
       # [Validation] task(s)

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -182,7 +182,18 @@ runs:
 
           Write-Verbose "Convert Tokens Input:`n $($ConvertTokensInputs | ConvertTo-Json -Depth 10)" -Verbose
 
-          # Invoke Token Replacement Functionality
+          # Invoke Token Replacement Functionality [For Module]
+          $null = Convert-TokensInFileList @ConvertTokensInputs
+
+          # Get target files for modules dependencies
+          $DependencyParameterFilePaths = [System.Collections.ArrayList]@()
+          $DependencyParameterFolders = Get-ChildItem -Path (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'dependencies') -Recurse -Filter 'parameters' -Directory
+          foreach ($FolderPath in $DependencyParameterFolders.FullName) {
+              $DependencyParameterFilePaths += Get-ChildItem -Path $FolderPath -Recurse -Filter '*.json'
+          }
+          $ConvertTokensInputs.FilePathList = $DependencyParameterFilePaths
+
+          # Invoke Token Replacement Functionality [For Dependencies]
           $null = Convert-TokensInFileList @ConvertTokensInputs
 
           Write-Output "::endgroup::"


### PR DESCRIPTION
Closes #1781 

# Description

Add support for token replacement for the dependency resources during the token replacement step in the deployment. The reason is that the removal step relies on dependency resources parameter files tokens to be replaced, and given that we do not have a value for the `localToken_namePrefix`, it will be replaced by empty thus impacting dependency resources risk being removed. Replacing the tokens for dependency files before the removal step kicks in guarantees that there are no tokens that need to be swapped

Future feature suggestion:
- Add support in the 'Test-ModuleLocally' script to allow for resource removal. 

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![RecoveryServices: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml)|
|[![Authorization: PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml)|
|[![ServiceBus: Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml)|
|[![AppConfiguration: ConfigurationStores](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml)|
|[![Insights: PrivateLinkScopes](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml)|
|[![DataFactory: Factories](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml/badge.svg?branch=users%2Fahmad%2FbugFix_resourceRemove)](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml)|

## Before

![image](https://user-images.githubusercontent.com/28486158/184495683-771b62ad-9d13-4b5f-b4f4-15f562e598f9.png)


## After 

![image](https://user-images.githubusercontent.com/28486158/184495590-1d3fa389-e65c-4415-be81-b6c7d1a8b945.png)

![image](https://user-images.githubusercontent.com/28486158/184495649-1594c52a-65c6-4a51-aba7-fb22aeb51c37.png)

## ADO

![image](https://user-images.githubusercontent.com/28486158/184511126-4952af7e-57bf-4736-a048-0f8b150b4b34.png)

![image](https://user-images.githubusercontent.com/28486158/184511146-b2c04d1f-a907-411c-b8b6-75a523444360.png)


# Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
