### PR TITLE
[Utiltities] Updated `Set-ModuleReadMe` script to work with latest PowerShell version

### DIFF
--- a/modules/Microsoft.Web/connections/readme.md
+++ b/modules/Microsoft.Web/connections/readme.md
@@ -16,7 +16,7 @@ This module deploys an Azure API connection.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Web/connections` | [2016-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Web/2016-06-01/connections) |
+| `Microsoft.Web/connections` | [2016-06-01](https://docs.microsoft.com/en-us/azure/templates) |
 
 ## Parameters
 

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -660,13 +660,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
-          "service": "sites",
-          "subnetResourceId": "<subnetResourceId>",
           "privateDnsZoneGroup": {
             "privateDNSResourceIds": [
               "<privateDNSZoneResourceId>"
             ]
-          }
+          },
+          "service": "sites",
+          "subnetResourceId": "<subnetResourceId>"
         }
       ]
     },
@@ -865,13 +865,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
-          "service": "sites",
-          "subnetResourceId": "<subnetResourceId>",
           "privateDnsZoneGroup": {
             "privateDNSResourceIds": [
               "<privateDNSZoneResourceId>"
             ]
-          }
+          },
+          "service": "sites",
+          "subnetResourceId": "<subnetResourceId>"
         }
       ]
     },

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -14,7 +14,7 @@ This module deploys a web or function app.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates) |
+| `Microsoft.Authorization/locks` | [2017-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2017-04-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/privateEndpoints` | [2022-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/privateEndpoints) |
@@ -507,13 +507,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
+        service: 'sites'
+        subnetResourceId: '<subnetResourceId>'
         privateDnsZoneGroup: {
           privateDNSResourceIds: [
             '<privateDNSZoneResourceId>'
           ]
         }
-        service: 'sites'
-        subnetResourceId: '<subnetResourceId>'
       }
     ]
     roleAssignments: [
@@ -660,13 +660,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
+          "service": "sites",
+          "subnetResourceId": "<subnetResourceId>",
           "privateDnsZoneGroup": {
             "privateDNSResourceIds": [
               "<privateDNSZoneResourceId>"
             ]
-          },
-          "service": "sites",
-          "subnetResourceId": "<subnetResourceId>"
+          }
         }
       ]
     },
@@ -787,13 +787,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     httpsOnly: true
     privateEndpoints: [
       {
+        service: 'sites'
+        subnetResourceId: '<subnetResourceId>'
         privateDnsZoneGroup: {
           privateDNSResourceIds: [
             '<privateDNSZoneResourceId>'
           ]
         }
-        service: 'sites'
-        subnetResourceId: '<subnetResourceId>'
       }
     ]
     roleAssignments: [
@@ -865,13 +865,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     "privateEndpoints": {
       "value": [
         {
+          "service": "sites",
+          "subnetResourceId": "<subnetResourceId>",
           "privateDnsZoneGroup": {
             "privateDNSResourceIds": [
               "<privateDNSZoneResourceId>"
             ]
-          },
-          "service": "sites",
-          "subnetResourceId": "<subnetResourceId>"
+          }
         }
       ]
     },

--- a/modules/Microsoft.Web/sites/readme.md
+++ b/modules/Microsoft.Web/sites/readme.md
@@ -507,13 +507,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        service: 'sites'
-        subnetResourceId: '<subnetResourceId>'
         privateDnsZoneGroup: {
           privateDNSResourceIds: [
             '<privateDNSZoneResourceId>'
           ]
         }
+        service: 'sites'
+        subnetResourceId: '<subnetResourceId>'
       }
     ]
     roleAssignments: [
@@ -787,13 +787,13 @@ module sites './Microsoft.Web/sites/deploy.bicep' = {
     httpsOnly: true
     privateEndpoints: [
       {
-        service: 'sites'
-        subnetResourceId: '<subnetResourceId>'
         privateDnsZoneGroup: {
           privateDNSResourceIds: [
             '<privateDNSZoneResourceId>'
           ]
         }
+        service: 'sites'
+        subnetResourceId: '<subnetResourceId>'
       }
     ]
     roleAssignments: [

--- a/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
+++ b/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
@@ -93,7 +93,7 @@ function ConvertTo-OrderedHashtable {
                 }
 
                 # Case: Primitive data types
-                $primitiveElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -notin @('Object[]', 'Hashtable') } | ConvertTo-Json | ConvertFrom-Json -AsHashtable -NoEnumerate
+                $primitiveElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -notin @('Object[]', 'Hashtable') } | ConvertTo-Json -Depth 99 | ConvertFrom-Json -AsHashtable -NoEnumerate -Depth 99
                 if ($primitiveElements.Count -gt 1) {
                     $primitiveElements = $primitiveElements | Sort-Object
                 }

--- a/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
+++ b/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
@@ -87,13 +87,13 @@ function ConvertTo-OrderedHashtable {
                 }
 
                 # Case: Array of objects
-                $hashTableElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -eq 'Hashtable' }
+                $hashTableElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -in @('Hashtable', 'OrderedHashtable') }
                 foreach ($hashTable in $hashTableElements) {
                     $arrayOutput += , (ConvertTo-OrderedHashtable -JSONInputObject ($hashTable | ConvertTo-Json -Depth 99))
                 }
 
                 # Case: Primitive data types
-                $primitiveElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -notin @('Object[]', 'Hashtable') } | ConvertTo-Json -Depth 99 | ConvertFrom-Json -AsHashtable -NoEnumerate -Depth 99
+                $primitiveElements = $JSONObject[$currentLevelKey] | Where-Object { $_.GetType().Name -notin @('Object[]', 'Hashtable', 'OrderedHashtable') } | ConvertTo-Json -Depth 99 | ConvertFrom-Json -AsHashtable -NoEnumerate -Depth 99
                 if ($primitiveElements.Count -gt 1) {
                     $primitiveElements = $primitiveElements | Sort-Object
                 }


### PR DESCRIPTION
# Description

- Updated `Set-ModuleReadMe` script to work with latest PowerShell version
- In a new version, `ConvertFrom-Json` returns now an 'OrderedHashtable' instead of a default Hashtable which can cause issues
- Also, re-ran the script on all modules

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
