### PR TITLE
[Fixes] Microsoft.Cache/redis - defaults privateDnsZoneGroups to []

### DIFF
--- a/modules/Microsoft.Cache/redis/deploy.bicep
+++ b/modules/Microsoft.Cache/redis/deploy.bicep
@@ -253,7 +253,7 @@ module redisCache_privateEndpoints '../../Microsoft.Network/privateEndpoints/dep
     enableDefaultTelemetry: enableReferencedModulesTelemetry
     location: reference(split(privateEndpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location
     lock: contains(privateEndpoint, 'lock') ? privateEndpoint.lock : lock
-    privateDnsZoneGroup: contains(privateEndpoint, 'privateDnsZoneGroup') ? privateEndpoint.privateDnsZoneGroup : {}
+    privateDnsZoneGroup: contains(privateEndpoint, 'privateDnsZoneGroup') ? privateEndpoint.privateDnsZoneGroup : []
     roleAssignments: contains(privateEndpoint, 'roleAssignments') ? privateEndpoint.roleAssignments : []
     tags: contains(privateEndpoint, 'tags') ? privateEndpoint.tags : {}
     manualPrivateLinkServiceConnections: contains(privateEndpoint, 'manualPrivateLinkServiceConnections') ? privateEndpoint.manualPrivateLinkServiceConnections : []


### PR DESCRIPTION
# Description

When deploying Azure Redis Cache with a private endpoint and the `privateDnsZoneGroups` param is not set, the deployment fails with:

```
Template parameter 'privateDnsZoneGroups' was provided an invalid value. Expected a value of type 'Array', but received a value of type 'Object'
```

The problem is that line 256 defaults to an empty object instead of an empty array:

```bicep
privateDnsZoneGroup: contains(privateEndpoint, 'privateDnsZoneGroup') ? privateEndpoint.privateDnsZoneGroup : {}
```

<https://github.com/Azure/ResourceModules/blob/main/modules/Microsoft.Cache/redis/deploy.bicep#L256>

The line should be changed to:

```bicep
privateDnsZoneGroup: contains(privateEndpoint, 'privateDnsZoneGroup') ? privateEndpoint.privateDnsZoneGroup : []
```

# Type of Change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I did format my code
