### PR TITLE
[CI environment] Update static validation version to v2

### DIFF
--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -142,7 +142,7 @@ runs:
         }
 
     - name: 'Publish Test Results'
-      uses: EnricoMi/publish-unit-test-result-action@v1
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         files: '${{ steps.pester_run_step.outputs.outputPath }}'

--- a/.github/actions/templates/validateModulePester/action.yml
+++ b/.github/actions/templates/validateModulePester/action.yml
@@ -145,4 +145,4 @@ runs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
-        files: '${{ steps.pester_run_step.outputs.outputPath }}'
+        junit_files: '${{ steps.pester_run_step.outputs.outputPath }}'

--- a/.github/workflows/platform.convertToArmTemplate.tests.yml
+++ b/.github/workflows/platform.convertToArmTemplate.tests.yml
@@ -45,7 +45,7 @@ jobs:
             }
           }
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: 'utilities/tools/tests/conversion-testResults-${{ matrix.tags }}.xml'

--- a/.github/workflows/platform.convertToArmTemplate.tests.yml
+++ b/.github/workflows/platform.convertToArmTemplate.tests.yml
@@ -48,4 +48,4 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: 'utilities/tools/tests/conversion-testResults-${{ matrix.tags }}.xml'
+          junit_files: 'utilities/tools/tests/conversion-testResults-${{ matrix.tags }}.xml'


### PR DESCRIPTION
# Description

Update to https://github.com/EnricoMi/publish-unit-test-result-action latest (v2)
Solves remaining `set-output` warning (ref issue #2211) still used by v1

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![DesktopVirtualization: HostPools](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml/badge.svg?branch=users%2Ferikag%2Fset-output-ext)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
