### PR TITLE
[Modules] Update AKS Orchestrator version when upgrade.

### DIFF
--- a/modules/Microsoft.ContainerService/managedClusters/.test/azure/dependencies.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/azure/dependencies.bicep
@@ -59,7 +59,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
             name: 'standard'
         }
         tenantId: tenant().tenantId
-        enablePurgeProtection: null
+        enablePurgeProtection: true // Required by nodepool vmss
+        softDeleteRetentionInDays: 7
         enabledForTemplateDeployment: true
         enabledForDiskEncryption: true
         enabledForDeployment: true

--- a/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
@@ -13,6 +13,9 @@ param location string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'csmazure'
 
+@description('Generated. Used as a basis for unique resource names.')
+param baseTime string = utcNow('u')
+
 // =========== //
 // Deployments //
 // =========== //
@@ -31,7 +34,8 @@ module resourceGroupResources 'dependencies.bicep' = {
     virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
     managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
     diskEncryptionSetName: 'dep-<<namePrefix>>-des-${serviceShort}'
-    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}'
+    // Adding base time to make the name unique as purge protection must be enabled (but may not be longer than 24 characters total)
+    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
   }
 }
 

--- a/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
@@ -11,7 +11,7 @@ param resourceGroupName string = 'ms.containerservice.managedclusters-${serviceS
 param location string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'csmazure'
+param serviceShort string = 'csmaz'
 
 @description('Generated. Used as a basis for unique resource names.')
 param baseTime string = utcNow('u')

--- a/modules/Microsoft.ContainerService/managedClusters/agentPools/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/agentPools/deploy.bicep
@@ -187,11 +187,11 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-07-01' existing = {
+resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' existing = {
   name: managedClusterName
 }
 
-resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2022-07-01' = {
+resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2022-09-01' = {
   name: name
   parent: managedCluster
   properties: {

--- a/modules/Microsoft.ContainerService/managedClusters/agentPools/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/agentPools/readme.md
@@ -13,7 +13,7 @@ This module deploys an Agent Pool for a Container Service Managed Cluster
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.ContainerService/managedClusters/agentPools` | [2022-07-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-07-01/managedClusters/agentPools) |
+| `Microsoft.ContainerService/managedClusters/agentPools` | [2022-09-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-09-01/managedClusters/agentPools) |
 
 ## Parameters
 

--- a/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -384,7 +384,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-07-01' = {
+resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' = {
   name: name
   location: location
   tags: tags
@@ -465,7 +465,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-07-01' 
     }
     autoScalerProfile: {
       'balance-similar-node-groups': autoScalerProfileBalanceSimilarNodeGroups
-      'expander': autoScalerProfileExpander
+      expander: autoScalerProfileExpander
       'max-empty-bulk-delete': autoScalerProfileMaxEmptyBulkDelete
       'max-graceful-termination-sec': autoScalerProfileMaxGracefulTerminationSec
       'max-node-provision-time': autoScalerProfileMaxNodeProvisionTime
@@ -526,7 +526,7 @@ module managedCluster_agentPools 'agentPools/deploy.bicep' = [for (agentPool, in
     nodeLabels: contains(agentPool, 'nodeLabels') ? agentPool.nodeLabels : {}
     nodePublicIpPrefixId: contains(agentPool, 'nodePublicIpPrefixId') ? agentPool.nodePublicIpPrefixId : ''
     nodeTaints: contains(agentPool, 'nodeTaints') ? agentPool.nodeTaints : []
-    orchestratorVersion: contains(agentPool, 'orchestratorVersion') ? agentPool.orchestratorVersion : ''
+    orchestratorVersion: contains(agentPool, 'orchestratorVersion') ? agentPool.orchestratorVersion : aksClusterKubernetesVersion
     osDiskSizeGB: contains(agentPool, 'osDiskSizeGB') ? agentPool.osDiskSizeGB : -1
     osDiskType: contains(agentPool, 'osDiskType') ? agentPool.osDiskType : ''
     osSku: contains(agentPool, 'osSku') ? agentPool.osSku : ''

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -16,8 +16,8 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.ContainerService/managedClusters` | [2022-07-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-07-01/managedClusters) |
-| `Microsoft.ContainerService/managedClusters/agentPools` | [2022-07-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-07-01/managedClusters/agentPools) |
+| `Microsoft.ContainerService/managedClusters` | [2022-09-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-09-01/managedClusters) |
+| `Microsoft.ContainerService/managedClusters/agentPools` | [2022-09-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2022-09-01/managedClusters/agentPools) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 
 ## Parameters

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -381,10 +381,10 @@ The following module usage examples are retrieved from the content of the files 
 
 ```bicep
 module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bicep' = {
-  name: '${uniqueString(deployment().name)}-test-csmazure'
+  name: '${uniqueString(deployment().name)}-test-csmaz'
   params: {
     // Required parameters
-    name: '<<namePrefix>>csmazure001'
+    name: '<<namePrefix>>csmaz001'
     primaryAgentPoolProfile: [
       {
         availabilityZones: [
@@ -494,7 +494,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
   "parameters": {
     // Required parameters
     "name": {
-      "value": "<<namePrefix>>csmazure001"
+      "value": "<<namePrefix>>csmaz001"
     },
     "primaryAgentPoolProfile": {
       "value": [


### PR DESCRIPTION
# Description

### Problem:
When the AKS is deployed with a default or spezific Version and then redeploy with a newer Version,
the module updates only the Kubernetes control plane not the node pools.
<img width="401" alt="Screenshot 2022-11-11 113257" src="https://user-images.githubusercontent.com/30857628/201350946-eca3583e-3e14-47c5-b9e9-5a47ce6e0fd6.png">
As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version.

### Solution:
The Operational version will be set to the Kubernetes version if it's set in parameters.
- Update API version

## Pipeline references

| Pipeline |
| - |
| [![ContainerService: ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Fjpeasier%2FFixUpdateKubernetesVersionOnNodePool)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
