### PR TITLE
[Modules] Clean up not used baseTime parameter

### DIFF
--- a/modules/Microsoft.ServiceBus/namespaces/deploy.bicep
+++ b/modules/Microsoft.ServiceBus/namespaces/deploy.bicep
@@ -80,9 +80,6 @@ param tags object = {}
 @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')
 param enableDefaultTelemetry bool = true
 
-@description('Generated. Do not provide a value! This date value is used to generate a SAS token to access the modules.')
-param baseTime string = utcNow('u')
-
 @description('Optional. The queues to create in the service bus namespace.')
 param queues array = []
 

--- a/modules/Microsoft.ServiceBus/namespaces/readme.md
+++ b/modules/Microsoft.ServiceBus/namespaces/readme.md
@@ -69,11 +69,6 @@ This module deploys a service bus namespace resource.
 | `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |
 | `zoneRedundant` | bool | `False` |  | Enabling this property creates a Premium Service Bus Namespace in regions supported availability zones. |
 
-**Generated parameters**
-| Parameter Name | Type | Default Value | Description |
-| :-- | :-- | :-- | :-- |
-| `baseTime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
-
 
 ### Parameter Usage: `roleAssignments`
 

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -116,9 +116,6 @@ param tags object = {}
 @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')
 param enableDefaultTelemetry bool = true
 
-@description('Generated. Do not provide a value! This date value is used to generate a SAS token to access the modules.')
-param basetime string = utcNow('u')
-
 @description('Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.')
 @allowed([
   ''

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -82,11 +82,6 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | `tags` | object | `{object}` |  | Tags of the resource. |
 | `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |
 
-**Generated parameters**
-| Parameter Name | Type | Default Value | Description |
-| :-- | :-- | :-- | :-- |
-| `basetime` | string | `[utcNow('u')]` | Do not provide a value! This date value is used to generate a SAS token to access the modules. |
-
 
 ### Parameter Usage: `roleAssignments`
 


### PR DESCRIPTION
# Description

Clean up not used `baseTime` parameter

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Ferikag%2F1965-baseTime)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml) |
| [![ServiceBus: Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml/badge.svg?branch=users%2Ferikag%2F1965-baseTime)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
