### PR TITLE
[Documentation] Reduced the `Set-ModuleReadMe` script's dependency on the CARML folder structure + smaller logical improvments

### DIFF
--- a/modules/Microsoft.AAD/DomainServices/readme.md
+++ b/modules/Microsoft.AAD/DomainServices/readme.md
@@ -214,6 +214,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.AnalysisServices/servers/readme.md
+++ b/modules/Microsoft.AnalysisServices/servers/readme.md
@@ -164,6 +164,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Max</h3>

--- a/modules/Microsoft.ApiManagement/service/readme.md
+++ b/modules/Microsoft.ApiManagement/service/readme.md
@@ -279,6 +279,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Max</h3>

--- a/modules/Microsoft.AppConfiguration/configurationStores/readme.md
+++ b/modules/Microsoft.AppConfiguration/configurationStores/readme.md
@@ -293,6 +293,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Authorization/locks/readme.md
+++ b/modules/Microsoft.Authorization/locks/readme.md
@@ -49,6 +49,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Rg</h3>

--- a/modules/Microsoft.Authorization/policyAssignments/readme.md
+++ b/modules/Microsoft.Authorization/policyAssignments/readme.md
@@ -175,6 +175,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Authorization/policyDefinitions/readme.md
+++ b/modules/Microsoft.Authorization/policyDefinitions/readme.md
@@ -133,6 +133,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Authorization/policyExemptions/readme.md
+++ b/modules/Microsoft.Authorization/policyExemptions/readme.md
@@ -156,6 +156,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Authorization/policySetDefinitions/readme.md
+++ b/modules/Microsoft.Authorization/policySetDefinitions/readme.md
@@ -139,6 +139,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Authorization/roleAssignments/readme.md
+++ b/modules/Microsoft.Authorization/roleAssignments/readme.md
@@ -174,6 +174,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Authorization/roleDefinitions/readme.md
+++ b/modules/Microsoft.Authorization/roleDefinitions/readme.md
@@ -178,6 +178,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Mg Min</h3>

--- a/modules/Microsoft.Automation/automationAccounts/readme.md
+++ b/modules/Microsoft.Automation/automationAccounts/readme.md
@@ -363,6 +363,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.Batch/batchAccounts/readme.md
+++ b/modules/Microsoft.Batch/batchAccounts/readme.md
@@ -238,6 +238,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.Cache/redis/readme.md
+++ b/modules/Microsoft.Cache/redis/readme.md
@@ -333,6 +333,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.CognitiveServices/accounts/readme.md
+++ b/modules/Microsoft.CognitiveServices/accounts/readme.md
@@ -419,6 +419,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.Compute/availabilitySets/readme.md
+++ b/modules/Microsoft.Compute/availabilitySets/readme.md
@@ -156,6 +156,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -162,6 +162,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Compute/disks/readme.md
+++ b/modules/Microsoft.Compute/disks/readme.md
@@ -172,6 +172,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Image</h3>

--- a/modules/Microsoft.Compute/galleries/readme.md
+++ b/modules/Microsoft.Compute/galleries/readme.md
@@ -155,6 +155,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Images</h3>

--- a/modules/Microsoft.Compute/images/readme.md
+++ b/modules/Microsoft.Compute/images/readme.md
@@ -156,6 +156,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Compute/proximityPlacementGroups/readme.md
+++ b/modules/Microsoft.Compute/proximityPlacementGroups/readme.md
@@ -153,6 +153,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Compute/virtualMachineScaleSets/readme.md
+++ b/modules/Microsoft.Compute/virtualMachineScaleSets/readme.md
@@ -882,6 +882,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Linux Min</h3>

--- a/modules/Microsoft.Compute/virtualMachines/readme.md
+++ b/modules/Microsoft.Compute/virtualMachines/readme.md
@@ -1013,6 +1013,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Linux Autmg</h3>

