### PR TITLE
[Testing] Updated RBAC tests to be more explicit about the principal type

### DIFF
--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -645,6 +645,7 @@ In addition, we follow the following, file-type-specific guidelines:
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
+            principalType: 'ServicePrincipal'
           }
         ]
         diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.AnalysisServices/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.AnalysisServices/servers/.test/common/deploy.test.bicep
@@ -63,6 +63,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
     diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.AnalysisServices/servers/.test/max/deploy.test.bicep
+++ b/modules/Microsoft.AnalysisServices/servers/.test/max/deploy.test.bicep
@@ -74,6 +74,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
     diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.AnalysisServices/servers/readme.md
+++ b/modules/Microsoft.AnalysisServices/servers/readme.md
@@ -193,6 +193,7 @@ module servers './Microsoft.AnalysisServices/servers/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -242,6 +243,7 @@ module servers './Microsoft.AnalysisServices/servers/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -297,6 +299,7 @@ module servers './Microsoft.AnalysisServices/servers/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -370,6 +373,7 @@ module servers './Microsoft.AnalysisServices/servers/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.ApiManagement/service/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ApiManagement/service/.test/common/deploy.test.bicep
@@ -70,10 +70,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.ApiManagement/service/.test/max/deploy.test.bicep
+++ b/modules/Microsoft.ApiManagement/service/.test/max/deploy.test.bicep
@@ -166,10 +166,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     subscriptions: [

--- a/modules/Microsoft.ApiManagement/service/readme.md
+++ b/modules/Microsoft.ApiManagement/service/readme.md
@@ -329,6 +329,7 @@ module service './Microsoft.ApiManagement/service/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -396,6 +397,7 @@ module service './Microsoft.ApiManagement/service/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -533,6 +535,7 @@ module service './Microsoft.ApiManagement/service/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -714,6 +717,7 @@ module service './Microsoft.ApiManagement/service/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.AppConfiguration/configurationStores/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.AppConfiguration/configurationStores/.test/common/deploy.test.bicep
@@ -70,10 +70,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'keyName'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         value: 'valueName'
@@ -82,10 +83,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     softDeleteRetentionInDays: 1

--- a/modules/Microsoft.AppConfiguration/configurationStores/readme.md
+++ b/modules/Microsoft.AppConfiguration/configurationStores/readme.md
@@ -328,6 +328,7 @@ module configurationStores './Microsoft.AppConfiguration/configurationStores/dep
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -340,6 +341,7 @@ module configurationStores './Microsoft.AppConfiguration/configurationStores/dep
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -400,6 +402,7 @@ module configurationStores './Microsoft.AppConfiguration/configurationStores/dep
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -416,6 +419,7 @@ module configurationStores './Microsoft.AppConfiguration/configurationStores/dep
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Automation/automationAccounts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Automation/automationAccounts/.test/common/deploy.test.bicep
@@ -107,10 +107,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     runbooks: [

--- a/modules/Microsoft.Automation/automationAccounts/readme.md
+++ b/modules/Microsoft.Automation/automationAccounts/readme.md
@@ -434,6 +434,7 @@ module automationAccounts './Microsoft.Automation/automationAccounts/deploy.bice
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -645,6 +646,7 @@ module automationAccounts './Microsoft.Automation/automationAccounts/deploy.bice
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.CognitiveServices/accounts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.CognitiveServices/accounts/.test/common/deploy.test.bicep
@@ -80,10 +80,11 @@ module testDeployment '../../deploy.bicep' = {
     }
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     sku: 'S0'

--- a/modules/Microsoft.CognitiveServices/accounts/readme.md
+++ b/modules/Microsoft.CognitiveServices/accounts/readme.md
@@ -476,6 +476,7 @@ module accounts './Microsoft.CognitiveServices/accounts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -564,6 +565,7 @@ module accounts './Microsoft.CognitiveServices/accounts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/availabilitySets/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/availabilitySets/.test/common/deploy.test.bicep
@@ -46,10 +46,11 @@ module testDeployment '../../deploy.bicep' = {
     proximityPlacementGroupId: resourceGroupResources.outputs.proximityPlacementGroupResourceId
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/availabilitySets/readme.md
+++ b/modules/Microsoft.Compute/availabilitySets/readme.md
@@ -181,6 +181,7 @@ module availabilitySets './Microsoft.Compute/availabilitySets/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -217,6 +218,7 @@ module availabilitySets './Microsoft.Compute/availabilitySets/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
@@ -46,10 +46,11 @@ module testDeployment '../../deploy.bicep' = {
     keyVaultResourceId: resourceGroupResources.outputs.keyVaultResourceId
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -187,6 +187,7 @@ module diskEncryptionSets './Microsoft.Compute/diskEncryptionSets/deploy.bicep' 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -223,6 +224,7 @@ module diskEncryptionSets './Microsoft.Compute/diskEncryptionSets/deploy.bicep' 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/disks/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/disks/.test/common/deploy.test.bicep
@@ -55,6 +55,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/disks/.test/image/deploy.test.bicep
+++ b/modules/Microsoft.Compute/disks/.test/image/deploy.test.bicep
@@ -50,6 +50,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/disks/.test/import/deploy.test.bicep
+++ b/modules/Microsoft.Compute/disks/.test/import/deploy.test.bicep
@@ -53,6 +53,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
     sourceUri: resourceGroupResources.outputs.vhdUri

--- a/modules/Microsoft.Compute/disks/readme.md
+++ b/modules/Microsoft.Compute/disks/readme.md
@@ -208,6 +208,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -262,6 +263,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -294,6 +296,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -333,6 +336,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -364,6 +368,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -402,6 +407,7 @@ module disks './Microsoft.Compute/disks/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/galleries/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/galleries/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/galleries/.test/images/deploy.test.bicep
+++ b/modules/Microsoft.Compute/galleries/.test/images/deploy.test.bicep
@@ -58,10 +58,11 @@ module testDeployment '../../deploy.bicep' = {
         publisher: 'MicrosoftWindowsServer'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         sku: '2022-datacenter-azure-edition'

--- a/modules/Microsoft.Compute/galleries/readme.md
+++ b/modules/Microsoft.Compute/galleries/readme.md
@@ -179,6 +179,7 @@ module galleries './Microsoft.Compute/galleries/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -212,6 +213,7 @@ module galleries './Microsoft.Compute/galleries/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -256,6 +258,7 @@ module galleries './Microsoft.Compute/galleries/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -317,6 +320,7 @@ module galleries './Microsoft.Compute/galleries/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],

--- a/modules/Microsoft.Compute/images/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/images/.test/common/deploy.test.bicep
@@ -52,10 +52,11 @@ module testDeployment '../../deploy.bicep' = {
     hyperVGeneration: 'V1'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     zoneResilient: true

--- a/modules/Microsoft.Compute/images/readme.md
+++ b/modules/Microsoft.Compute/images/readme.md
@@ -184,6 +184,7 @@ module images './Microsoft.Compute/images/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -230,6 +231,7 @@ module images './Microsoft.Compute/images/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/proximityPlacementGroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/proximityPlacementGroups/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Compute/proximityPlacementGroups/readme.md
+++ b/modules/Microsoft.Compute/proximityPlacementGroups/readme.md
@@ -177,6 +177,7 @@ module proximityPlacementGroups './Microsoft.Compute/proximityPlacementGroups/de
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -210,6 +211,7 @@ module proximityPlacementGroups './Microsoft.Compute/proximityPlacementGroups/de
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
@@ -98,10 +98,11 @@ module testDeployment '../../deploy.bicep' = {
               publicIpNameSuffix: '-pip-01'
               roleAssignments: [
                 {
+                  roleDefinitionIdOrName: 'Reader'
                   principalIds: [
                     resourceGroupResources.outputs.managedIdentityPrincipalId
                   ]
-                  roleDefinitionIdOrName: 'Reader'
+                  principalType: 'ServicePrincipal'
                 }
               ]
             }
@@ -111,10 +112,11 @@ module testDeployment '../../deploy.bicep' = {
         nicSuffix: '-nic-01'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
       }
@@ -208,10 +210,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
@@ -96,10 +96,11 @@ module testDeployment '../../deploy.bicep' = {
               publicIpNameSuffix: '-pip-01'
               roleAssignments: [
                 {
+                  roleDefinitionIdOrName: 'Reader'
                   principalIds: [
                     resourceGroupResources.outputs.managedIdentityPrincipalId
                   ]
-                  roleDefinitionIdOrName: 'Reader'
+                  principalType: 'ServicePrincipal'
                 }
               ]
             }
@@ -109,10 +110,11 @@ module testDeployment '../../deploy.bicep' = {
         nicSuffix: '-nic-01'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
       }
@@ -219,10 +221,11 @@ module testDeployment '../../deploy.bicep' = {
     proximityPlacementGroupResourceId: resourceGroupResources.outputs.proximityPlacementGroupResourceId
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.Compute/virtualMachines/readme.md
+++ b/modules/Microsoft.Compute/virtualMachines/readme.md
@@ -1062,6 +1062,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
                   principalIds: [
                     '<managedIdentityPrincipalId>'
                   ]
+                  principalType: 'ServicePrincipal'
                   roleDefinitionIdOrName: 'Reader'
                 }
               ]
@@ -1075,6 +1076,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -1175,6 +1177,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1234,6 +1237,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
                     "principalIds": [
                       "<managedIdentityPrincipalId>"
                     ],
+                    "principalType": "ServicePrincipal",
                     "roleDefinitionIdOrName": "Reader"
                   }
                 ]
@@ -1247,6 +1251,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ]
@@ -1403,6 +1408,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -1733,6 +1739,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
                   principalIds: [
                     '<managedIdentityPrincipalId>'
                   ]
+                  principalType: 'ServicePrincipal'
                   roleDefinitionIdOrName: 'Reader'
                 }
               ]
