### PR TITLE
[CI environment] Replace `set-output` commands with GH environment file `$env:GITHUB_OUTPUT`

### DIFF
--- a/.github/actions/templates/getModuleTestFiles/action.yml
+++ b/.github/actions/templates/getModuleTestFiles/action.yml
@@ -39,5 +39,6 @@ runs:
           $compressedOutput = "[$compressedOutput]"
         }
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
-        Write-Output "::set-output name=moduleTestFilePaths::$compressedOutput"
+        # Write-Output "::set-output name=moduleTestFilePaths::$compressedOutput"
+        echo "moduleTestFilePaths=$compressedOutput" >> $env:GITHUB_OUTPUT
         Write-Output '::endgroup::'

--- a/.github/actions/templates/getModuleTestFiles/action.yml
+++ b/.github/actions/templates/getModuleTestFiles/action.yml
@@ -39,6 +39,5 @@ runs:
           $compressedOutput = "[$compressedOutput]"
         }
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
-        # echo "moduleTestFilePaths=$compressedOutput" >> $env:GITHUB_OUTPUT
         Write-Output ('{0}={1}' -f 'moduleTestFilePaths', $compressedOutput) >> $env:GITHUB_OUTPUT
         Write-Output '::endgroup::'

--- a/.github/actions/templates/getModuleTestFiles/action.yml
+++ b/.github/actions/templates/getModuleTestFiles/action.yml
@@ -39,5 +39,6 @@ runs:
           $compressedOutput = "[$compressedOutput]"
         }
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
-        echo "moduleTestFilePaths=$compressedOutput" >> $env:GITHUB_OUTPUT
+        # echo "moduleTestFilePaths=$compressedOutput" >> $env:GITHUB_OUTPUT
+        Write-Output ('{0}={1}' -f 'moduleTestFilePaths', $compressedOutput) >> $env:GITHUB_OUTPUT
         Write-Output '::endgroup::'

--- a/.github/actions/templates/getModuleTestFiles/action.yml
+++ b/.github/actions/templates/getModuleTestFiles/action.yml
@@ -39,6 +39,5 @@ runs:
           $compressedOutput = "[$compressedOutput]"
         }
         Write-Verbose "Publishing output: $compressedOutput" -Verbose
-        # Write-Output "::set-output name=moduleTestFilePaths::$compressedOutput"
         echo "moduleTestFilePaths=$compressedOutput" >> $env:GITHUB_OUTPUT
         Write-Output '::endgroup::'

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -80,7 +80,8 @@ runs:
         }
 
         # Output values to be accessed by next jobs
-        echo "removeDeployment=$removeDeployment" >> $env:GITHUB_OUTPUT
+        # echo "removeDeployment=$removeDeployment" >> $env:GITHUB_OUTPUT
+        Write-Output ('{0}={1}' -f 'removeDeployment', $removeDeployment) >> $env:GITHUB_OUTPUT
 
         Write-Output '::endgroup::'
       shell: pwsh

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -80,7 +80,8 @@ runs:
         }
 
         # Output values to be accessed by next jobs
-        Write-Output "::set-output name=removeDeployment::$removeDeployment"
+        # Write-Output "::set-output name=removeDeployment::$removeDeployment"
+        echo "removeDeployment=$removeDeployment" >> $env:GITHUB_OUTPUT
 
         Write-Output '::endgroup::'
       shell: pwsh

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -80,7 +80,6 @@ runs:
         }
 
         # Output values to be accessed by next jobs
-        # echo "removeDeployment=$removeDeployment" >> $env:GITHUB_OUTPUT
         Write-Output ('{0}={1}' -f 'removeDeployment', $removeDeployment) >> $env:GITHUB_OUTPUT
 
         Write-Output '::endgroup::'

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -80,7 +80,6 @@ runs:
         }
 
         # Output values to be accessed by next jobs
-        # Write-Output "::set-output name=removeDeployment::$removeDeployment"
         echo "removeDeployment=$removeDeployment" >> $env:GITHUB_OUTPUT
 
         Write-Output '::endgroup::'

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -345,21 +345,18 @@ runs:
           $res = New-TemplateDeployment @functionInput -Verbose
 
           # Get deployment name