--- a/modules/Microsoft.Consumption/budgets/readme.md
+++ b/modules/Microsoft.Consumption/budgets/readme.md
@@ -55,6 +55,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.ContainerInstance/containerGroups/readme.md
+++ b/modules/Microsoft.ContainerInstance/containerGroups/readme.md
@@ -177,6 +177,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.ContainerRegistry/registries/readme.md
+++ b/modules/Microsoft.ContainerRegistry/registries/readme.md
@@ -346,6 +346,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -367,6 +367,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Azure</h3>

--- a/modules/Microsoft.DBforPostgreSQL/flexibleServers/readme.md
+++ b/modules/Microsoft.DBforPostgreSQL/flexibleServers/readme.md
@@ -326,6 +326,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.DataFactory/factories/readme.md
+++ b/modules/Microsoft.DataFactory/factories/readme.md
@@ -351,6 +351,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.DataProtection/backupVaults/readme.md
+++ b/modules/Microsoft.DataProtection/backupVaults/readme.md
@@ -339,6 +339,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Databricks/workspaces/readme.md
+++ b/modules/Microsoft.Databricks/workspaces/readme.md
@@ -226,6 +226,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.DesktopVirtualization/applicationgroups/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/applicationgroups/readme.md
@@ -166,6 +166,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.DesktopVirtualization/hostpools/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/hostpools/readme.md
@@ -262,6 +262,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.DesktopVirtualization/scalingplans/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/scalingplans/readme.md
@@ -264,6 +264,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.DesktopVirtualization/workspaces/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/workspaces/readme.md
@@ -163,6 +163,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
@@ -539,6 +539,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Gremlindb</h3>

--- a/modules/Microsoft.EventGrid/systemTopics/readme.md
+++ b/modules/Microsoft.EventGrid/systemTopics/readme.md
@@ -276,6 +276,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.EventGrid/topics/readme.md
+++ b/modules/Microsoft.EventGrid/topics/readme.md
@@ -251,6 +251,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.EventHub/namespaces/readme.md
+++ b/modules/Microsoft.EventHub/namespaces/readme.md
@@ -296,6 +296,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.HealthBot/healthBots/readme.md
+++ b/modules/Microsoft.HealthBot/healthBots/readme.md
@@ -153,6 +153,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/actionGroups/readme.md
+++ b/modules/Microsoft.Insights/actionGroups/readme.md
@@ -239,6 +239,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/activityLogAlerts/readme.md
+++ b/modules/Microsoft.Insights/activityLogAlerts/readme.md
@@ -401,6 +401,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/components/readme.md
+++ b/modules/Microsoft.Insights/components/readme.md
@@ -157,6 +157,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/diagnosticSettings/readme.md
+++ b/modules/Microsoft.Insights/diagnosticSettings/readme.md
@@ -48,6 +48,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/metricAlerts/readme.md
+++ b/modules/Microsoft.Insights/metricAlerts/readme.md
@@ -382,6 +382,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Insights/privateLinkScopes/readme.md
+++ b/modules/Microsoft.Insights/privateLinkScopes/readme.md
@@ -242,6 +242,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/modules/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -164,6 +164,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.KeyVault/vaults/readme.md
+++ b/modules/Microsoft.KeyVault/vaults/readme.md
@@ -394,6 +394,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.KubernetesConfiguration/extensions/readme.md
+++ b/modules/Microsoft.KubernetesConfiguration/extensions/readme.md
@@ -72,6 +72,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.KubernetesConfiguration/fluxConfigurations/readme.md
+++ b/modules/Microsoft.KubernetesConfiguration/fluxConfigurations/readme.md
@@ -74,6 +74,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Logic/workflows/readme.md
+++ b/modules/Microsoft.Logic/workflows/readme.md
@@ -319,6 +319,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.MachineLearningServices/workspaces/readme.md
+++ b/modules/Microsoft.MachineLearningServices/workspaces/readme.md
@@ -413,6 +413,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
+++ b/modules/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
@@ -149,6 +149,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.ManagedServices/registrationDefinitions/readme.md
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/readme.md
@@ -172,6 +172,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Management/managementGroups/readme.md
+++ b/modules/Microsoft.Management/managementGroups/readme.md
@@ -130,6 +130,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.NetApp/netAppAccounts/readme.md
+++ b/modules/Microsoft.NetApp/netAppAccounts/readme.md
@@ -161,6 +161,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/applicationGateways/readme.md
+++ b/modules/Microsoft.Network/applicationGateways/readme.md
@@ -229,6 +229,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/applicationSecurityGroups/readme.md
+++ b/modules/Microsoft.Network/applicationSecurityGroups/readme.md
@@ -152,6 +152,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/azureFirewalls/readme.md
+++ b/modules/Microsoft.Network/azureFirewalls/readme.md
@@ -310,6 +310,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Addpip</h3>

