### PR TITLE
[Fixes] Fixed test DNS name

### DIFF
--- a/modules/Microsoft.DBforPostgreSQL/flexibleServers/.test/private/dependencies.bicep
+++ b/modules/Microsoft.DBforPostgreSQL/flexibleServers/.test/private/dependencies.bicep
@@ -36,7 +36,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
 }
 
 resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-    name: 'postgres.database.azure.com'
+    name: '${split(virtualNetworkName, '-')[1]}.postgres.database.azure.com'
     location: 'global'
 
     resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {


### PR DESCRIPTION
# Description

It appears this is a special case for this resource provider. When comparing the [parameter files](https://github.com/Azure/ResourceModules/blob/main/utilities/pipelines/dependencies/Microsoft.Network/privateDnsZones/parameters/postgres.parameters.json) it becomes relatively apparant ...

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![DbForPostgreSQL: FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml/badge.svg?branch=users%2Falsehr%2F2234_dbfp)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
