### PR TITLE
[Modules] NetApp nfs41 adding principalType to RBAC

### DIFF
--- a/modules/Microsoft.NetApp/netAppAccounts/.test/nfs41/deploy.test.bicep
+++ b/modules/Microsoft.NetApp/netAppAccounts/.test/nfs41/deploy.test.bicep
@@ -51,6 +51,7 @@ module testDeployment '../../deploy.bicep' = {
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
             roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         serviceLevel: 'Premium'
@@ -77,6 +78,7 @@ module testDeployment '../../deploy.bicep' = {
                   resourceGroupResources.outputs.managedIdentityPrincipalId
                 ]
                 roleDefinitionIdOrName: 'Reader'
+                principalType: 'ServicePrincipal'
               }
             ]
             subnetResourceId: resourceGroupResources.outputs.subnetResourceId
@@ -110,6 +112,7 @@ module testDeployment '../../deploy.bicep' = {
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
             roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         serviceLevel: 'Premium'
@@ -123,6 +126,7 @@ module testDeployment '../../deploy.bicep' = {
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
         roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     tags: {

--- a/modules/Microsoft.NetApp/netAppAccounts/readme.md
+++ b/modules/Microsoft.NetApp/netAppAccounts/readme.md
@@ -437,6 +437,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -463,6 +464,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
                 principalIds: [
                   '<managedIdentityPrincipalId>'
                 ]
+                principalType: 'ServicePrincipal'
                 roleDefinitionIdOrName: 'Reader'
               }
             ]
@@ -496,6 +498,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -509,6 +512,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -550,6 +554,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -576,6 +581,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
                   "principalIds": [
                     "<managedIdentityPrincipalId>"
                   ],
+                  "principalType": "ServicePrincipal",
                   "roleDefinitionIdOrName": "Reader"
                 }
               ],
@@ -609,6 +615,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -624,6 +631,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]


### PR DESCRIPTION
# Description

Missing RBAC principalType for NetApp nfs41 test caused deployment validation to fail

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![NetApp: NetAppAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml/badge.svg?branch=users%2Ferikag%2F2209-fix-anf)](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