@@ -1746,6 +1753,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -1859,6 +1867,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1918,6 +1927,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
                     "principalIds": [
                       "<managedIdentityPrincipalId>"
                     ],
+                    "principalType": "ServicePrincipal",
                     "roleDefinitionIdOrName": "Reader"
                   }
                 ]
@@ -1931,6 +1941,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ]
@@ -2102,6 +2113,7 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.ContainerRegistry/registries/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ContainerRegistry/registries/.test/common/deploy.test.bicep
@@ -94,10 +94,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.ContainerRegistry/registries/readme.md
+++ b/modules/Microsoft.ContainerRegistry/registries/readme.md
@@ -407,6 +407,7 @@ module registries './Microsoft.ContainerRegistry/registries/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -512,6 +513,7 @@ module registries './Microsoft.ContainerRegistry/registries/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
@@ -141,10 +141,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.ContainerService/managedClusters/.test/kubenet/deploy.test.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/kubenet/deploy.test.bicep
@@ -133,10 +133,11 @@ module testDeployment '../../deploy.bicep' = {
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     userAssignedIdentities: {

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -472,6 +472,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -604,6 +605,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -712,6 +714,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -837,6 +840,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DataFactory/factories/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DataFactory/factories/.test/common/deploy.test.bicep
@@ -109,10 +109,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.DataFactory/factories/readme.md
+++ b/modules/Microsoft.DataFactory/factories/readme.md
@@ -422,6 +422,7 @@ module factories './Microsoft.DataFactory/factories/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -532,6 +533,7 @@ module factories './Microsoft.DataFactory/factories/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DataProtection/backupVaults/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DataProtection/backupVaults/.test/common/deploy.test.bicep
@@ -43,10 +43,11 @@ module testDeployment '../../deploy.bicep' = {
     name: '<<namePrefix>>${serviceShort}001'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.DataProtection/backupVaults/readme.md
+++ b/modules/Microsoft.DataProtection/backupVaults/readme.md
@@ -424,6 +424,7 @@ module backupVaults './Microsoft.DataProtection/backupVaults/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -522,6 +523,7 @@ module backupVaults './Microsoft.DataProtection/backupVaults/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Databricks/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Databricks/workspaces/.test/common/deploy.test.bicep
@@ -63,10 +63,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Databricks/workspaces/readme.md
+++ b/modules/Microsoft.Databricks/workspaces/readme.md
@@ -255,6 +255,7 @@ module workspaces './Microsoft.Databricks/workspaces/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -303,6 +304,7 @@ module workspaces './Microsoft.Databricks/workspaces/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DesktopVirtualization/applicationgroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DesktopVirtualization/applicationgroups/.test/common/deploy.test.bicep
@@ -87,10 +87,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.DesktopVirtualization/applicationgroups/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/applicationgroups/readme.md
@@ -218,6 +218,7 @@ module applicationgroups './Microsoft.DesktopVirtualization/applicationgroups/de
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -301,6 +302,7 @@ module applicationgroups './Microsoft.DesktopVirtualization/applicationgroups/de
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DesktopVirtualization/hostpools/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DesktopVirtualization/hostpools/.test/common/deploy.test.bicep
@@ -71,10 +71,11 @@ module testDeployment '../../deploy.bicep' = {
     personalDesktopAssignmentType: 'Automatic'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     vmTemplate: {

--- a/modules/Microsoft.DesktopVirtualization/hostpools/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/hostpools/readme.md
@@ -300,6 +300,7 @@ module hostpools './Microsoft.DesktopVirtualization/hostpools/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -389,6 +390,7 @@ module hostpools './Microsoft.DesktopVirtualization/hostpools/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DesktopVirtualization/scalingplans/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DesktopVirtualization/scalingplans/.test/common/deploy.test.bicep
@@ -57,10 +57,11 @@ module testDeployment '../../deploy.bicep' = {
     name: '<<namePrefix>>${serviceShort}001'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.DesktopVirtualization/scalingplans/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/scalingplans/readme.md
@@ -294,6 +294,7 @@ module scalingplans './Microsoft.DesktopVirtualization/scalingplans/deploy.bicep
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -350,6 +351,7 @@ module scalingplans './Microsoft.DesktopVirtualization/scalingplans/deploy.bicep
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DesktopVirtualization/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.DesktopVirtualization/workspaces/.test/common/deploy.test.bicep
@@ -69,10 +69,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     workspaceDescription: 'This is my first AVD Workspace'

--- a/modules/Microsoft.DesktopVirtualization/workspaces/readme.md
+++ b/modules/Microsoft.DesktopVirtualization/workspaces/readme.md
@@ -196,6 +196,7 @@ module workspaces './Microsoft.DesktopVirtualization/workspaces/deploy.bicep' = 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -254,6 +255,7 @@ module workspaces './Microsoft.DesktopVirtualization/workspaces/deploy.bicep' = 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.DocumentDB/databaseAccounts/.test/gremlindb/deploy.test.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/.test/gremlindb/deploy.test.bicep
@@ -118,10 +118,11 @@ module testDeployment '../../deploy.bicep' = {
     location: location
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.DocumentDB/databaseAccounts/.test/mongodb/deploy.test.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/.test/mongodb/deploy.test.bicep
@@ -259,10 +259,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.DocumentDB/databaseAccounts/.test/plain/deploy.test.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/.test/plain/deploy.test.bicep
@@ -75,10 +75,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.DocumentDB/databaseAccounts/.test/sqldb/deploy.test.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/.test/sqldb/deploy.test.bicep
@@ -75,10 +75,11 @@ module testDeployment '../../deploy.bicep' = {
     location: location
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     sqlDatabases: [

--- a/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
@@ -623,6 +623,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -733,6 +734,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -967,6 +969,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1216,6 +1219,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -1266,6 +1270,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1328,6 +1333,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -1375,6 +1381,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1458,6 +1465,7 @@ module databaseAccounts './Microsoft.DocumentDB/databaseAccounts/deploy.bicep' =
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.EventGrid/systemTopics/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.EventGrid/systemTopics/.test/common/deploy.test.bicep
@@ -66,10 +66,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.EventGrid/systemTopics/readme.md
+++ b/modules/Microsoft.EventGrid/systemTopics/readme.md
@@ -307,6 +307,7 @@ module systemTopics './Microsoft.EventGrid/systemTopics/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -361,6 +362,7 @@ module systemTopics './Microsoft.EventGrid/systemTopics/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.EventGrid/topics/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.EventGrid/topics/.test/common/deploy.test.bicep
@@ -81,10 +81,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.EventGrid/topics/readme.md
+++ b/modules/Microsoft.EventGrid/topics/readme.md
@@ -297,6 +297,7 @@ module topics './Microsoft.EventGrid/topics/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -366,6 +367,7 @@ module topics './Microsoft.EventGrid/topics/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.EventHub/namespaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.EventHub/namespaces/.test/common/deploy.test.bicep
@@ -122,10 +122,11 @@ module testDeployment '../../deploy.bicep' = {
         partitionCount: 2
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         status: 'Active'
@@ -161,10 +162,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.EventHub/namespaces/readme.md
+++ b/modules/Microsoft.EventHub/namespaces/readme.md
@@ -385,6 +385,7 @@ module namespaces './Microsoft.EventHub/namespaces/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -424,6 +425,7 @@ module namespaces './Microsoft.EventHub/namespaces/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -532,6 +534,7 @@ module namespaces './Microsoft.EventHub/namespaces/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -579,6 +582,7 @@ module namespaces './Microsoft.EventHub/namespaces/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.HealthBot/healthBots/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.HealthBot/healthBots/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.HealthBot/healthBots/readme.md
+++ b/modules/Microsoft.HealthBot/healthBots/readme.md
@@ -177,6 +177,7 @@ module healthBots './Microsoft.HealthBot/healthBots/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -210,6 +211,7 @@ module healthBots './Microsoft.HealthBot/healthBots/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Insights/components/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Insights/components/.test/common/deploy.test.bicep
@@ -45,10 +45,11 @@ module testDeployment '../../deploy.bicep' = {
     workspaceResourceId: resourceGroupResources.outputs.logAnalyticsWorkspaceResourceId
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Insights/components/readme.md
+++ b/modules/Microsoft.Insights/components/readme.md
@@ -181,6 +181,7 @@ module components './Microsoft.Insights/components/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -214,6 +215,7 @@ module components './Microsoft.Insights/components/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Insights/metricAlerts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Insights/metricAlerts/.test/common/deploy.test.bicep
@@ -59,10 +59,11 @@ module testDeployment '../../deploy.bicep' = {
     alertCriteriaType: 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     targetResourceRegion: 'westeurope'

--- a/modules/Microsoft.Insights/metricAlerts/readme.md
+++ b/modules/Microsoft.Insights/metricAlerts/readme.md
@@ -421,6 +421,7 @@ module metricAlerts './Microsoft.Insights/metricAlerts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -475,6 +476,7 @@ module metricAlerts './Microsoft.Insights/metricAlerts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Insights/privateLinkScopes/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Insights/privateLinkScopes/.test/common/deploy.test.bicep
@@ -62,10 +62,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Insights/privateLinkScopes/readme.md
+++ b/modules/Microsoft.Insights/privateLinkScopes/readme.md
@@ -276,6 +276,7 @@ module privateLinkScopes './Microsoft.Insights/privateLinkScopes/deploy.bicep' =
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -325,6 +326,7 @@ module privateLinkScopes './Microsoft.Insights/privateLinkScopes/deploy.bicep' =
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Insights/scheduledQueryRules/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Insights/scheduledQueryRules/.test/common/deploy.test.bicep
@@ -75,10 +75,11 @@ module testDeployment '../../deploy.bicep' = {
     queryTimeRange: 'PT5M'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     scopes: [

--- a/modules/Microsoft.Insights/scheduledQueryRules/readme.md
+++ b/modules/Microsoft.Insights/scheduledQueryRules/readme.md
@@ -221,6 +221,7 @@ module scheduledQueryRules './Microsoft.Insights/scheduledQueryRules/deploy.bice
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -299,6 +300,7 @@ module scheduledQueryRules './Microsoft.Insights/scheduledQueryRules/deploy.bice
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.KeyVault/vaults/.test/common/deploy.test.bicep
@@ -98,10 +98,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'keyName'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
       }
@@ -135,10 +136,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     secrets: {
@@ -150,10 +152,11 @@ module testDeployment '../../deploy.bicep' = {
           name: 'secretName'
           roleAssignments: [
             {
+              roleDefinitionIdOrName: 'Reader'
               principalIds: [
                 resourceGroupResources.outputs.managedIdentityPrincipalId
               ]
-              roleDefinitionIdOrName: 'Reader'
+              principalType: 'ServicePrincipal'
             }
           ]
           value: 'secretValue'

--- a/modules/Microsoft.KeyVault/vaults/readme.md
+++ b/modules/Microsoft.KeyVault/vaults/readme.md
@@ -440,6 +440,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -477,6 +478,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -492,6 +494,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
               principalIds: [
                 '<managedIdentityPrincipalId>'
               ]
+              principalType: 'ServicePrincipal'
               roleDefinitionIdOrName: 'Reader'
             }
           ]
@@ -583,6 +586,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ]
@@ -628,6 +632,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -645,6 +650,7 @@ module vaults './Microsoft.KeyVault/vaults/deploy.bicep' = {
                 "principalIds": [
                   "<managedIdentityPrincipalId>"
                 ],
+                "principalType": "ServicePrincipal",
                 "roleDefinitionIdOrName": "Reader"
               }
             ],

--- a/modules/Microsoft.Logic/workflows/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Logic/workflows/.test/common/deploy.test.bicep
@@ -63,10 +63,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     userAssignedIdentities: {

--- a/modules/Microsoft.Logic/workflows/readme.md
+++ b/modules/Microsoft.Logic/workflows/readme.md
@@ -348,6 +348,7 @@ module workflows './Microsoft.Logic/workflows/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -434,6 +435,7 @@ module workflows './Microsoft.Logic/workflows/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.MachineLearningServices/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.MachineLearningServices/workspaces/.test/common/deploy.test.bicep
@@ -115,10 +115,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: false

--- a/modules/Microsoft.MachineLearningServices/workspaces/readme.md
+++ b/modules/Microsoft.MachineLearningServices/workspaces/readme.md
@@ -492,6 +492,7 @@ module workspaces './Microsoft.MachineLearningServices/workspaces/deploy.bicep' 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -611,6 +612,7 @@ module workspaces './Microsoft.MachineLearningServices/workspaces/deploy.bicep' 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.ManagedIdentity/userAssignedIdentities/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ManagedIdentity/userAssignedIdentities/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     tags: {

--- a/modules/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
+++ b/modules/Microsoft.ManagedIdentity/userAssignedIdentities/readme.md
@@ -170,6 +170,7 @@ module userAssignedIdentities './Microsoft.ManagedIdentity/userAssignedIdentitie
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -205,6 +206,7 @@ module userAssignedIdentities './Microsoft.ManagedIdentity/userAssignedIdentitie
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.NetApp/netAppAccounts/.test/nfs3/deploy.test.bicep
+++ b/modules/Microsoft.NetApp/netAppAccounts/.test/nfs3/deploy.test.bicep
@@ -47,10 +47,11 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>-${serviceShort}-cp-001'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         serviceLevel: 'Premium'
@@ -73,10 +74,11 @@ module testDeployment '../../deploy.bicep' = {
             ]
             roleAssignments: [
               {
+                roleDefinitionIdOrName: 'Reader'
                 principalIds: [
                   resourceGroupResources.outputs.managedIdentityPrincipalId
                 ]
-                roleDefinitionIdOrName: 'Reader'
+                principalType: 'ServicePrincipal'
               }
             ]
             subnetResourceId: resourceGroupResources.outputs.subnetResourceId
@@ -96,10 +98,11 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>-${serviceShort}-cp-002'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         serviceLevel: 'Premium'
@@ -110,10 +113,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     tags: {

--- a/modules/Microsoft.NetApp/netAppAccounts/.test/nfs41/deploy.test.bicep
+++ b/modules/Microsoft.NetApp/netAppAccounts/.test/nfs41/deploy.test.bicep
@@ -47,10 +47,10 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>-${serviceShort}-cp-001'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
             principalType: 'ServicePrincipal'
           }
         ]
@@ -74,10 +74,10 @@ module testDeployment '../../deploy.bicep' = {
             ]
             roleAssignments: [
               {
+                roleDefinitionIdOrName: 'Reader'
                 principalIds: [
                   resourceGroupResources.outputs.managedIdentityPrincipalId
                 ]
-                roleDefinitionIdOrName: 'Reader'
                 principalType: 'ServicePrincipal'
               }
             ]
@@ -108,10 +108,10 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>-${serviceShort}-cp-002'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
             principalType: 'ServicePrincipal'
           }
         ]
@@ -122,10 +122,10 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
         principalType: 'ServicePrincipal'
       }
     ]

--- a/modules/Microsoft.NetApp/netAppAccounts/readme.md
+++ b/modules/Microsoft.NetApp/netAppAccounts/readme.md
@@ -224,6 +224,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -250,6 +251,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
                 principalIds: [
                   '<managedIdentityPrincipalId>'
                 ]
+                principalType: 'ServicePrincipal'
                 roleDefinitionIdOrName: 'Reader'
               }
             ]
@@ -273,6 +275,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -287,6 +290,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -328,6 +332,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -354,6 +359,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
                   "principalIds": [
                     "<managedIdentityPrincipalId>"
                   ],
+                  "principalType": "ServicePrincipal",
                   "roleDefinitionIdOrName": "Reader"
                 }
               ],
@@ -377,6 +383,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -395,6 +402,7 @@ module netAppAccounts './Microsoft.NetApp/netAppAccounts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/applicationGateways/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/applicationGateways/.test/common/deploy.test.bicep
@@ -353,10 +353,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     sku: 'WAF_v2'

--- a/modules/Microsoft.Network/applicationGateways/readme.md
+++ b/modules/Microsoft.Network/applicationGateways/readme.md
@@ -542,6 +542,7 @@ module applicationGateways './Microsoft.Network/applicationGateways/deploy.bicep
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -916,6 +917,7 @@ module applicationGateways './Microsoft.Network/applicationGateways/deploy.bicep
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/applicationSecurityGroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/applicationSecurityGroups/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/applicationSecurityGroups/readme.md
+++ b/modules/Microsoft.Network/applicationSecurityGroups/readme.md
@@ -176,6 +176,7 @@ module applicationSecurityGroups './Microsoft.Network/applicationSecurityGroups/
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -209,6 +210,7 @@ module applicationSecurityGroups './Microsoft.Network/applicationSecurityGroups/
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/azureFirewalls/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/azureFirewalls/.test/common/deploy.test.bicep
@@ -148,10 +148,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     zones: [

--- a/modules/Microsoft.Network/azureFirewalls/.test/custompip/deploy.test.bicep
+++ b/modules/Microsoft.Network/azureFirewalls/.test/custompip/deploy.test.bicep
@@ -57,10 +57,11 @@ module testDeployment '../../deploy.bicep' = {
       publicIPPrefixResourceId: ''
       roleAssignments: [
         {
+          roleDefinitionIdOrName: 'Reader'
           principalIds: [
             resourceGroupResources.outputs.managedIdentityPrincipalId
           ]
-          roleDefinitionIdOrName: 'Reader'
+          principalType: 'ServicePrincipal'
         }
       ]
       skuName: 'Standard'

--- a/modules/Microsoft.Network/azureFirewalls/readme.md
+++ b/modules/Microsoft.Network/azureFirewalls/readme.md
@@ -481,6 +481,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -625,6 +626,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -674,6 +676,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
           principalIds: [
             '<managedIdentityPrincipalId>'
           ]
+          principalType: 'ServicePrincipal'
           roleDefinitionIdOrName: 'Reader'
         }
       ]
@@ -722,6 +725,7 @@ module azureFirewalls './Microsoft.Network/azureFirewalls/deploy.bicep' = {
             "principalIds": [
               "<managedIdentityPrincipalId>"
             ],
+            "principalType": "ServicePrincipal",
             "roleDefinitionIdOrName": "Reader"
           }
         ],

--- a/modules/Microsoft.Network/bastionHosts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/bastionHosts/.test/common/deploy.test.bicep
@@ -71,10 +71,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     scaleUnits: 4

--- a/modules/Microsoft.Network/bastionHosts/.test/custompip/deploy.test.bicep
+++ b/modules/Microsoft.Network/bastionHosts/.test/custompip/deploy.test.bicep
@@ -57,10 +57,11 @@ module testDeployment '../../deploy.bicep' = {
       publicIPPrefixResourceId: ''
       roleAssignments: [
         {
+          roleDefinitionIdOrName: 'Reader'
           principalIds: [
             resourceGroupResources.outputs.managedIdentityPrincipalId
           ]
-          roleDefinitionIdOrName: 'Reader'
+          principalType: 'ServicePrincipal'
         }
       ]
       skuName: 'Standard'

--- a/modules/Microsoft.Network/bastionHosts/readme.md
+++ b/modules/Microsoft.Network/bastionHosts/readme.md
@@ -332,6 +332,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -400,6 +401,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -448,6 +450,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
           principalIds: [
             '<managedIdentityPrincipalId>'
           ]
+          principalType: 'ServicePrincipal'
           roleDefinitionIdOrName: 'Reader'
         }
       ]
@@ -496,6 +499,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
             "principalIds": [
               "<managedIdentityPrincipalId>"
             ],
+            "principalType": "ServicePrincipal",
             "roleDefinitionIdOrName": "Reader"
           }
         ],