--- a/modules/Microsoft.Network/bastionHosts/readme.md
+++ b/modules/Microsoft.Network/bastionHosts/readme.md
@@ -297,6 +297,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Custompip</h3>

--- a/modules/Microsoft.Network/connections/readme.md
+++ b/modules/Microsoft.Network/connections/readme.md
@@ -311,6 +311,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Vnet2vnet</h3>

--- a/modules/Microsoft.Network/ddosProtectionPlans/readme.md
+++ b/modules/Microsoft.Network/ddosProtectionPlans/readme.md
@@ -152,6 +152,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/expressRouteCircuits/readme.md
+++ b/modules/Microsoft.Network/expressRouteCircuits/readme.md
@@ -174,6 +174,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/firewallPolicies/readme.md
+++ b/modules/Microsoft.Network/firewallPolicies/readme.md
@@ -143,6 +143,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/frontDoors/readme.md
+++ b/modules/Microsoft.Network/frontDoors/readme.md
@@ -169,6 +169,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/ipGroups/readme.md
+++ b/modules/Microsoft.Network/ipGroups/readme.md
@@ -153,6 +153,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/loadBalancers/readme.md
+++ b/modules/Microsoft.Network/loadBalancers/readme.md
@@ -466,6 +466,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Internal</h3>

--- a/modules/Microsoft.Network/localNetworkGateways/readme.md
+++ b/modules/Microsoft.Network/localNetworkGateways/readme.md
@@ -158,6 +158,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/natGateways/readme.md
+++ b/modules/Microsoft.Network/natGateways/readme.md
@@ -170,6 +170,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -186,6 +186,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/networkSecurityGroups/readme.md
+++ b/modules/Microsoft.Network/networkSecurityGroups/readme.md
@@ -162,6 +162,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/networkWatchers/readme.md
+++ b/modules/Microsoft.Network/networkWatchers/readme.md
@@ -153,6 +153,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/privateDnsZones/readme.md
+++ b/modules/Microsoft.Network/privateDnsZones/readme.md
@@ -170,6 +170,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/privateEndpoints/readme.md
+++ b/modules/Microsoft.Network/privateEndpoints/readme.md
@@ -169,6 +169,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/privateLinkServices/readme.md
+++ b/modules/Microsoft.Network/privateLinkServices/readme.md
@@ -428,6 +428,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/publicIPAddresses/readme.md
+++ b/modules/Microsoft.Network/publicIPAddresses/readme.md
@@ -166,6 +166,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/publicIPPrefixes/readme.md
+++ b/modules/Microsoft.Network/publicIPPrefixes/readme.md
@@ -153,6 +153,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/routeTables/readme.md
+++ b/modules/Microsoft.Network/routeTables/readme.md
@@ -243,6 +243,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/trafficmanagerprofiles/readme.md
+++ b/modules/Microsoft.Network/trafficmanagerprofiles/readme.md
@@ -257,6 +257,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Network/virtualHubs/readme.md
+++ b/modules/Microsoft.Network/virtualHubs/readme.md
@@ -110,6 +110,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/virtualNetworkGateways/readme.md
+++ b/modules/Microsoft.Network/virtualNetworkGateways/readme.md
@@ -247,6 +247,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Expressroute</h3>

