### PR TITLE
Added new dependencies and updated pls resources references

### DIFF
--- a/.azuredevops/platformPipelines/platform.dependencies.yml
+++ b/.azuredevops/platformPipelines/platform.dependencies.yml
@@ -1014,4 +1014,7 @@ stages:
           deploymentBlocks:
             - path: $(dependencyPath)/$(resourceType)/parameters/internal.parameters.json
               templateFilePath: $(templateFilePath)
-              displayName: Deploy module
+              displayName: Deploy Internal LB
+            - path: $(dependencyPath)/$(resourceType)/parameters/pls.parameters.json
+              templateFilePath: $(templateFilePath)
+              displayName: Deploy PLS LB

--- a/.github/workflows/platform.dependencies.yml
+++ b/.github/workflows/platform.dependencies.yml
@@ -1464,7 +1464,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parameterFilePaths: ['internal.parameters.json']
+        parameterFilePaths: ['internal.parameters.json', 'pls.parameters.json']
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/modules/Microsoft.Network/privateLinkServices/.test/min.parameters.json
+++ b/modules/Microsoft.Network/privateLinkServices/.test/min.parameters.json
@@ -11,7 +11,7 @@
                     "name": "minpls01",
                     "properties": {
                         "subnet": {
-                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009"
                         }
                     }
                 }
@@ -20,7 +20,7 @@
         "loadBalancerFrontendIpConfigurations": {
             "value": [
                 {
-                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig1"
+                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls-min"
                 }
             ]
         }

--- a/modules/Microsoft.Network/privateLinkServices/.test/parameters.json
+++ b/modules/Microsoft.Network/privateLinkServices/.test/parameters.json
@@ -16,7 +16,7 @@
                         "primary": true,
                         "privateIPAllocationMethod": "Dynamic",
                         "subnet": {
-                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009"
                         }
                     }
                 }
@@ -25,7 +25,7 @@
         "loadBalancerFrontendIpConfigurations": {
             "value": [
                 {
-                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig2"
+                    "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls"
                 }
             ]
         },

--- a/modules/Microsoft.Network/privateLinkServices/readme.md
+++ b/modules/Microsoft.Network/privateLinkServices/readme.md
@@ -1,6 +1,6 @@
 # Network PrivateLinkServices `[Microsoft.Network/privateLinkServices]`
 
-This module deploys Network PrivateLinkServices.
+This module deploys Network Private Link Services.
 
 ## Navigation
 
@@ -206,8 +206,8 @@ Auto-approval controls the automated access to the Private Link service. The sub
 // Example to auto-approve a specific set of subscriptions. This should always be a subset of the subscriptions provided under the "visibility" param
 "autoApproval": {
   "value": [
-    "b2ee16b1-3061-44d4-bc49-565e0f3c8021", // Subscription 1
-    "fa4d3ead-c7d5-4f1f-87bc-b06a30974542" // Subscription 2
+    "12345678-1234-1234-1234-123456781234", // Subscription 1
+    "87654321-1234-1234-1234-123456781234" // Subscription 2
   ]
 }
 ```
@@ -226,8 +226,8 @@ autoApproval: [
 
 // Example to auto-approve a specific set of subscriptions. This should always be a subset of the subscriptions provided under "visibility"
 autoApproval: [
-  'b2ee16b1-3061-44d4-bc49-565e0f3c8021' // Subscription 1
-  'fa4d3ead-c7d5-4f1f-87bc-b06a30974542' // Subscription 2
+  '12345678-1234-1234-1234-123456781234' // Subscription 1
+  '87654321-1234-1234-1234-123456781234' // Subscription 2
 ]
 ```
 
