### PR TITLE
[Modules] Configure privateDnsZoneGroups on batchAccount

### DIFF
--- a/modules/Microsoft.Batch/batchAccounts/.test/encr.parameters.json
+++ b/modules/Microsoft.Batch/batchAccounts/.test/encr.parameters.json
@@ -32,7 +32,12 @@
             "value": [
                 {
                     "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints",
-                    "service": "batchAccount"
+                    "service": "batchAccount",
+                    "privateDnsZoneGroup": {
+                        "privateDNSResourceIds": [
+                            "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com"
+                        ]
+                    }
                 }
             ]
         }

--- a/modules/Microsoft.Batch/batchAccounts/.test/parameters.json
+++ b/modules/Microsoft.Batch/batchAccounts/.test/parameters.json
@@ -21,6 +21,11 @@
                 }
             ]
         },
+        "networkProfileAllowedIpRanges": {
+            "value": [
+                "127.0.0.1"
+            ]
+        },
         "diagnosticLogsRetentionInDays": {
             "value": 7
         },

--- a/modules/Microsoft.Batch/batchAccounts/.test/parameters.json
+++ b/modules/Microsoft.Batch/batchAccounts/.test/parameters.json
@@ -12,7 +12,12 @@
             "value": [
                 {
                     "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints",
-                    "service": "batchAccount"
+                    "service": "batchAccount",
+                    "privateDnsZoneGroup": {
+                        "privateDNSResourceIds": [
+                            "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com"
+                        ]
+                    }
                 }
             ]
         },

--- a/modules/Microsoft.Batch/batchAccounts/deploy.bicep
+++ b/modules/Microsoft.Batch/batchAccounts/deploy.bicep
@@ -204,7 +204,7 @@ resource batchAccount 'Microsoft.Batch/batchAccounts@2022-06-01' = {
       id: keyVaultReferenceResourceId
       url: keyVaultReferenceKeyVault.properties.vaultUri
     } : null
-    networkProfile: (publicNetworkAccess == 'Disabled') || !empty(networkProfileDefaultAction) ? null : {
+    networkProfile: (publicNetworkAccess == 'Disabled') || empty(networkProfileAllowedIpRanges) ? null : {
       accountAccess: {
         defaultAction: networkProfileDefaultAction
         ipRules: networkProfileIpRules

--- a/modules/Microsoft.Batch/batchAccounts/readme.md
+++ b/modules/Microsoft.Batch/batchAccounts/readme.md
@@ -14,7 +14,7 @@
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Batch/batchAccounts` | [2022-01-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Batch/2022-01-01/batchAccounts) |
+| `Microsoft.Batch/batchAccounts` | [2022-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Batch/2022-06-01/batchAccounts) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/privateEndpoints` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/privateEndpoints) |
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/privateEndpoints/privateDnsZoneGroups) |
@@ -50,9 +50,11 @@
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `location` | string | `[resourceGroup().location]` |  | Location for all Resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `networkProfileAllowedIpRanges` | array | `[]` |  | Array of IP ranges to filter client IP address. It is only applicable when publicNetworkAccess is not explicitly disabled. |
+| `networkProfileDefaultAction` | string | `'Deny'` | `[Allow, Deny]` | The network profile default action for endpoint access. It is only applicable when publicNetworkAccess is not explicitly disabled. |
 | `poolAllocationMode` | string | `'BatchService'` | `[BatchService, UserSubscription]` | The allocation mode for creating pools in the Batch account. Determines which quota will be used. |
 | `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
-| `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set. |
+| `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkProfileAllowedIpRanges are not set. |
 | `storageAccessIdentity` | string | `''` |  | The resource ID of a user assigned identity assigned to pools which have compute nodes that need access to auto-storage. |
 | `storageAuthenticationMode` | string | `'StorageKeys'` | `[BatchAccountManagedIdentity, StorageKeys]` | The authentication mode which the Batch service will use to manage the auto-storage account. |
 | `systemAssignedIdentity` | bool | `False` |  | Enables system assigned managed identity on the resource. |
@@ -398,6 +400,9 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     diagnosticStorageAccountId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Storage/storageAccounts/adp<<namePrefix>>azsax001'
     diagnosticWorkspaceId: '/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/microsoft.operationalinsights/workspaces/adp-<<namePrefix>>-az-law-x-001'
     lock: 'CanNotDelete'
+    networkProfileAllowedIpRanges: [
+      '127.0.0.1'
+    ]
     poolAllocationMode: 'BatchService'
     privateEndpoints: [
       {
@@ -454,6 +459,11 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     },
     "lock": {
       "value": "CanNotDelete"
+    },
+    "networkProfileAllowedIpRanges": {
+      "value": [
+        "127.0.0.1"
+      ]
     },
     "poolAllocationMode": {
       "value": "BatchService"

--- a/modules/Microsoft.Batch/batchAccounts/readme.md
+++ b/modules/Microsoft.Batch/batchAccounts/readme.md
@@ -257,6 +257,11 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     poolAllocationMode: 'BatchService'
     privateEndpoints: [
       {
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com'
+          ]
+        }
         service: 'batchAccount'
         subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints'
       }
@@ -302,6 +307,11 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
+          "privateDnsZoneGroup": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com"
+            ]
+          },
           "service": "batchAccount",
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints"
         }
@@ -391,6 +401,11 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     poolAllocationMode: 'BatchService'
     privateEndpoints: [
       {
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com'
+          ]
+        }
         service: 'batchAccount'
         subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints'
       }
@@ -446,6 +461,11 @@ module batchAccounts './Microsoft.Batch/batchAccounts/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
+          "privateDnsZoneGroup": {
+            "privateDNSResourceIds": [
+              "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/privatelink.batch.azure.com"
+            ]
+          },
           "service": "batchAccount",
           "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/adp-<<namePrefix>>-az-vnet-x-001/subnets/<<namePrefix>>-az-subnet-x-005-privateEndpoints"
         }

--- a/modules/Microsoft.Batch/batchAccounts/version.json
+++ b/modules/Microsoft.Batch/batchAccounts/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }


### PR DESCRIPTION
# Description

Updating networking. In particular
   - add option to specify network profile (Selected networks). Required API version update.
   - public network access is set to disabled if private endpoints are set and if network profile is not set
   - add privateDnsZoneGroups on batchAccount tests using private endpoints

Version update

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Batch: BatchAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.batch.batchaccounts.yml/badge.svg?branch=users%2Ferikag%2F1975-batch-dns)](https://github.com/Azure/ResourceModules/actions/workflows/ms.batch.batchaccounts.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