--- a/modules/Microsoft.Network/virtualNetworks/readme.md
+++ b/modules/Microsoft.Network/virtualNetworks/readme.md
@@ -355,6 +355,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/virtualWans/readme.md
+++ b/modules/Microsoft.Network/virtualWans/readme.md
@@ -156,6 +156,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/vpnGateways/readme.md
+++ b/modules/Microsoft.Network/vpnGateways/readme.md
@@ -177,6 +177,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Network/vpnSites/readme.md
+++ b/modules/Microsoft.Network/vpnSites/readme.md
@@ -325,6 +325,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.OperationalInsights/workspaces/readme.md
+++ b/modules/Microsoft.OperationalInsights/workspaces/readme.md
@@ -458,6 +458,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.OperationsManagement/solutions/readme.md
+++ b/modules/Microsoft.OperationsManagement/solutions/readme.md
@@ -50,6 +50,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.PowerBIDedicated/capacities/readme.md
+++ b/modules/Microsoft.PowerBIDedicated/capacities/readme.md
@@ -156,6 +156,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.RecoveryServices/vaults/readme.md
+++ b/modules/Microsoft.RecoveryServices/vaults/readme.md
@@ -908,6 +908,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Dr</h3>

--- a/modules/Microsoft.Resources/deploymentScripts/readme.md
+++ b/modules/Microsoft.Resources/deploymentScripts/readme.md
@@ -148,6 +148,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Cli</h3>

--- a/modules/Microsoft.Resources/resourceGroups/readme.md
+++ b/modules/Microsoft.Resources/resourceGroups/readme.md
@@ -160,6 +160,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Resources/tags/readme.md
+++ b/modules/Microsoft.Resources/tags/readme.md
@@ -86,6 +86,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Security/azureSecurityCenter/readme.md
+++ b/modules/Microsoft.Security/azureSecurityCenter/readme.md
@@ -103,6 +103,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.ServiceBus/namespaces/readme.md
+++ b/modules/Microsoft.ServiceBus/namespaces/readme.md
@@ -342,6 +342,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.ServiceFabric/clusters/readme.md
+++ b/modules/Microsoft.ServiceFabric/clusters/readme.md
@@ -235,6 +235,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Cert</h3>

--- a/modules/Microsoft.SignalRService/webPubSub/readme.md
+++ b/modules/Microsoft.SignalRService/webPubSub/readme.md
@@ -358,6 +358,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Sql/managedInstances/readme.md
+++ b/modules/Microsoft.Sql/managedInstances/readme.md
@@ -281,6 +281,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -336,6 +336,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Admin</h3>

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -378,6 +378,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encr</h3>

--- a/modules/Microsoft.Synapse/privateLinkHubs/readme.md
+++ b/modules/Microsoft.Synapse/privateLinkHubs/readme.md
@@ -240,6 +240,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -305,6 +305,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Encryptionwsai</h3>

--- a/modules/Microsoft.VirtualMachineImages/imageTemplates/readme.md
+++ b/modules/Microsoft.VirtualMachineImages/imageTemplates/readme.md
@@ -268,6 +268,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Web/connections/readme.md
+++ b/modules/Microsoft.Web/connections/readme.md
@@ -160,6 +160,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Web/hostingEnvironments/readme.md
+++ b/modules/Microsoft.Web/hostingEnvironments/readme.md
@@ -206,6 +206,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Asev2</h3>

--- a/modules/Microsoft.Web/serverfarms/readme.md
+++ b/modules/Microsoft.Web/serverfarms/readme.md
@@ -206,6 +206,7 @@ _None_
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Parameters</h3>

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -408,6 +408,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Fa Min</h3>

--- a/modules/Microsoft.Web/staticSites/readme.md
+++ b/modules/Microsoft.Web/staticSites/readme.md
@@ -287,6 +287,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
    >**Note**: The name of each example is based on the name of the file from which it is taken.
+
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
 <h3>Example 1: Min</h3>

