### PR TITLE
[Modules] Update the API version for Virtual Hubs to latest version

### DIFF
--- a/modules/Microsoft.Network/virtualHubs/deploy.bicep
+++ b/modules/Microsoft.Network/virtualHubs/deploy.bicep
@@ -93,7 +93,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource virtualHub 'Microsoft.Network/virtualHubs@2021-08-01' = {
+resource virtualHub 'Microsoft.Network/virtualHubs@2022-05-01' = {
   name: name
   location: location
   tags: tags

--- a/modules/Microsoft.Network/virtualHubs/hubRouteTables/deploy.bicep
+++ b/modules/Microsoft.Network/virtualHubs/hubRouteTables/deploy.bicep
@@ -25,11 +25,11 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource virtualHub 'Microsoft.Network/virtualHubs@2021-08-01' existing = {
+resource virtualHub 'Microsoft.Network/virtualHubs@2022-05-01' existing = {
   name: virtualHubName
 }
 
-resource hubRouteTable 'Microsoft.Network/virtualHubs/hubRouteTables@2021-08-01' = {
+resource hubRouteTable 'Microsoft.Network/virtualHubs/hubRouteTables@2022-05-01' = {
   name: name
   parent: virtualHub
   properties: {

--- a/modules/Microsoft.Network/virtualHubs/hubRouteTables/readme.md
+++ b/modules/Microsoft.Network/virtualHubs/hubRouteTables/readme.md
@@ -13,7 +13,7 @@ This module deploys virtual hub route tables.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Network/virtualHubs/hubRouteTables` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/virtualHubs/hubRouteTables) |
+| `Microsoft.Network/virtualHubs/hubRouteTables` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/virtualHubs/hubRouteTables) |
 
 ## Parameters
 

--- a/modules/Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/deploy.bicep
+++ b/modules/Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/deploy.bicep
@@ -28,11 +28,11 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource virtualHub 'Microsoft.Network/virtualHubs@2021-08-01' existing = {
+resource virtualHub 'Microsoft.Network/virtualHubs@2022-05-01' existing = {
   name: virtualHubName
 }
 
-resource hubVirtualNetworkConnection 'Microsoft.Network/virtualHubs/hubVirtualNetworkConnections@2021-08-01' = {
+resource hubVirtualNetworkConnection 'Microsoft.Network/virtualHubs/hubVirtualNetworkConnections@2022-05-01' = {
   name: name
   parent: virtualHub
   properties: {

--- a/modules/Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/readme.md
+++ b/modules/Microsoft.Network/virtualHubs/hubVirtualNetworkConnections/readme.md
@@ -13,7 +13,7 @@ This module deploys virtual hub virtual network connections.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/virtualHubs/hubVirtualNetworkConnections) |
+| `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/virtualHubs/hubVirtualNetworkConnections) |
 
 ## Parameters
 

--- a/modules/Microsoft.Network/virtualHubs/readme.md
+++ b/modules/Microsoft.Network/virtualHubs/readme.md
@@ -15,9 +15,9 @@ This module deploys a Virtual Hub.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
-| `Microsoft.Network/virtualHubs` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/virtualHubs) |
-| `Microsoft.Network/virtualHubs/hubRouteTables` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/virtualHubs/hubRouteTables) |
-| `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections` | [2021-08-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2021-08-01/virtualHubs/hubVirtualNetworkConnections) |
+| `Microsoft.Network/virtualHubs` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/virtualHubs) |
+| `Microsoft.Network/virtualHubs/hubRouteTables` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/virtualHubs/hubRouteTables) |
+| `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/virtualHubs/hubVirtualNetworkConnections) |
 
 ## Parameters
 


### PR DESCRIPTION
Based on #2253 
---

change the API version from 2021-08-01 to 2022-05-01 because when we want add the virtualRouterAsn we are getting the following error:

```
"CustomAsnNotSupportedByVirtualHub\\\",\\r\\n    \\\"message\\\": \\\"To modify router ASN in virtual hub, please use API version 2022-01-01 and beyond
```

# Description

>Thank you for your contribution !

> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network: VirtualHubs](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualhubs.yml/badge.svg?branch=users%2Faavdberg%2F2253_apiUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualhubs.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
