### PR TITLE
[Utilities] Aligned deployment name generation of `Test-TemplateDeployment` & `New-TemplateDeployment`

### DIFF
--- a/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
@@ -107,7 +107,7 @@ function Test-TemplateDeployment {
             $providerNamespaceShort = ($providerNamespace -creplace '[^A-Z]').ToLower() # e.g., ac
 
             $resourceType = $shortPathElem[1] # e.g., configurationStores
-            $resourceTypeShort = ('{0}{1}' -f ($resourceType.ToLower())[0..2], ($resourceType -creplace '[^A-Z]')).ToLower() # e.g. cs
+            $resourceTypeShort = ('{0}{1}' -f ($resourceType.ToLower())[0], ($resourceType -creplace '[^A-Z]')).ToLower() # e.g. cs
 
             $testFolderShort = Split-Path (Split-Path $templateFilePath -Parent) -Leaf  # e.g., common
 

--- a/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
@@ -122,9 +122,9 @@ function Test-TemplateDeployment {
         Write-Verbose "Testing with deployment name [$deploymentName]" -Verbose
         $DeploymentInputs['DeploymentName'] = $deploymentName
 
-        #######################
-        ## INVOKE DEPLOYMENT ##
-        #######################
+        #################
+        ## INVOKE TEST ##
+        #################
         switch ($deploymentScope) {
             'resourceGroup' {
                 if (-not [String]::IsNullOrEmpty($subscriptionId)) {


### PR DESCRIPTION
# Description

- Aligned deployment name generation of `Test-TemplateDeployment` & `New-TemplateDeployment`
- For example: `c-g-common-20221111T1211149371Z`

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Falsehr%2FtestTemplateDeploymentName)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