-          # echo "deploymentName=$($res.deploymentName)" >> $env:GITHUB_OUTPUT
           Write-Output ('{0}={1}' -f 'deploymentName', $res.deploymentName) >> $env:GITHUB_OUTPUT
 
           # Populate further outputs
           $deploymentOutputHash = @{}
 
           foreach ($outputKey in $res.deploymentOutput.Keys) {
-            # echo "outputKey=$($res.deploymentOutput[$outputKey].Value)" >> $env:GITHUB_OUTPUT
             Write-Output ('{0}={1}' -f 'outputKey', $res.deploymentOutput[$outputKey].Value) >> $env:GITHUB_OUTPUT
             $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
           }
 
           $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
           Write-Verbose "Deployment output: $deploymentOutput" -Verbose
-          # echo "deploymentOutput=$deploymentOutput" >> $env:GITHUB_OUTPUT
           Write-Output ('{0}={1}' -f 'deploymentOutput', $deploymentOutput) >> $env:GITHUB_OUTPUT
 
           if ($res.ContainsKey('exception')) {

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -345,21 +345,18 @@ runs:
           $res = New-TemplateDeployment @functionInput -Verbose
 
           # Get deployment name
-          # Write-Output ('::set-output name={0}::{1}' -f 'deploymentName', $res.deploymentName)
           echo "deploymentName=$res.deploymentName" >> $env:GITHUB_OUTPUT
 
           # Populate further outputs
           $deploymentOutputHash = @{}
 
           foreach ($outputKey in $res.deploymentOutput.Keys) {
-            # Write-Output ('::set-output name={0}::{1}' -f $outputKey, $res.deploymentOutput[$outputKey].Value)
             echo "outputKey=$res.deploymentOutput[$outputKey].Value" >> $env:GITHUB_OUTPUT
             $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
           }
 
           $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
           Write-Verbose "Deployment output: $deploymentOutput" -Verbose
-          # Write-Output ('::set-output name={0}::{1}' -f 'deploymentOutput', $deploymentOutput)
           echo "deploymentOutput=$deploymentOutput" >> $env:GITHUB_OUTPUT
 
           if ($res.ContainsKey('exception')) {

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -345,19 +345,22 @@ runs:
           $res = New-TemplateDeployment @functionInput -Verbose
 
           # Get deployment name
-          Write-Output ('::set-output name={0}::{1}' -f 'deploymentName', $res.deploymentName)
+          # Write-Output ('::set-output name={0}::{1}' -f 'deploymentName', $res.deploymentName)
+          echo "deploymentName=$res.deploymentName" >> $env:GITHUB_OUTPUT
 
           # Populate further outputs
           $deploymentOutputHash = @{}
 
           foreach ($outputKey in $res.deploymentOutput.Keys) {
-            Write-Output ('::set-output name={0}::{1}' -f $outputKey, $res.deploymentOutput[$outputKey].Value)
+            # Write-Output ('::set-output name={0}::{1}' -f $outputKey, $res.deploymentOutput[$outputKey].Value)
+            echo "outputKey=$res.deploymentOutput[$outputKey].Value" >> $env:GITHUB_OUTPUT
             $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
           }
 
           $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
           Write-Verbose "Deployment output: $deploymentOutput" -Verbose
-          Write-Output ('::set-output name={0}::{1}' -f 'deploymentOutput', $deploymentOutput)
+          # Write-Output ('::set-output name={0}::{1}' -f 'deploymentOutput', $deploymentOutput)
+          echo "deploymentOutput=$deploymentOutput" >> $env:GITHUB_OUTPUT
 
           if ($res.ContainsKey('exception')) {
             # Happens only if there is an exception

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -345,19 +345,22 @@ runs:
           $res = New-TemplateDeployment @functionInput -Verbose
 
           # Get deployment name
-          echo "deploymentName=$($res.deploymentName)" >> $env:GITHUB_OUTPUT
+          # echo "deploymentName=$($res.deploymentName)" >> $env:GITHUB_OUTPUT
+          Write-Output ('{0}={1}' -f 'deploymentName', $res.deploymentName) >> $env:GITHUB_OUTPUT
 
           # Populate further outputs
           $deploymentOutputHash = @{}
 
           foreach ($outputKey in $res.deploymentOutput.Keys) {
-            echo "outputKey=$($res.deploymentOutput[$outputKey].Value)" >> $env:GITHUB_OUTPUT
+            # echo "outputKey=$($res.deploymentOutput[$outputKey].Value)" >> $env:GITHUB_OUTPUT
+            Write-Output ('{0}={1}' -f 'outputKey', $res.deploymentOutput[$outputKey].Value) >> $env:GITHUB_OUTPUT
             $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
           }
 
           $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
           Write-Verbose "Deployment output: $deploymentOutput" -Verbose
-          echo "deploymentOutput=$deploymentOutput" >> $env:GITHUB_OUTPUT
+          # echo "deploymentOutput=$deploymentOutput" >> $env:GITHUB_OUTPUT
+          Write-Output ('{0}={1}' -f 'deploymentOutput', $deploymentOutput) >> $env:GITHUB_OUTPUT
 
           if ($res.ContainsKey('exception')) {
             # Happens only if there is an exception

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -345,13 +345,13 @@ runs:
           $res = New-TemplateDeployment @functionInput -Verbose
 
           # Get deployment name
-          echo "deploymentName=$res.deploymentName" >> $env:GITHUB_OUTPUT
+          echo "deploymentName=$($res.deploymentName)" >> $env:GITHUB_OUTPUT
 
           # Populate further outputs
           $deploymentOutputHash = @{}
 
           foreach ($outputKey in $res.deploymentOutput.Keys) {
-            echo "outputKey=$res.deploymentOutput[$outputKey].Value" >> $env:GITHUB_OUTPUT
+            echo "outputKey=$($res.deploymentOutput[$outputKey].Value)" >> $env:GITHUB_OUTPUT
             $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
           }
 

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -118,7 +118,8 @@ runs:
         $outputPathFile = 'testResults.xml'
         $outputPath = Join-Path $outputPathDirectory $outputPathFile
         Write-Verbose "Pester tests output: $outputPath" -Verbose
-        echo "outputPath=$outputPath" >> $env:GITHUB_OUTPUT
+        # echo "outputPath=$outputPath" >> $env:GITHUB_OUTPUT
+        Write-Output ('{0}={1}' -f 'outputPath', $outputPath) >> $env:GITHUB_OUTPUT
 
         # --------------------- #
         # Invoke Pester test(s) #

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -118,7 +118,6 @@ runs:
         $outputPathFile = 'testResults.xml'
         $outputPath = Join-Path $outputPathDirectory $outputPathFile
         Write-Verbose "Pester tests output: $outputPath" -Verbose
-        # echo "outputPath=$outputPath" >> $env:GITHUB_OUTPUT
         Write-Output ('{0}={1}' -f 'outputPath', $outputPath) >> $env:GITHUB_OUTPUT
 
         # --------------------- #

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -118,7 +118,8 @@ runs:
         $outputPathFile = 'testResults.xml'
         $outputPath = Join-Path $outputPathDirectory $outputPathFile
         Write-Verbose "Pester tests output: $outputPath" -Verbose
-        Write-Output ('::set-output name={0}::{1}' -f 'outputPath', $outputPath)
+        # Write-Output ('::set-output name={0}::{1}' -f 'outputPath', $outputPath)
+        echo "outputPath=$outputPath" >> $env:GITHUB_OUTPUT
 
         # --------------------- #
         # Invoke Pester test(s) #

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -118,7 +118,6 @@ runs:
         $outputPathFile = 'testResults.xml'
         $outputPath = Join-Path $outputPathDirectory $outputPathFile
         Write-Verbose "Pester tests output: $outputPath" -Verbose
-        # Write-Output ('::set-output name={0}::{1}' -f 'outputPath', $outputPath)
         echo "outputPath=$outputPath" >> $env:GITHUB_OUTPUT
 
         # --------------------- #


### PR DESCRIPTION
# Description

Following examples [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows) and specifically [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions?tool=powershell#setting-an-output-parameter) for PowerShell workflow commands

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Ferikag%2F2211-env-files)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |
| [![DesktopVirtualization: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml/badge.svg?branch=users%2Ferikag%2F2211-env-files)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
