### PR TITLE
[Module] Lighthouse - fix group object IDs

### DIFF
--- a/modules/Microsoft.ManagedServices/registrationDefinitions/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/.test/common/deploy.test.bicep
@@ -21,7 +21,7 @@ module testDeployment '../../deploy.bicep' = {
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
       {
-        principalId: 'e2f126a7-136e-443f-b39f-f73ddfd146b1'
+        principalId: '9bce07dd-ae3a-4062-a24d-33631a4b35e8'
         principalIdDisplayName: 'ResourceModules-Contributor'
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }

--- a/modules/Microsoft.ManagedServices/registrationDefinitions/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/.test/common/deploy.test.bicep
@@ -16,7 +16,7 @@ module testDeployment '../../deploy.bicep' = {
     name: 'Component Validation - <<namePrefix>>${serviceShort} Subscription assignment'
     authorizations: [
       {
-        principalId: 'e87a249c-b53b-4685-94fe-863af522e4ee'
+        principalId: '9740a11d-a508-4a83-8ed5-4cb5bff5154a'
         principalIdDisplayName: 'ResourceModules-Reader'
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
@@ -26,7 +26,7 @@ module testDeployment '../../deploy.bicep' = {
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }
       {
-        principalId: '87813317-fb25-4c76-91fe-783af429d109'
+        principalId: '441519e3-00e5-4070-8ec8-4b8cddf6409a'
         principalIdDisplayName: 'ResourceModules-LHManagement'
         roleDefinitionId: '91c1777a-f3dc-4fae-b103-61d183457e46'
       }

--- a/modules/Microsoft.ManagedServices/registrationDefinitions/.test/rg/deploy.test.bicep
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/.test/rg/deploy.test.bicep
@@ -39,7 +39,7 @@ module testDeployment '../../deploy.bicep' = {
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
       {
-        principalId: 'e2f126a7-136e-443f-b39f-f73ddfd146b1'
+        principalId: '9bce07dd-ae3a-4062-a24d-33631a4b35e8'
         principalIdDisplayName: 'ResourceModules-Contributor'
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }

--- a/modules/Microsoft.ManagedServices/registrationDefinitions/.test/rg/deploy.test.bicep
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/.test/rg/deploy.test.bicep
@@ -34,7 +34,7 @@ module testDeployment '../../deploy.bicep' = {
     name: 'Component Validation - <<namePrefix>>${serviceShort} Resource group assignment'
     authorizations: [
       {
-        principalId: 'e87a249c-b53b-4685-94fe-863af522e4ee'
+        principalId: '9740a11d-a508-4a83-8ed5-4cb5bff5154a'
         principalIdDisplayName: 'ResourceModules-Reader'
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
@@ -44,7 +44,7 @@ module testDeployment '../../deploy.bicep' = {
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }
       {
-        principalId: '87813317-fb25-4c76-91fe-783af429d109'
+        principalId: '441519e3-00e5-4070-8ec8-4b8cddf6409a'
         principalIdDisplayName: 'ResourceModules-LHManagement'
         roleDefinitionId: '91c1777a-f3dc-4fae-b103-61d183457e46'
       }

--- a/modules/Microsoft.ManagedServices/registrationDefinitions/readme.md
+++ b/modules/Microsoft.ManagedServices/registrationDefinitions/readme.md
@@ -190,17 +190,17 @@ module registrationDefinitions './Microsoft.ManagedServices/registrationDefiniti
     // Required parameters
     authorizations: [
       {
-        principalId: 'e87a249c-b53b-4685-94fe-863af522e4ee'
+        principalId: '9740a11d-a508-4a83-8ed5-4cb5bff5154a'
         principalIdDisplayName: 'ResourceModules-Reader'
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
       {
-        principalId: 'e2f126a7-136e-443f-b39f-f73ddfd146b1'
+        principalId: '9bce07dd-ae3a-4062-a24d-33631a4b35e8'
         principalIdDisplayName: 'ResourceModules-Contributor'
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }
       {
-        principalId: '87813317-fb25-4c76-91fe-783af429d109'
+        principalId: '441519e3-00e5-4070-8ec8-4b8cddf6409a'
         principalIdDisplayName: 'ResourceModules-LHManagement'
         roleDefinitionId: '91c1777a-f3dc-4fae-b103-61d183457e46'
       }
@@ -228,17 +228,17 @@ module registrationDefinitions './Microsoft.ManagedServices/registrationDefiniti
     "authorizations": {
       "value": [
         {
-          "principalId": "e87a249c-b53b-4685-94fe-863af522e4ee",
+          "principalId": "9740a11d-a508-4a83-8ed5-4cb5bff5154a",
           "principalIdDisplayName": "ResourceModules-Reader",
           "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
         },
         {
-          "principalId": "e2f126a7-136e-443f-b39f-f73ddfd146b1",
+          "principalId": "9bce07dd-ae3a-4062-a24d-33631a4b35e8",
           "principalIdDisplayName": "ResourceModules-Contributor",
           "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
         },
         {
-          "principalId": "87813317-fb25-4c76-91fe-783af429d109",
+          "principalId": "441519e3-00e5-4070-8ec8-4b8cddf6409a",
           "principalIdDisplayName": "ResourceModules-LHManagement",
           "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46"
         }
@@ -273,17 +273,17 @@ module registrationDefinitions './Microsoft.ManagedServices/registrationDefiniti
     // Required parameters
     authorizations: [
       {
-        principalId: 'e87a249c-b53b-4685-94fe-863af522e4ee'
+        principalId: '9740a11d-a508-4a83-8ed5-4cb5bff5154a'
         principalIdDisplayName: 'ResourceModules-Reader'
         roleDefinitionId: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
       }
       {
-        principalId: 'e2f126a7-136e-443f-b39f-f73ddfd146b1'
+        principalId: '9bce07dd-ae3a-4062-a24d-33631a4b35e8'
         principalIdDisplayName: 'ResourceModules-Contributor'
         roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
       }
       {
-        principalId: '87813317-fb25-4c76-91fe-783af429d109'
+        principalId: '441519e3-00e5-4070-8ec8-4b8cddf6409a'
         principalIdDisplayName: 'ResourceModules-LHManagement'
         roleDefinitionId: '91c1777a-f3dc-4fae-b103-61d183457e46'
       }
@@ -313,17 +313,17 @@ module registrationDefinitions './Microsoft.ManagedServices/registrationDefiniti
     "authorizations": {
       "value": [
         {
-          "principalId": "e87a249c-b53b-4685-94fe-863af522e4ee",
+          "principalId": "9740a11d-a508-4a83-8ed5-4cb5bff5154a",
           "principalIdDisplayName": "ResourceModules-Reader",
           "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
         },
         {
-          "principalId": "e2f126a7-136e-443f-b39f-f73ddfd146b1",
+          "principalId": "9bce07dd-ae3a-4062-a24d-33631a4b35e8",
           "principalIdDisplayName": "ResourceModules-Contributor",
           "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
         },
         {
-          "principalId": "87813317-fb25-4c76-91fe-783af429d109",
+          "principalId": "441519e3-00e5-4070-8ec8-4b8cddf6409a",
           "principalIdDisplayName": "ResourceModules-LHManagement",
           "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46"
         }


### PR DESCRIPTION
# Description

Due to some group cleanup in the target tenant, recreating groups for testing and validation purposes.

## Pipeline references

| Pipeline |
| - |
| [![ManagedServices: RegistrationDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedservices.registrationdefinitions.yml/badge.svg?branch=users%2Fmast%2F2279)](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedservices.registrationdefinitions.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
