### PR TITLE
Update the API version to newer version in deploy.bicep

### DIFF
--- a/modules/Microsoft.Network/virtualHubs/deploy.bicep
+++ b/modules/Microsoft.Network/virtualHubs/deploy.bicep
@@ -93,7 +93,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource virtualHub 'Microsoft.Network/virtualHubs@2021-08-01' = {
+resource virtualHub 'Microsoft.Network/virtualHubs@2022-05-01' = {
   name: name
   location: location
   tags: tags


### PR DESCRIPTION
change the API version from 2021-08-01 to 2022-05-01 because when we want add the virtualRouterAsn we are getting the following error:

```
"CustomAsnNotSupportedByVirtualHub\\\",\\r\\n    \\\"message\\\": \\\"To modify router ASN in virtual hub, please use API version 2022-01-01 and beyond
```

# Description

>Thank you for your contribution !

> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