@@ -247,9 +247,9 @@ Visibility is the property that controls the exposure settings for your Private 
   "value"
   // Example showing usage of visibility param
   "subscriptions": [
-    "b2ee16b1-3061-44d4-bc49-565e0f3c8021", // Subscription 1
-    "fa4d3ead-c7d5-4f1f-87bc-b06a30974542", // Subscription 2
-    "5fab3dcc-4e5e-4d3f-8943-ed9e717bb310" // Subscription 3
+    "12345678-1234-1234-1234-123456781234", // Subscription 1
+    "87654321-1234-1234-1234-123456781234", // Subscription 2
+    "12341234-1234-1234-1234-123456781234" // Subscription 3
   ]
 }
 ```
@@ -263,9 +263,9 @@ Visibility is the property that controls the exposure settings for your Private 
 ```bicep
 visibility: {
   subscriptions: [
-    'b2ee16b1-3061-44d4-bc49-565e0f3c8021' // Subscription 1
-    'fa4d3ead-c7d5-4f1f-87bc-b06a30974542' // Subscription 2
-    '5fab3dcc-4e5e-4d3f-8943-ed9e717bb310' // Subscription 3
+    '12345678-1234-1234-1234-123456781234' // Subscription 1
+    '87654321-1234-1234-1234-123456781234' // Subscription 2
+    '12341234-1234-1234-1234-123456781234' // Subscription 3
   ]
 }
 ```
@@ -448,14 +448,14 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
         name: 'minpls01'
         properties: {
           subnet: {
-            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001'
+            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009'
           }
         }
       }
     ]
     loadBalancerFrontendIpConfigurations: [
       {
-        id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig1'
+        id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls-min'
       }
     ]
   }
@@ -485,7 +485,7 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
           "name": "minpls01",
           "properties": {
             "subnet": {
-              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009"
             }
           }
         }
@@ -494,7 +494,7 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
     "loadBalancerFrontendIpConfigurations": {
       "value": [
         {
-          "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig1"
+          "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls-min"
         }
       ]
     }
@@ -535,14 +535,14 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
           primary: true
           privateIPAllocationMethod: 'Dynamic'
           subnet: {
-            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001'
+            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009'
           }
         }
       }
     ]
     loadBalancerFrontendIpConfigurations: [
       {
-        id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig2'
+        id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls'
       }
     ]
     lock: 'CanNotDelete'
@@ -604,7 +604,7 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
             "primary": true,
             "privateIPAllocationMethod": "Dynamic",
             "subnet": {
-              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-009"
             }
           }
         }
@@ -613,7 +613,7 @@ module privateLinkServices './Microsoft.Network/privateLinkServices/deploy.bicep
     "loadBalancerFrontendIpConfigurations": {
       "value": [
         {
-          "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/frontendIPConfigurations/privateIPConfig2"
+          "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-pls-001/frontendIPConfigurations/frontend-pls"
         }
       ]
     },

--- a/utilities/pipelines/dependencies/Microsoft.Network/loadBalancers/parameters/pls.parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/loadBalancers/parameters/pls.parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "adp-<<namePrefix>>-az-lb-pls-001"
+        },
+        "loadBalancerSku": {
+            "value": "Standard"
+        },
+        "frontendIPConfigurations": {
+            "value": [
+                {
+                    "name": "frontend-pls-min",
+                    "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                },
+                {
+                    "name": "frontend-pls",
+                    "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+                }
+            ]
+        }
+    }
+}

--- a/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/parameters.json
+++ b/utilities/pipelines/dependencies/Microsoft.Network/virtualNetworks/parameters/parameters.json
@@ -121,6 +121,12 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "<<namePrefix>>-az-subnet-x-009", // PLS subnet 1
+                    "addressPrefix": "10.0.10.0/24",
+                    "privateEndpointNetworkPolicies": "Disabled",
+                    "privateLinkServiceNetworkPolicies": "Disabled"
                 }
             ]
         }


### PR DESCRIPTION
closes #1803 

# Description

Private Link services rely on dependences that don't allow it to be successfully deployed. Two issues:
- The Azure Load Balancer frontend cannot be referenced from the existing 'internal' dependency load balancer due to NAT rules. Hence created a new PLS load balancer with 2 separate frontends as we cannot create additional frontends with the existing one.
- The subnets do require private link network policies to be disabled. Hence created new subnets for it.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network: PrivateLinkServices](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatelinkservices.yml/badge.svg?branch=users%2Fahmad%2FbugFix_PLS_dependency)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatelinkservices.yml)|

**NOTE ** Dependency pipeline is OK. and failure is not related to this fix

![image](https://user-images.githubusercontent.com/28486158/187002624-422815d1-5e80-485e-9b19-76f89987b609.png)


# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)


# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