--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -310,6 +310,12 @@ Add module references (cross-references) to the module's readme
 .DESCRIPTION
 Add module references (cross-references) to the module's readme. This includes both local (i.e., file path), as well as remote references (e.g., ACR)
 
+.PARAMETER ModuleRoot
+Mandatory. The file path to the module's root
+
+.PARAMETER FullModuleIdentifier
+Mandatory. The full identifier of the module (i.e., ProviderNamespace + ResourceType)
+
 .PARAMETER TemplateFileContent
 Mandatory. The template file content object to crawl data from
 
@@ -320,13 +326,19 @@ Mandatory. The readme file content array to update
 Optional. The identifier of the 'outputs' section. Defaults to '## Cross-referenced modules'
 
 .EXAMPLE
-Set-CrossReferencesSection -TemplateFileContent @{ resource = @{}; ... } -ReadMeFileContent @('# Title', '', '## Section 1', ...)
+Set-CrossReferencesSection -ModuleRoot 'C:/Microsoft.KeyVault/vaults' -FullModuleIdentifier 'Microsoft.KeyVault/vaults' -TemplateFileContent @{ resource = @{}; ... } -ReadMeFileContent @('# Title', '', '## Section 1', ...)
 Update the given readme file's 'Cross-referenced modules' section based on the given template file content
 #>
 function Set-CrossReferencesSection {
 
     [CmdletBinding(SupportsShouldProcess)]
     param (
+        [Parameter(Mandatory = $true)]
+        [string] $ModuleRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string] $FullModuleIdentifier,
+
         [Parameter(Mandatory)]
         [hashtable] $TemplateFileContent,
 
@@ -339,9 +351,6 @@ function Set-CrossReferencesSection {
 
     . (Join-Path (Split-Path $PSScriptRoot -Parent) 'tools' 'Get-CrossReferencedModuleList.ps1')
 
-    $moduleRoot = Split-Path $TemplateFilePath -Parent
-    $resourceTypeIdentifier = $moduleRoot.Replace('\', '/').Split('/modules/')[1].TrimStart('/')
-
     # Process content
     $SectionContent = [System.Collections.ArrayList]@(
         'This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).',
@@ -350,7 +359,7 @@ function Set-CrossReferencesSection {
         '| :-- | :-- |'
     )
 
-    $dependencies = (Get-CrossReferencedModuleList)[$resourceTypeIdentifier]
+    $dependencies = (Get-CrossReferencedModuleList)[$FullModuleIdentifier]
 
     if ($dependencies.Keys -contains 'localPathReferences' -and $dependencies['localPathReferences']) {
         foreach ($reference in ($dependencies['localPathReferences'] | Sort-Object)) {
@@ -823,14 +832,14 @@ Generate 'Deployment examples' for the ReadMe out of the parameter files current
 .DESCRIPTION
 Generate 'Deployment examples' for the ReadMe out of the parameter files currently used to test the template
 
-.PARAMETER TemplateFilePath
-Mandatory. The path to the template file
+.PARAMETER ModuleRoot
+Mandatory. The file path to the module's root
+
+.PARAMETER FullModuleIdentifier
+Mandatory. The full identifier of the module (i.e., ProviderNamespace + ResourceType)
 
 .PARAMETER TemplateFileContent
 Mandatory. The template file content object to crawl data from
-
-.PARAMETER TemplateFilePath
-Mandatory. The path to the template file
 
 .PARAMETER ReadMeFileContent
 Mandatory. The readme file content array to update
@@ -845,7 +854,7 @@ Optional. A switch to control whether or not to add a ARM-JSON-Parameter file ex
 Optional. A switch to control whether or not to add a Bicep deployment example. Defaults to true.
 
 .EXAMPLE
-Set-DeploymentExamplesSection -TemplateFileContent @{ resource = @{}; ... } -TemplateFilePath 'C:/deploy.bicep' -ReadMeFileContent @('# Title', '', '## Section 1', ...)
+Set-DeploymentExamplesSection -ModuleRoot 'C:/Microsoft.KeyVault/vaults' -FullModuleIdentifier 'Microsoft.KeyVault/vaults' -TemplateFileContent @{ resource = @{}; ... } -ReadMeFileContent @('# Title', '', '## Section 1', ...)
 
 Update the given readme file's 'Deployment Examples' section based on the given template file content
 #>
@@ -854,7 +863,10 @@ function Set-DeploymentExamplesSection {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Mandatory = $true)]
-        [string] $TemplateFilePath,
+        [string] $ModuleRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string] $FullModuleIdentifier,
 
         [Parameter(Mandatory)]
         [hashtable] $TemplateFileContent,
@@ -879,19 +891,17 @@ function Set-DeploymentExamplesSection {
     $SectionContent = [System.Collections.ArrayList]@(
         'The following module usage examples are retrieved from the content of the files hosted in the module''s `.test` folder.',
         '   >**Note**: The name of each example is based on the name of the file from which it is taken.',
+        '',
         '   >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.',
         ''
     )
 
-    $moduleRoot = Split-Path $TemplateFilePath -Parent
-    $fullIdentifier = $moduleRoot.Replace('\', '/').Split('/modules/')[1].TrimStart('/')
-
     # Get resource type and make first letter upper case. Requires manual handling as ToTitleCase lowercases everything but the first letter
-    $providerNamespace = ($fullIdentifier.Split('/')[0] -split '\.' | ForEach-Object { $_.Substring(0, 1).ToUpper() + $_.Substring(1) }) -join '.'
-    $resourceType = $fullIdentifier.Split('/')[1]
+    $providerNamespace = ($fullModuleIdentifier.Split('/')[0] -split '\.' | ForEach-Object { $_.Substring(0, 1).ToUpper() + $_.Substring(1) }) -join '.'
+    $resourceType = $fullModuleIdentifier.Split('/')[1]
     $resourceTypeUpper = $resourceType.Substring(0, 1).ToUpper() + $resourceType.Substring(1)
 
-    $resourceTypeIdentifier = "$providerNamespace/$resourceType"
+    $FullModuleIdentifier = "$providerNamespace/$resourceType"
 
     $testFilePaths = Get-ModuleTestFileList -ModulePath $moduleRoot | ForEach-Object { Join-Path $moduleRoot $_ }
 
@@ -948,7 +958,7 @@ function Set-DeploymentExamplesSection {
 
             # [3/6] Format header, remove scope property & any empty line
             $rawBicepExample = $rawBicepExampleString -split '\n'
-            $rawBicepExample[0] = "module $resourceType './$resourceTypeIdentifier/deploy.bicep' = {"
+            $rawBicepExample[0] = "module $resourceType './$FullModuleIdentifier/deploy.bicep' = {"
             $rawBicepExample = $rawBicepExample | Where-Object { $_ -notmatch 'scope: *' } | Where-Object { -not [String]::IsNullOrEmpty($_) }
 
             # [4/6] Extract param block
@@ -1144,7 +1154,7 @@ function Set-DeploymentExamplesSection {
                     ''
                     '```bicep',
                     $extendedKeyVaultReferences,
-                    "module $resourceType './$resourceTypeIdentifier/deploy.bicep' = {"
+                    "module $resourceType './$FullModuleIdentifier/deploy.bicep' = {"
                     "  name: '`${uniqueString(deployment().name)}-$resourceTypeUpper'"
                     '  params: {'
                     $bicepExample.TrimEnd(),
@@ -1373,20 +1383,21 @@ function Set-ModuleReadMe {
         throw "Failed to compile [$TemplateFilePath]"
     }
 
-    $fullResourcePath = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/modules/')[1]
+    $moduleRoot = Split-Path $TemplateFilePath -Parent
+    $fullModuleIdentifier = 'Microsoft.{0}' -f $moduleRoot.Replace('\', '/').split('/Microsoft.')[1]
 
     # Check readme
     if (-not (Test-Path $ReadMeFilePath) -or ([String]::IsNullOrEmpty((Get-Content $ReadMeFilePath -Raw)))) {
         # Create new readme file
 
         # Build resource name
-        $serviceIdentifiers = $fullResourcePath.Replace('Microsoft.', '').Replace('/.', '/').Split('/')
+        $serviceIdentifiers = $fullModuleIdentifier.Replace('Microsoft.', '').Replace('/.', '/').Split('/')
         $serviceIdentifiers = $serviceIdentifiers | ForEach-Object { $_.substring(0, 1).toupper() + $_.substring(1) }
         $serviceIdentifiers = $serviceIdentifiers | ForEach-Object { $_ -creplace '(?<=\w)([A-Z])', '$1' }
         $assumedResourceName = $serviceIdentifiers -join ' '
 
         $initialContent = @(
-            "# $assumedResourceName ``[$fullResourcePath]``",
+            "# $assumedResourceName ``[$fullModuleIdentifier]``",
             '',
             "This module deploys $assumedResourceName."
             '// TODO: Replace Resource and fill in description',
@@ -1408,14 +1419,14 @@ function Set-ModuleReadMe {
     }
 
     # Update title
-    if ($TemplateFilePath.Replace('\', '/') -like '*/modules/*') {
+    if ($TemplateFilePath.Replace('\', '/') -like '*/deploy.*') {
 
-        if ($readMeFileContent[0] -notlike "*``[$fullResourcePath]``") {
+        if ($readMeFileContent[0] -notlike "*``[$fullModuleIdentifier]``") {
             # Cut outdated
             $readMeFileContent[0] = $readMeFileContent[0].Split('`[')[0]
 
             # Add latest
-            $readMeFileContent[0] = '{0} `[{1}]`' -f $readMeFileContent[0], $fullResourcePath
+            $readMeFileContent[0] = '{0} `[{1}]`' -f $readMeFileContent[0], $fullModuleIdentifier
         }
         # Remove excess whitespace
         $readMeFileContent[0] = $readMeFileContent[0] -replace '\s+', ' '
@@ -1456,20 +1467,23 @@ function Set-ModuleReadMe {
         # Handle [CrossReferences] section
         # ========================
         $inputObject = @{
-            ReadMeFileContent   = $readMeFileContent
-            TemplateFileContent = $templateFileContent
+            ModuleRoot           = $ModuleRoot
+            FullModuleIdentifier = $fullModuleIdentifier
+            ReadMeFileContent    = $readMeFileContent
+            TemplateFileContent  = $templateFileContent
         }
         $readMeFileContent = Set-CrossReferencesSection @inputObject
     }
 
-    $isTopLevelModule = $TemplateFilePath.Replace('\', '/').Split('/modules/')[1].Split('/').Count -eq 3 # <provider>/<resourceType>/deploy.*
+    $isTopLevelModule = $fullModuleIdentifier.Split('/').Count -eq 2 # <provider>/<resourceType>
     if ($SectionsToRefresh -contains 'Deployment examples' -and $isTopLevelModule) {
         # Handle [Deployment examples] section
         # ===================================
         $inputObject = @{
-            ReadMeFileContent   = $readMeFileContent
-            TemplateFilePath    = $TemplateFilePath
-            TemplateFileContent = $templateFileContent
+            ModuleRoot           = $ModuleRoot
+            FullModuleIdentifier = $fullModuleIdentifier
+            ReadMeFileContent    = $readMeFileContent
+            TemplateFileContent  = $templateFileContent
         }
         $readMeFileContent = Set-DeploymentExamplesSection @inputObject
     }


### PR DESCRIPTION
# Description

- Reduced the `Set-ModuleReadMe` script's dependency on the CARML folder structure (splitting at `Microsoft.` instead of `/modules/`) to allow usage of script also outside the CARML 'module' folder
- Smaller logical improvments (e.g. less places with splits)
- Refreshed ReadMe's to apply a small visual update to deployment examples

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2FreadmeSplit)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation
