### PR TITLE
[Fixes] Key Vault - Fix parameter usage section

### DIFF
--- a/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
@@ -113,7 +113,7 @@ module testDeployment '../../deploy.bicep' = {
       ipRules: []
       virtualNetworkRules: [
         {
-          action: 'Allow'
+          // action: 'Allow'
           id: resourceGroupResources.outputs.subnetResourceId
         }
       ]

--- a/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
@@ -113,7 +113,6 @@ module testDeployment '../../deploy.bicep' = {
       ipRules: []
       virtualNetworkRules: [
         {
-          // action: 'Allow'
           id: resourceGroupResources.outputs.subnetResourceId
         }
       ]

--- a/modules/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/modules/Microsoft.KeyVault/vaults/deploy.bicep
@@ -152,13 +152,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   }
 }]
 
-var networkAcls_var = {
-  bypass: !empty(networkAcls) ? networkAcls.bypass : null
-  defaultAction: !empty(networkAcls) ? networkAcls.defaultAction : null
-  virtualNetworkRules: (!empty(networkAcls) && contains(networkAcls, 'virtualNetworkRules')) ? networkAcls.virtualNetworkRules : []
-  ipRules: (!empty(networkAcls) && contains(networkAcls, 'ipRules')) ? networkAcls.ipRules : []
-}
-
 var formattedAccessPolicies = [for accessPolicy in accessPolicies: {
   applicationId: contains(accessPolicy, 'applicationId') ? accessPolicy.applicationId : ''
   objectId: contains(accessPolicy, 'objectId') ? accessPolicy.objectId : ''
@@ -204,7 +197,12 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
       name: vaultSku
       family: 'A'
     }
-    networkAcls: !empty(networkAcls) ? networkAcls_var : null
+    networkAcls: !empty(networkAcls) ? {
+      bypass: contains(networkAcls, 'bypass') ? networkAcls.bypass : null
+      defaultAction: contains(networkAcls, 'defaultAction') ? networkAcls.defaultAction : null
+      virtualNetworkRules: contains(networkAcls, 'virtualNetworkRules') ? networkAcls.virtualNetworkRules : []
+      ipRules: contains(networkAcls, 'ipRules') ? networkAcls.ipRules : []
+    } : null
     publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) && empty(networkAcls) ? 'Disabled' : null)
   }
 }

--- a/modules/Microsoft.KeyVault/vaults/deploy.bicep
+++ b/modules/Microsoft.KeyVault/vaults/deploy.bicep
@@ -64,7 +64,7 @@ param vaultSku string = 'premium'
 @description('Optional. Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny.')
 param networkAcls object = {}
 
-@description('Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set.')
+@description('Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.')
 @allowed([
   ''
   'Enabled'
@@ -205,7 +205,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
       family: 'A'
     }
     networkAcls: !empty(networkAcls) ? networkAcls_var : null
-    publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) ? 'Disabled' : null)
+    publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) && empty(networkAcls) ? 'Disabled' : null)
   }
 }
 

--- a/modules/Microsoft.KeyVault/vaults/readme.md
+++ b/modules/Microsoft.KeyVault/vaults/readme.md
@@ -467,7 +467,6 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
       ipRules: []
       virtualNetworkRules: [
         {
-          action: 'Allow'
           id: '<id>'
         }
       ]
@@ -606,7 +605,6 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
         "ipRules": [],
         "virtualNetworkRules": [
           {
-            "action": "Allow",
             "id": "<id>"
           }
         ]

--- a/modules/Microsoft.KeyVault/vaults/readme.md
+++ b/modules/Microsoft.KeyVault/vaults/readme.md
@@ -58,7 +58,7 @@ This module deploys a key vault and its child resources.
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
 | `networkAcls` | object | `{object}` |  | Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny. |
 | `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
-| `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set. |
+| `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `secrets` | secureObject | `{object}` |  | All secrets to create. |
 | `softDeleteRetentionInDays` | int | `90` |  | softDelete data retention days. It accepts >=7 and <=90. |

--- a/modules/Microsoft.KeyVault/vaults/readme.md
+++ b/modules/Microsoft.KeyVault/vaults/readme.md
@@ -179,7 +179,7 @@ tags: {
         "defaultAction": "Deny",
         "virtualNetworkRules": [
             {
-                "subnetId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001"
+                "id": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001"
             }
         ],
         "ipRules": []
@@ -199,36 +199,11 @@ networkAcls: {
     defaultAction: 'Deny'
     virtualNetworkRules: [
         {
-            subnetId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001'
+            id: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001'
         }
     ]
     ipRules: []
 }
-```
-
-</details>
-<p>
-
-### Parameter Usage: `vNetId`
-
-<details>
-
-<summary>Parameter JSON format</summary>
-
-```json
-"vNetId": {
-    "value": "/subscriptions/00000000/resourceGroups/resourceGroup"
-}
-```
-
-</details>
-
-<details>
-
-<summary>Bicep format</summary>
-
-```bicep
-vNetId: '/subscriptions/00000000/resourceGroups/resourceGroup'
 ```
 
 </details>


### PR DESCRIPTION
# Description

- Remove outdated `vNetId` parameter usage
- Update `networkAcls` parameter usage
- Removed parameter value from common test. `action: 'Allow'` is added by default.
- Cleaned up variable `networkAcls_var` from the module

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
