### PR TITLE
[Modules] Update ContainerService/managedClusters add enableRBAC parameter for multiple authentication options

### DIFF
--- a/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -96,8 +96,11 @@ param aadProfileAdminGroupObjectIDs array = []
 @description('Optional. Specifies whether to enable managed AAD integration.')
 param aadProfileManaged bool = true
 
+@description('Optional. Whether to enable Kubernetes Role-Based Access Control.')
+param enableRBAC bool = true
+
 @description('Optional. Specifies whether to enable Azure RBAC for Kubernetes authorization.')
-param aadProfileEnableAzureRBAC bool = true
+param aadProfileEnableAzureRBAC bool = enableRBAC
 
 @description('Optional. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled.')
 param disableLocalAccounts bool = false
@@ -436,7 +439,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-06-01' 
     oidcIssuerProfile: enableOidcIssuerProfile ? {
       enabled: enableOidcIssuerProfile
     } : null
-    enableRBAC: aadProfileEnableAzureRBAC
+    enableRBAC: enableRBAC
     disableLocalAccounts: disableLocalAccounts
     nodeResourceGroup: nodeResourceGroup
     enablePodSecurityPolicy: enablePodSecurityPolicy

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -38,7 +38,7 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | :-- | :-- | :-- | :-- | :-- |
 | `aadProfileAdminGroupObjectIDs` | array | `[]` |  | Specifies the AAD group object IDs that will have admin role of the cluster. |
 | `aadProfileClientAppID` | string | `''` |  | The client AAD application ID. |
-| `aadProfileEnableAzureRBAC` | bool | `True` |  | Specifies whether to enable Azure RBAC for Kubernetes authorization. |
+| `aadProfileEnableAzureRBAC` | bool | `[parameters('enableRBAC')]` |  | Specifies whether to enable Azure RBAC for Kubernetes authorization. |
 | `aadProfileManaged` | bool | `True` |  | Specifies whether to enable managed AAD integration. |
 | `aadProfileServerAppID` | string | `''` |  | The server AAD application ID. |
 | `aadProfileServerAppSecret` | string | `''` |  | The server AAD application secret. |
@@ -97,6 +97,7 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | `enablePodSecurityPolicy` | bool | `False` |  | Whether to enable Kubernetes pod security policy. |
 | `enablePrivateCluster` | bool | `False` |  | Specifies whether to create the cluster as a private cluster or not. |
 | `enablePrivateClusterPublicFQDN` | bool | `False` |  | Whether to create additional public FQDN for private cluster or not. |
+| `enableRBAC` | bool | `True` |  | Whether to enable Kubernetes Role-Based Access Control. |
 | `enableSecretRotation` | string | `'false'` | `[false, true]` | Specifies whether the KeyvaultSecretsProvider add-on uses secret rotation. |
 | `httpApplicationRoutingEnabled` | bool | `False` |  | Specifies whether the httpApplicationRouting add-on is enabled or not. |
 | `ingressApplicationGatewayEnabled` | bool | `False` |  | Specifies whether the ingressApplicationGateway (AGIC) add-on is enabled or not. |


### PR DESCRIPTION
# Description

>Thank you for your contribution !

> To make sure every Authentication and Authorization method can be selected, I created a new parameter `enableRBAC` to 
> enable or disable RBAC regardless of AzureRBAC configuration so you can choose between local accounts or Azure AD for 
> authentication and Azure RBAC or Kubernetes RBAC for your authorization needs.


## Pipeline references
[![ContainerService: ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml)


# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
