### PR TITLE
[Fixes] Fixed usage of deployment name in Test-Deployment script

### DIFF
--- a/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/resourceDeployment/Test-TemplateDeployment.ps1
@@ -119,8 +119,10 @@ function Test-TemplateDeployment {
             $deploymentName = ('{0}-{1}' -f $deploymentNamePrefix, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'))[0..63] -join ''
         } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
-        Write-Verbose "Testing with deployment name [$deploymentName]" -Verbose
-        $DeploymentInputs['DeploymentName'] = $deploymentName
+        if ($deploymentScope -ne 'resourceGroup') {
+            Write-Verbose "Testing with deployment name [$deploymentName]" -Verbose
+            $DeploymentInputs['DeploymentName'] = $deploymentName
+        }
 
         #################
         ## INVOKE TEST ##


### PR DESCRIPTION
# Description

- The name is only supported for non-resource-group-scoped deployments

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Synapse: Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Falsehr%2FfixedDeploymentNameRef)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) <= unrelated, expected error |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
