### PR TITLE
[Modules] Extend Web Sites with kvrefidentity

### DIFF
--- a/modules/Microsoft.Web/sites/.test/FunctionAppCommon/deploy.test.bicep
+++ b/modules/Microsoft.Web/sites/.test/FunctionAppCommon/deploy.test.bicep
@@ -156,6 +156,7 @@ module testDeployment '../../deploy.bicep' = {
       }
     ]
     setAzureWebJobsDashboard: true
+    keyVaultAccessIdentityResourceId: resourceGroupResources.outputs.managedIdentityResourceId
     siteConfig: {
       alwaysOn: true
       use32BitWorkerProcess: false

--- a/modules/Microsoft.Web/sites/deploy.bicep
+++ b/modules/Microsoft.Web/sites/deploy.bicep
@@ -34,6 +34,9 @@ param systemAssignedIdentity bool = false
 @description('Optional. The ID(s) to assign to the resource.')
 param userAssignedIdentities object = {}
 
+@description('Optional. The resource ID of the assigned identity to be used to access a key vault with.')
+param keyVaultAccessIdentityResourceId string = ''
+
 @description('Optional. Checks if Customer provided storage account is required.')
 param storageAccountRequired bool = false
 
@@ -194,6 +197,7 @@ resource app 'Microsoft.Web/sites@2021-03-01' = {
       id: appServiceEnvironmentId
     } : null
     storageAccountRequired: storageAccountRequired
+    keyVaultReferenceIdentity: !empty(keyVaultAccessIdentityResourceId) ? keyVaultAccessIdentityResourceId: null
     virtualNetworkSubnetId: !empty(virtualNetworkSubnetId) ? virtualNetworkSubnetId : any(null)
     siteConfig: siteConfig
   }

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -503,6 +503,7 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     diagnosticLogsRetentionInDays: 7
     diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
+    keyVaultAccessIdentityResourceId: '<keyVaultAccessIdentityResourceId>'
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
@@ -649,6 +650,9 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     },
     "diagnosticWorkspaceId": {
       "value": "<diagnosticWorkspaceId>"
+    },
+    "keyVaultAccessIdentityResourceId": {
+      "value": "<keyVaultAccessIdentityResourceId>"
     },
     "lock": {
       "value": "CanNotDelete"

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -51,6 +51,7 @@ This module deploys a web or function app.
 | `diagnosticWorkspaceId` | string | `''` |  | Resource ID of log analytics workspace. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `httpsOnly` | bool | `True` |  | Configures a site to accept only HTTPS requests. Issues redirect for HTTP requests. |
+| `keyVaultAccessIdentityResourceId` | string | `''` |  | The resource ID of the assigned identity to be used to access a key vault with. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all Resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
 | `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |


### PR DESCRIPTION
# Description

This PR will introduce the ability to define a specific identity to be used by the app service when authenticating to a keyvault.
Previously this missing property could lead to issues when using a system- and a user-assigned identity at the same time.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| [![Web: Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg?branch=users%2Ff_blix%2Fsites-kvrefidentity)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml) |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
