### PR TITLE
[CI environment] Extend and optimize resource removal of nested deployments with higher scope than the parent

### DIFF
--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -66,6 +66,7 @@ function Initialize-DeploymentRemoval {
         # The initial sequence is a general order-recommendation
         $removalSequence = @(
             'Microsoft.Authorization/locks',
+            'Microsoft.Authorization/roleAssignments',
             'Microsoft.Insights/diagnosticSettings',
             'Microsoft.Network/privateEndpoints/privateDnsZoneGroups',
             'Microsoft.Network/privateEndpoints',


### PR DESCRIPTION
# Description

Prerequisite for PR #2136 and #2019. 
In the new dependencies approach for compute images, a deployment at subscription scope (roleAssignment) is nested in a deployment at resource group scope (rg dependencies). The current removal logic does not cover this scenario and the nested deployment is not fetched when having a higher scope than the parent. Hence the roleAssignment is not removed, and a subsequent validation of the module fails.

- Improving fetching of deployments and resources to delete to support the above scenario.
- Adding roleAssignment removal priority 

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Consumption: Budgets](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml/badge.svg?branch=users%2Ferikag%2Fupdate-removal)](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml) |
| [![Insights: ActionGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml/badge.svg?branch=users%2Ferikag%2Fupdate-removal)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml) |
| [![Compute: VirtualMachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg?branch=users%2Ferikag%2Fupdate-removal)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml) -> old approach |
| [![Authorization: PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Ferikag%2Fupdate-removal)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml) |
| [![Authorization: RoleAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roleassignments.yml/badge.svg?branch=users%2Ferikag%2Fupdate-removal)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roleassignments.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
