### PR TITLE
[Modules] Default value for IpConfiguration name

### DIFF
--- a/modules/Microsoft.Network/networkInterfaces/.test/parameters.json
+++ b/modules/Microsoft.Network/networkInterfaces/.test/parameters.json
@@ -35,13 +35,7 @@
                     ]
                 },
                 {
-                    "name": null,
                     "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001",
-                    "loadBalancerBackendAddressPools": [
-                        {
-                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers"
-                        }
-                    ],
                     "applicationSecurityGroups": [
                         {
                             "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"

--- a/modules/Microsoft.Network/networkInterfaces/.test/parameters.json
+++ b/modules/Microsoft.Network/networkInterfaces/.test/parameters.json
@@ -33,6 +33,20 @@
                             "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"
                         }
                     ]
+                },
+                {
+                    "name": null,
+                    "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001",
+                    "loadBalancerBackendAddressPools": [
+                        {
+                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers"
+                        }
+                    ],
+                    "applicationSecurityGroups": [
+                        {
+                            "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"
+                        }
+                    ]
                 }
             ]
         },

--- a/modules/Microsoft.Network/networkInterfaces/deploy.bicep
+++ b/modules/Microsoft.Network/networkInterfaces/deploy.bicep
@@ -100,7 +100,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = {
       id: networkSecurityGroupResourceId
     } : null
     ipConfigurations: [for (ipConfiguration, index) in ipConfigurations: {
-      name: !empty(ipConfiguration.name) ? ipConfiguration.name : 'ipconfig-${index}'
+      name: contains(ipConfiguration, 'name') ? ipConfiguration.name : 'ipconfig0${index + 1}'
       properties: {
         primary: index == 0 ? true : false
         privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null

--- a/modules/Microsoft.Network/networkInterfaces/deploy.bicep
+++ b/modules/Microsoft.Network/networkInterfaces/deploy.bicep
@@ -100,7 +100,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = {
       id: networkSecurityGroupResourceId
     } : null
     ipConfigurations: [for (ipConfiguration, index) in ipConfigurations: {
-      name: !empty(ipConfiguration.name) ? ipConfiguration.name : null
+      name: !empty(ipConfiguration.name) ? ipConfiguration.name : 'ipconfig-${index}'
       properties: {
         primary: index == 0 ? true : false
         privateIPAllocationMethod: contains(ipConfiguration, 'privateIPAllocationMethod') ? (!empty(ipConfiguration.privateIPAllocationMethod) ? ipConfiguration.privateIPAllocationMethod : null) : null

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -273,12 +273,6 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
             id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001'
           }
         ]
-        loadBalancerBackendAddressPools: [
-          {
-            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers'
-          }
-        ]
-        name: null
         subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001'
       }
     ]
@@ -337,12 +331,6 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
               "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"
             }
           ],
-          "loadBalancerBackendAddressPools": [
-            {
-              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers"
-            }
-          ],
-          "name": null,
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
         }
       ]

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -4,11 +4,16 @@ This module deploys Network Interfaces.
 
 ## Navigation
 
-- [Resource Types](#Resource-Types)
-- [Parameters](#Parameters)
-- [Outputs](#Outputs)
-- [Cross-referenced modules](#Cross-referenced-modules)
-- [Deployment examples](#Deployment-examples)
+- [Network Interface `[Microsoft.Network/networkInterfaces]`](#network-interface-microsoftnetworknetworkinterfaces)
+  - [Navigation](#navigation)
+  - [Resource Types](#resource-types)
+  - [Parameters](#parameters)
+    - [Parameter Usage: `ipConfigurations`](#parameter-usage-ipconfigurations)
+    - [Parameter Usage: `roleAssignments`](#parameter-usage-roleassignments)
+    - [Parameter Usage: `tags`](#parameter-usage-tags)
+  - [Outputs](#outputs)
+  - [Cross-referenced modules](#cross-referenced-modules)
+  - [Deployment examples](#deployment-examples)
 
 ## Resource Types
 
@@ -46,7 +51,6 @@ This module deploys Network Interfaces.
 | `networkSecurityGroupResourceId` | string | `''` |  | The network security group (NSG) to attach to the network interface. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
-
 
 ### Parameter Usage: `ipConfigurations`
 

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -267,6 +267,20 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
         name: 'ipconfig01'
         subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001'
       }
+      {
+        applicationSecurityGroups: [
+          {
+            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001'
+          }
+        ]
+        loadBalancerBackendAddressPools: [
+          {
+            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers'
+          }
+        ]
+        name: null
+        subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001'
+      }
     ]
     name: '<<namePrefix>>-az-nic-x-001'
     // Non-required parameters
@@ -315,6 +329,20 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
             }
           ],
           "name": "ipconfig01",
+          "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
+        },
+        {
+          "applicationSecurityGroups": [
+            {
+              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/applicationSecurityGroups/adp-<<namePrefix>>-az-asg-x-001"
+            }
+          ],
+          "loadBalancerBackendAddressPools": [
+            {
+              "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/loadBalancers/adp-<<namePrefix>>-az-lb-internal-001/backendAddressPools/servers"
+            }
+          ],
+          "name": null,
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-001"
         }
       ]

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -4,16 +4,11 @@ This module deploys Network Interfaces.
 
 ## Navigation
 
-- [Network Interface `[Microsoft.Network/networkInterfaces]`](#network-interface-microsoftnetworknetworkinterfaces)
-  - [Navigation](#navigation)
-  - [Resource Types](#resource-types)
-  - [Parameters](#parameters)
-    - [Parameter Usage: `ipConfigurations`](#parameter-usage-ipconfigurations)
-    - [Parameter Usage: `roleAssignments`](#parameter-usage-roleassignments)
-    - [Parameter Usage: `tags`](#parameter-usage-tags)
-  - [Outputs](#outputs)
-  - [Cross-referenced modules](#cross-referenced-modules)
-  - [Deployment examples](#deployment-examples)
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+- [Deployment examples](#Deployment-examples)
 
 ## Resource Types
 
@@ -51,6 +46,7 @@ This module deploys Network Interfaces.
 | `networkSecurityGroupResourceId` | string | `''` |  | The network security group (NSG) to attach to the network interface. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
+
 
 ### Parameter Usage: `ipConfigurations`
 


### PR DESCRIPTION
# Description

#1278 

Added a default value for the Ip configuration of network interfaces. Now if no value is provided for the IP configuration, the IP configuration is named 'ipconfig-{currentIndex}'. 

<img width="742" alt="image" src="https://user-images.githubusercontent.com/20752807/187032625-d600f5b5-4ea9-4619-8021-3376915e5705.png">

Whilst there are other IP configuration name values across the modules (e.g., Azure Firewall), only the Virtual Machine is updated. The rationale being the name for an AZ Firewall IP configuration is more significant than that within a network interface. 

## Pipeline references

| Pipeline |
| - |
| [![Network: NetworkInterfaces](https://github.com/milescattini/Bicep-ResourceModules/actions/workflows/ms.network.networkinterfaces.yml/badge.svg)](https://github.com/milescattini/Bicep-ResourceModules/actions/workflows/ms.network.networkinterfaces.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
