### PR TITLE
[Fixes] missing kind property for microsoft web site module

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,5 @@
 https://foo.psd1/
+https://sts.windows.net/
 https://teststringforvalidation.com/
 http://localhost/
 https://mystorageaccount.blob.core.windows.net

--- a/modules/Microsoft.Web/sites/config-appsettings/deploy.bicep
+++ b/modules/Microsoft.Web/sites/config-appsettings/deploy.bicep
@@ -6,9 +6,11 @@ param appName string
 
 @description('Required. Type of site to deploy.')
 @allowed([
-  'functionapp'
-  'functionapp,linux'
-  'app'
+  'functionapp' // function app windows os
+  'functionapp,linux' // function app linux os
+  'functionapp,workflowapp' // logic app workflow
+  'functionapp,workflowapp,linux' // logic app docker container
+  'app' // normal web app
 ])
 param kind string
 

--- a/modules/Microsoft.Web/sites/config-appsettings/readme.md
+++ b/modules/Microsoft.Web/sites/config-appsettings/readme.md
@@ -21,7 +21,7 @@ This module deploys the app settings.
 
 | Parameter Name | Type | Allowed Values | Description |
 | :-- | :-- | :-- | :-- |
-| `kind` | string | `[app, functionapp, functionapp,linux]` | Type of site to deploy. |
+| `kind` | string | `[app, functionapp, functionapp,linux, functionapp,workflowapp, functionapp,workflowapp,linux]` | Type of site to deploy. |
 
 **Conditional parameters**
 

--- a/modules/Microsoft.Web/sites/config-authsettingsv2/deploy.bicep
+++ b/modules/Microsoft.Web/sites/config-authsettingsv2/deploy.bicep
@@ -6,9 +6,11 @@ param appName string
 
 @description('Required. Type of site to deploy.')
 @allowed([
-  'functionapp'
-  'functionapp,linux'
-  'app'
+  'functionapp' // function app windows os
+  'functionapp,linux' // function app linux os
+  'functionapp,workflowapp' // logic app workflow
+  'functionapp,workflowapp,linux' // logic app docker container
+  'app' // normal web app
 ])
 param kind string
 

--- a/modules/Microsoft.Web/sites/config-authsettingsv2/readme.md
+++ b/modules/Microsoft.Web/sites/config-authsettingsv2/readme.md
@@ -22,7 +22,7 @@ This module deploys the auth settings v2.
 | Parameter Name | Type | Allowed Values | Description |
 | :-- | :-- | :-- | :-- |
 | `authSettingV2Configuration` | object |  | The auth settings V2 configuration. |
-| `kind` | string | `[app, functionapp, functionapp,linux]` | Type of site to deploy. |
+| `kind` | string | `[app, functionapp, functionapp,linux, functionapp,workflowapp, functionapp,workflowapp,linux]` | Type of site to deploy. |
 
 **Conditional parameters**
 

--- a/modules/Microsoft.Web/sites/deploy.bicep
+++ b/modules/Microsoft.Web/sites/deploy.bicep
@@ -10,9 +10,11 @@ param location string = resourceGroup().location
 
 @description('Required. Type of site to deploy.')
 @allowed([
-  'functionapp'
-  'functionapp,linux'
-  'app'
+  'functionapp' // function app windows os
+  'functionapp,linux' // function app linux os
+  'functionapp,workflowapp' // logic app workflow
+  'functionapp,workflowapp,linux' // logic app docker container
+  'app' // normal web app
 ])
 param kind string
 

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -14,7 +14,7 @@ This module deploys a web or function app.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
+| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/privateEndpoints` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/privateEndpoints) |
@@ -28,7 +28,7 @@ This module deploys a web or function app.
 
 | Parameter Name | Type | Allowed Values | Description |
 | :-- | :-- | :-- | :-- |
-| `kind` | string | `[app, functionapp, functionapp,linux]` | Type of site to deploy. |
+| `kind` | string | `[app, functionapp, functionapp,linux, functionapp,workflowapp, functionapp,workflowapp,linux]` | Type of site to deploy. |
 | `name` | string |  | Name of the site. |
 | `serverFarmResourceId` | string |  | The resource ID of the app service plan to use for the site. |
 


### PR DESCRIPTION
# Description

- Updated the kind property of the Microsoft.Web/sites module to also include options to deploy a logic app.
- Fixed broken link checker by adding the sts.microsoft.com URL as an exception as its part of the code and not to be checked by the linter.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

## Pipeline
[![Web: Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg?branch=users%2Ffblix%2F2304-missing-kind-property-for-microsoft-web-site-module)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml)


# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