--- a/modules/Microsoft.Network/ddosProtectionPlans/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/ddosProtectionPlans/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/ddosProtectionPlans/readme.md
+++ b/modules/Microsoft.Network/ddosProtectionPlans/readme.md
@@ -176,6 +176,7 @@ module ddosProtectionPlans './Microsoft.Network/ddosProtectionPlans/deploy.bicep
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -209,6 +210,7 @@ module ddosProtectionPlans './Microsoft.Network/ddosProtectionPlans/deploy.bicep
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/expressRouteCircuits/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/expressRouteCircuits/.test/common/deploy.test.bicep
@@ -66,10 +66,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     skuFamily: 'MeteredData'

--- a/modules/Microsoft.Network/expressRouteCircuits/readme.md
+++ b/modules/Microsoft.Network/expressRouteCircuits/readme.md
@@ -206,6 +206,7 @@ module expressRouteCircuits './Microsoft.Network/expressRouteCircuits/deploy.bic
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -265,6 +266,7 @@ module expressRouteCircuits './Microsoft.Network/expressRouteCircuits/deploy.bic
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/frontDoors/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/frontDoors/.test/common/deploy.test.bicep
@@ -133,10 +133,11 @@ module testDeployment '../../deploy.bicep' = {
     sendRecvTimeoutSeconds: 10
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/frontDoors/readme.md
+++ b/modules/Microsoft.Network/frontDoors/readme.md
@@ -281,6 +281,7 @@ module frontDoors './Microsoft.Network/frontDoors/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -415,6 +416,7 @@ module frontDoors './Microsoft.Network/frontDoors/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/ipGroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/ipGroups/.test/common/deploy.test.bicep
@@ -48,10 +48,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/ipGroups/readme.md
+++ b/modules/Microsoft.Network/ipGroups/readme.md
@@ -181,6 +181,7 @@ module ipGroups './Microsoft.Network/ipGroups/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -220,6 +221,7 @@ module ipGroups './Microsoft.Network/ipGroups/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/loadBalancers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/loadBalancers/.test/common/deploy.test.bicep
@@ -144,10 +144,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/loadBalancers/.test/internal/deploy.test.bicep
+++ b/modules/Microsoft.Network/loadBalancers/.test/internal/deploy.test.bicep
@@ -118,10 +118,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/loadBalancers/readme.md
+++ b/modules/Microsoft.Network/loadBalancers/readme.md
@@ -575,6 +575,7 @@ module loadBalancers './Microsoft.Network/loadBalancers/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -715,6 +716,7 @@ module loadBalancers './Microsoft.Network/loadBalancers/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -804,6 +806,7 @@ module loadBalancers './Microsoft.Network/loadBalancers/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -916,6 +919,7 @@ module loadBalancers './Microsoft.Network/loadBalancers/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/localNetworkGateways/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/localNetworkGateways/.test/common/deploy.test.bicep
@@ -50,10 +50,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/localNetworkGateways/readme.md
+++ b/modules/Microsoft.Network/localNetworkGateways/readme.md
@@ -188,6 +188,7 @@ module localNetworkGateways './Microsoft.Network/localNetworkGateways/deploy.bic
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -235,6 +236,7 @@ module localNetworkGateways './Microsoft.Network/localNetworkGateways/deploy.bic
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/natGateways/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/natGateways/.test/common/deploy.test.bicep
@@ -64,10 +64,11 @@ module testDeployment '../../deploy.bicep' = {
     natGatewayPublicIpAddress: true
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/natGateways/readme.md
+++ b/modules/Microsoft.Network/natGateways/readme.md
@@ -200,6 +200,7 @@ module natGateways './Microsoft.Network/natGateways/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -251,6 +252,7 @@ module natGateways './Microsoft.Network/natGateways/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/networkInterfaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/networkInterfaces/.test/common/deploy.test.bicep
@@ -90,10 +90,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/networkInterfaces/readme.md
+++ b/modules/Microsoft.Network/networkInterfaces/readme.md
@@ -239,6 +239,7 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -313,6 +314,7 @@ module networkInterfaces './Microsoft.Network/networkInterfaces/deploy.bicep' = 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/networkSecurityGroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/networkSecurityGroups/.test/common/deploy.test.bicep
@@ -64,10 +64,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     securityRules: [

--- a/modules/Microsoft.Network/networkSecurityGroups/readme.md
+++ b/modules/Microsoft.Network/networkSecurityGroups/readme.md
@@ -191,6 +191,7 @@ module networkSecurityGroups './Microsoft.Network/networkSecurityGroups/deploy.b
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -303,6 +304,7 @@ module networkSecurityGroups './Microsoft.Network/networkSecurityGroups/deploy.b
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/privateDnsZones/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/privateDnsZones/.test/common/deploy.test.bicep
@@ -52,10 +52,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'A_10.240.4.4'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         ttl: 3600
@@ -80,10 +81,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'CNAME_test'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         ttl: 3600
@@ -101,10 +103,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'MX_contoso'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         ttl: 3600
@@ -120,10 +123,11 @@ module testDeployment '../../deploy.bicep' = {
         ]
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         ttl: 3600
@@ -131,10 +135,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     soa: [
@@ -142,10 +147,11 @@ module testDeployment '../../deploy.bicep' = {
         name: '@'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         soaRecord: {
@@ -165,10 +171,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'SRV_contoso'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         srvRecords: [
@@ -187,10 +194,11 @@ module testDeployment '../../deploy.bicep' = {
         name: 'TXT_test'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         ttl: 3600

--- a/modules/Microsoft.Network/privateDnsZones/readme.md
+++ b/modules/Microsoft.Network/privateDnsZones/readme.md
@@ -201,6 +201,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -229,6 +230,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -250,6 +252,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -269,6 +272,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -280,6 +284,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -291,6 +296,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -314,6 +320,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -336,6 +343,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -390,6 +398,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -422,6 +431,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -447,6 +457,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -468,6 +479,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -481,6 +493,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -494,6 +507,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -519,6 +533,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],
@@ -543,6 +558,7 @@ module privateDnsZones './Microsoft.Network/privateDnsZones/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],

--- a/modules/Microsoft.Network/privateEndpoints/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/privateEndpoints/.test/common/deploy.test.bicep
@@ -57,10 +57,11 @@ module testDeployment '../../deploy.bicep' = {
     }
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     ipConfigurations: [

--- a/modules/Microsoft.Network/privateEndpoints/readme.md
+++ b/modules/Microsoft.Network/privateEndpoints/readme.md
@@ -335,6 +335,7 @@ module privateEndpoints './Microsoft.Network/privateEndpoints/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -408,6 +409,7 @@ module privateEndpoints './Microsoft.Network/privateEndpoints/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/publicIPAddresses/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/publicIPAddresses/.test/common/deploy.test.bicep
@@ -64,10 +64,11 @@ module testDeployment '../../deploy.bicep' = {
     publicIPAllocationMethod: 'Static'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     skuName: 'Standard'

--- a/modules/Microsoft.Network/publicIPAddresses/readme.md
+++ b/modules/Microsoft.Network/publicIPAddresses/readme.md
@@ -196,6 +196,7 @@ module publicIPAddresses './Microsoft.Network/publicIPAddresses/deploy.bicep' = 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -253,6 +254,7 @@ module publicIPAddresses './Microsoft.Network/publicIPAddresses/deploy.bicep' = 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/publicIPPrefixes/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/publicIPPrefixes/.test/common/deploy.test.bicep
@@ -45,10 +45,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/publicIPPrefixes/readme.md
+++ b/modules/Microsoft.Network/publicIPPrefixes/readme.md
@@ -178,6 +178,7 @@ module publicIPPrefixes './Microsoft.Network/publicIPPrefixes/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -214,6 +215,7 @@ module publicIPPrefixes './Microsoft.Network/publicIPPrefixes/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/routeTables/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/routeTables/.test/common/deploy.test.bicep
@@ -44,10 +44,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     routes: [

--- a/modules/Microsoft.Network/routeTables/readme.md
+++ b/modules/Microsoft.Network/routeTables/readme.md
@@ -267,6 +267,7 @@ module routeTables './Microsoft.Network/routeTables/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -310,6 +311,7 @@ module routeTables './Microsoft.Network/routeTables/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/trafficmanagerprofiles/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/trafficmanagerprofiles/.test/common/deploy.test.bicep
@@ -64,10 +64,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/trafficmanagerprofiles/readme.md
+++ b/modules/Microsoft.Network/trafficmanagerprofiles/readme.md
@@ -287,6 +287,7 @@ module trafficmanagerprofiles './Microsoft.Network/trafficmanagerprofiles/deploy
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -338,6 +339,7 @@ module trafficmanagerprofiles './Microsoft.Network/trafficmanagerprofiles/deploy
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/virtualNetworks/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/virtualNetworks/.test/common/deploy.test.bicep
@@ -72,10 +72,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     subnets: [
@@ -89,10 +90,11 @@ module testDeployment '../../deploy.bicep' = {
         networkSecurityGroupId: resourceGroupResources.outputs.networkSecurityGroupResourceId
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         routeTableId: resourceGroupResources.outputs.routeTableResourceId

--- a/modules/Microsoft.Network/virtualNetworks/readme.md
+++ b/modules/Microsoft.Network/virtualNetworks/readme.md
@@ -391,6 +391,7 @@ module virtualNetworks './Microsoft.Network/virtualNetworks/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -408,6 +409,7 @@ module virtualNetworks './Microsoft.Network/virtualNetworks/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -496,6 +498,7 @@ module virtualNetworks './Microsoft.Network/virtualNetworks/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -515,6 +518,7 @@ module virtualNetworks './Microsoft.Network/virtualNetworks/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ],

--- a/modules/Microsoft.Network/virtualWans/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/virtualWans/.test/common/deploy.test.bicep
@@ -47,10 +47,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     type: 'Basic'

--- a/modules/Microsoft.Network/virtualWans/readme.md
+++ b/modules/Microsoft.Network/virtualWans/readme.md
@@ -183,6 +183,7 @@ module virtualWans './Microsoft.Network/virtualWans/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -226,6 +227,7 @@ module virtualWans './Microsoft.Network/virtualWans/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Network/vpnSites/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/vpnSites/.test/common/deploy.test.bicep
@@ -94,6 +94,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Network/vpnSites/readme.md
+++ b/modules/Microsoft.Network/vpnSites/readme.md
@@ -365,6 +365,7 @@ module vpnSites './Microsoft.Network/vpnSites/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -449,6 +450,7 @@ module vpnSites './Microsoft.Network/vpnSites/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.RecoveryServices/vaults/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.RecoveryServices/vaults/.test/common/deploy.test.bicep
@@ -313,10 +313,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     systemAssignedIdentity: true

--- a/modules/Microsoft.RecoveryServices/vaults/readme.md
+++ b/modules/Microsoft.RecoveryServices/vaults/readme.md
@@ -1186,6 +1186,7 @@ module vaults './Microsoft.RecoveryServices/vaults/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1495,6 +1496,7 @@ module vaults './Microsoft.RecoveryServices/vaults/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Resources/resourceGroups/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Resources/resourceGroups/.test/common/deploy.test.bicep
@@ -43,10 +43,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     tags: {

--- a/modules/Microsoft.Resources/resourceGroups/readme.md
+++ b/modules/Microsoft.Resources/resourceGroups/readme.md
@@ -184,6 +184,7 @@ module resourceGroups './Microsoft.Resources/resourceGroups/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -220,6 +221,7 @@ module resourceGroups './Microsoft.Resources/resourceGroups/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.ServiceBus/namespaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ServiceBus/namespaces/.test/common/deploy.test.bicep
@@ -63,10 +63,11 @@ module testDeployment '../../deploy.bicep' = {
     }
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     networkRuleSets: {
@@ -113,10 +114,11 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>${serviceShort}q001'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         authorizationRules: [
@@ -143,10 +145,11 @@ module testDeployment '../../deploy.bicep' = {
         name: '<<namePrefix>>${serviceShort}t001'
         roleAssignments: [
           {
+            roleDefinitionIdOrName: 'Reader'
             principalIds: [
               resourceGroupResources.outputs.managedIdentityPrincipalId
             ]
-            roleDefinitionIdOrName: 'Reader'
+            principalType: 'ServicePrincipal'
           }
         ]
         authorizationRules: [

--- a/modules/Microsoft.ServiceBus/namespaces/.test/encr/deploy.test.bicep
+++ b/modules/Microsoft.ServiceBus/namespaces/.test/encr/deploy.test.bicep
@@ -50,10 +50,11 @@ module testDeployment '../../deploy.bicep' = {
     skuName: 'Premium'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     networkRuleSets: {

--- a/modules/Microsoft.ServiceBus/namespaces/readme.md
+++ b/modules/Microsoft.ServiceBus/namespaces/readme.md
@@ -441,6 +441,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -451,6 +452,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -484,6 +486,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
             principalIds: [
               '<managedIdentityPrincipalId>'
             ]
+            principalType: 'ServicePrincipal'
             roleDefinitionIdOrName: 'Reader'
           }
         ]
@@ -613,6 +616,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ]
@@ -625,6 +629,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -666,6 +671,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
               "principalIds": [
                 "<managedIdentityPrincipalId>"
               ],
+              "principalType": "ServicePrincipal",
               "roleDefinitionIdOrName": "Reader"
             }
           ]
@@ -744,6 +750,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -831,6 +838,7 @@ module namespaces './Microsoft.ServiceBus/namespaces/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -71,6 +71,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
     vulnerabilityAssessmentsObj: {

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -456,6 +456,7 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -567,6 +568,7 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
@@ -103,6 +103,7 @@ module testDeployment '../../deploy.bicep' = {
               principalIds: [
                 resourceGroupResources.outputs.managedIdentityPrincipalId
               ]
+              principalType: 'ServicePrincipal'
             }
           ]
         }
@@ -131,6 +132,7 @@ module testDeployment '../../deploy.bicep' = {
               principalIds: [
                 resourceGroupResources.outputs.managedIdentityPrincipalId
               ]
+              principalType: 'ServicePrincipal'
             }
           ]
         }
@@ -170,6 +172,7 @@ module testDeployment '../../deploy.bicep' = {
               principalIds: [
                 resourceGroupResources.outputs.managedIdentityPrincipalId
               ]
+              principalType: 'ServicePrincipal'
             }
           ]
         }
@@ -186,10 +189,11 @@ module testDeployment '../../deploy.bicep' = {
     }
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.Storage/storageAccounts/.test/nfs/deploy.test.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/nfs/deploy.test.bicep
@@ -74,10 +74,11 @@ module testDeployment '../../deploy.bicep' = {
     }
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     diagnosticLogsRetentionInDays: 7

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -410,6 +410,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
               principalIds: [
                 '<managedIdentityPrincipalId>'
               ]
+              principalType: 'ServicePrincipal'
               roleDefinitionIdOrName: 'Reader'
             }
           ]
@@ -447,6 +448,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
               principalIds: [
                 '<managedIdentityPrincipalId>'
               ]
+              principalType: 'ServicePrincipal'
               roleDefinitionIdOrName: 'Reader'
             }
           ]
@@ -504,6 +506,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
               principalIds: [
                 '<managedIdentityPrincipalId>'
               ]
+              principalType: 'ServicePrincipal'
               roleDefinitionIdOrName: 'Reader'
             }
           ]
@@ -520,6 +523,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -574,6 +578,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
                 "principalIds": [
                   "<managedIdentityPrincipalId>"
                 ],
+                "principalType": "ServicePrincipal",
                 "roleDefinitionIdOrName": "Reader"
               }
             ]
