### PR TITLE
[Utilities] Updated the deployment name generation to be more detailed

### DIFF
--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -210,7 +210,7 @@ function New-DeploymentWithParameterFile {
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
             do {
-                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])-#$retryCount"
+                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])-t$retryCount"
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -210,7 +210,7 @@ function New-DeploymentWithParameterFile {
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
             do {
-                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format yyyyMMddTHHMMssffffZ)[0..63])-#$retryCount"
+                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])-#$retryCount"
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -216,7 +216,7 @@ function New-DeploymentWithParameterFile {
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
             do {
-                $deploymentName = ('{0}-{1}-t{2}' -f $deploymentNamePrefix, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'), $retryCount)[0..63] -join ''
+                $deploymentName = ('{0}-t{2}-{1}' -f $deploymentNamePrefix, $retryCount, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'))[0..63] -join ''
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -216,7 +216,7 @@ function New-DeploymentWithParameterFile {
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
             do {
-                $deploymentName = ('{0}-t{2}-{1}' -f $deploymentNamePrefix, $retryCount, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'))[0..63] -join ''
+                $deploymentName = ('{0}-t{1}-{2}' -f $deploymentNamePrefix, $retryCount, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'))[0..63] -join ''
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose

--- a/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/New-TemplateDeployment.ps1
@@ -210,7 +210,7 @@ function New-DeploymentWithParameterFile {
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
             do {
-                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..63])-t$retryCount"
+                $deploymentName = "$deploymentNamePrefix-$(-join (Get-Date -Format 'yyyyMMddTHHMMssffffZ')[0..60])-t$retryCount"
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose


### PR DESCRIPTION
# Description

- Adjusted the deployment name logic to regenerate it each time a retry takes place (added with a `t#` in the end)
- Also incorporated the module's name in case the template's file path allows it

Examples

- Analysis Servies
  ![image](https://user-images.githubusercontent.com/5365358/200069137-f4e46bd8-7e0d-43ef-9361-2f220a57b123.png)
- Key Vault
  ```
  VERBOSE: Deploying with deployment name [KeyVault-vaults-min-20221104T2011351293Z-t1]
  VERBOSE: Deploying with deployment name [KeyVault-vaults-min-20221104T2011411996Z-t2]
  VERBOSE: Deploying with deployment name [KeyVault-vaults-min-20221104T2011437597Z-t3]
  ```

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2F2276_deploymentName&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |
| [![KeyVault: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Falsehr%2F2276_deploymentName)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml) (unrelated failing pipeline) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
