### PR TITLE
[Fixes] Update latest az cli version for Deployment Scripts cli test

### DIFF
--- a/modules/Microsoft.Resources/deploymentScripts/.test/cli/deploy.test.bicep
+++ b/modules/Microsoft.Resources/deploymentScripts/.test/cli/deploy.test.bicep
@@ -41,7 +41,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    azCliVersion: '2.41.0'
+    azCliVersion: '2.40.0'
     cleanupPreference: 'Always'
     kind: 'AzureCLI'
     retentionInterval: 'P1D'

--- a/modules/Microsoft.Resources/deploymentScripts/readme.md
+++ b/modules/Microsoft.Resources/deploymentScripts/readme.md
@@ -167,7 +167,7 @@ module deploymentScripts './Microsoft.Resources/deploymentScripts/deploy.bicep' 
     // Required parameters
     name: '<<namePrefix>>rdscli001'
     // Non-required parameters
-    azCliVersion: '2.41.0'
+    azCliVersion: '2.40.0'
     cleanupPreference: 'Always'
     kind: 'AzureCLI'
     retentionInterval: 'P1D'
@@ -199,7 +199,7 @@ module deploymentScripts './Microsoft.Resources/deploymentScripts/deploy.bicep' 
     },
     // Non-required parameters
     "azCliVersion": {
-      "value": "2.41.0"
+      "value": "2.40.0"
     },
     "cleanupPreference": {
       "value": "Always"


### PR DESCRIPTION
# Description

Latest az cli version is 2.41.0, but not yet supported by Deployment Scripts and causing deployment validation to fail on cli test.
Reverting to current runner up 2.40.0

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Resources: DeploymentScripts](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.deploymentscripts.yml/badge.svg?branch=users%2Ferikag%2F2221-fix-ds)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.deploymentscripts.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