@@ -623,6 +628,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
                 "principalIds": [
                   "<managedIdentityPrincipalId>"
                 ],
+                "principalType": "ServicePrincipal",
                 "roleDefinitionIdOrName": "Reader"
               }
             ],
@@ -688,6 +694,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
                 "principalIds": [
                   "<managedIdentityPrincipalId>"
                 ],
+                "principalType": "ServicePrincipal",
                 "roleDefinitionIdOrName": "Reader"
               }
             ]
@@ -708,6 +715,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -940,6 +948,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -1008,6 +1017,7 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Synapse/privateLinkHubs/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/privateLinkHubs/.test/common/deploy.test.bicep
@@ -57,10 +57,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
       {
         principalIds: [

--- a/modules/Microsoft.Synapse/privateLinkHubs/readme.md
+++ b/modules/Microsoft.Synapse/privateLinkHubs/readme.md
@@ -275,6 +275,7 @@ module privateLinkHubs './Microsoft.Synapse/privateLinkHubs/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
       {
@@ -327,6 +328,7 @@ module privateLinkHubs './Microsoft.Synapse/privateLinkHubs/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         },
         {

--- a/modules/Microsoft.VirtualMachineImages/imageTemplates/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.VirtualMachineImages/imageTemplates/.test/common/deploy.test.bicep
@@ -77,6 +77,7 @@ module testDeployment '../../deploy.bicep' = {
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
+        principalType: 'ServicePrincipal'
       }
     ]
     sigImageDefinitionId: resourceGroupResources.outputs.sigImageDefinitionId

--- a/modules/Microsoft.VirtualMachineImages/imageTemplates/readme.md
+++ b/modules/Microsoft.VirtualMachineImages/imageTemplates/readme.md
@@ -311,6 +311,7 @@ module imageTemplates './Microsoft.VirtualMachineImages/imageTemplates/deploy.bi
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -381,6 +382,7 @@ module imageTemplates './Microsoft.VirtualMachineImages/imageTemplates/deploy.bi
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Web/connections/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Web/connections/.test/common/deploy.test.bicep
@@ -49,10 +49,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Web/connections/readme.md
+++ b/modules/Microsoft.Web/connections/readme.md
@@ -188,6 +188,7 @@ module connections './Microsoft.Web/connections/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -229,6 +230,7 @@ module connections './Microsoft.Web/connections/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Web/hostingEnvironments/.test/asev2/deploy.test.bicep
+++ b/modules/Microsoft.Web/hostingEnvironments/.test/asev2/deploy.test.bicep
@@ -74,10 +74,11 @@ module testDeployment '../../deploy.bicep' = {
     multiSize: 'Standard_D1_V2'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Web/hostingEnvironments/.test/asev3/deploy.test.bicep
+++ b/modules/Microsoft.Web/hostingEnvironments/.test/asev3/deploy.test.bicep
@@ -72,10 +72,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
   }

--- a/modules/Microsoft.Web/hostingEnvironments/readme.md
+++ b/modules/Microsoft.Web/hostingEnvironments/readme.md
@@ -244,6 +244,7 @@ module hostingEnvironments './Microsoft.Web/hostingEnvironments/deploy.bicep' = 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -309,6 +310,7 @@ module hostingEnvironments './Microsoft.Web/hostingEnvironments/deploy.bicep' = 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -351,6 +353,7 @@ module hostingEnvironments './Microsoft.Web/hostingEnvironments/deploy.bicep' = 
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -410,6 +413,7 @@ module hostingEnvironments './Microsoft.Web/hostingEnvironments/deploy.bicep' = 
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Web/serverfarms/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Web/serverfarms/.test/common/deploy.test.bicep
@@ -70,10 +70,11 @@ module testDeployment '../../deploy.bicep' = {
     lock: 'CanNotDelete'
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     tags: {

--- a/modules/Microsoft.Web/serverfarms/readme.md
+++ b/modules/Microsoft.Web/serverfarms/readme.md
@@ -242,6 +242,7 @@ module serverfarms './Microsoft.Web/serverfarms/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -303,6 +304,7 @@ module serverfarms './Microsoft.Web/serverfarms/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Web/sites/.test/FunctionAppCommon/deploy.test.bicep
+++ b/modules/Microsoft.Web/sites/.test/FunctionAppCommon/deploy.test.bicep
@@ -149,10 +149,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     setAzureWebJobsDashboard: true

--- a/modules/Microsoft.Web/sites/.test/webAppCommon/deploy.test.bicep
+++ b/modules/Microsoft.Web/sites/.test/webAppCommon/deploy.test.bicep
@@ -78,10 +78,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     siteConfig: {

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -521,6 +521,7 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -676,6 +677,7 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]
@@ -801,6 +803,7 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -881,6 +884,7 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]

--- a/modules/Microsoft.Web/staticSites/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Web/staticSites/.test/common/deploy.test.bicep
@@ -60,10 +60,11 @@ module testDeployment '../../deploy.bicep' = {
     ]
     roleAssignments: [
       {
+        roleDefinitionIdOrName: 'Reader'
         principalIds: [
           resourceGroupResources.outputs.managedIdentityPrincipalId
         ]
-        roleDefinitionIdOrName: 'Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     sku: 'Standard'

--- a/modules/Microsoft.Web/staticSites/readme.md
+++ b/modules/Microsoft.Web/staticSites/readme.md
@@ -375,6 +375,7 @@ module staticSites './Microsoft.Web/staticSites/deploy.bicep' = {
         principalIds: [
           '<managedIdentityPrincipalId>'
         ]
+        principalType: 'ServicePrincipal'
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -450,6 +451,7 @@ module staticSites './Microsoft.Web/staticSites/deploy.bicep' = {
           "principalIds": [
             "<managedIdentityPrincipalId>"
           ],
+          "principalType": "ServicePrincipal",
           "roleDefinitionIdOrName": "Reader"
         }
       ]


### PR DESCRIPTION
# Description

- Updated RBAC tests to be more explicit about the principal type (sometimes required to prevent errors if principal propagation isn't fast enough)
- Regenerated docs

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2F2260_rbacUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |
| [![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2F2260_rbacUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
