### PR TITLE
[CI environment] Remove deploymentOutput from validate deployment action/pipeline template 

### DIFF
--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -71,7 +71,7 @@ inputs:
 outputs:
   deploymentOutput:
     description: 'The module deployment output in json format'
-    value: ${{ steps.deploy_step.outputs.deploymentOutput }}
+    value: ${{ fromJSON(steps.deploy_step.outputs.deploymentOutput) }}
 
 runs:
   using: 'composite'

--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -68,10 +68,12 @@ inputs:
     default: 'true'
     required: false
 
-outputs:
-  deploymentOutput:
-    description: 'The module deployment output in json format'
-    value: ${{ fromJSON(steps.deploy_step.outputs.deploymentOutput) }}
+# outputs:
+#   deploymentOutput:
+#     description: 'The module deployment output in json format'
+#     # value: ${{ fromJSON(steps.deploy_step.outputs.deploymentOutput) }}
+#     value: {{ steps.deploy_step.outputs.deploymentOutput }}
+
 
 runs:
   using: 'composite'
@@ -347,17 +349,17 @@ runs:
           # Get deployment name
           Write-Output ('{0}={1}' -f 'deploymentName', $res.deploymentName) >> $env:GITHUB_OUTPUT
 
-          # Populate further outputs
-          $deploymentOutputHash = @{}
+          # # Populate further outputs
+          # $deploymentOutputHash = @{}
 
-          foreach ($outputKey in $res.deploymentOutput.Keys) {
-            Write-Output ('{0}={1}' -f 'outputKey', $res.deploymentOutput[$outputKey].Value) >> $env:GITHUB_OUTPUT
-            $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
-          }
+          # foreach ($outputKey in $res.deploymentOutput.Keys) {
+          #   Write-Output ('{0}={1}' -f 'outputKey', $res.deploymentOutput[$outputKey].Value) >> $env:GITHUB_OUTPUT
+          #   $deploymentOutputHash.add($outputKey, $res.deploymentOutput[$outputKey].Value)
+          # }
 
-          $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
-          Write-Verbose "Deployment output: $deploymentOutput" -Verbose
-          Write-Output ('{0}={1}' -f 'deploymentOutput', $deploymentOutput) >> $env:GITHUB_OUTPUT
+          # $deploymentOutput = $deploymentOutputHash | ConvertTo-Json -Compress -Depth 100
+          # Write-Verbose "Deployment output: $deploymentOutput" -Verbose
+          # Write-Output ('{0}={1}' -f 'deploymentOutput', $deploymentOutput) >> $env:GITHUB_OUTPUT
 
           if ($res.ContainsKey('exception')) {
             # Happens only if there is an exception


### PR DESCRIPTION
# Description

[DRAFT] Purpose of this PR is solely to show proposed (quick) fix to issue #2323 

The `deploymentOutput` output parameter was originally added to the validate deployment action (GH) and pipeline template (ADO) to support pipeline orchestration for the dependencies pipeline.
With the new self-contained dependencies approach, the `deploymentOutput` output parameter is not used by the CI environment and could hence be removed together with its generation code snippet.

If accepted, the commented code should be removed and the change should be merged with PR #2297, currently blocked by issue #1791.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Synapse: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Ferikag%2F2323-output)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) |
| [![AnalysisServices: Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Ferikag%2F2323-output)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
