### PR TITLE
[Modules] Update reference usage in template

### DIFF
--- a/modules/Microsoft.VirtualMachineImages/imageTemplates/deploy.bicep
+++ b/modules/Microsoft.VirtualMachineImages/imageTemplates/deploy.bicep
@@ -86,7 +86,7 @@ var conditionalManagedImage = empty(managedImageName) ? [] : array(managedImage)
 var sharedImage = {
   type: 'SharedImage'
   galleryImageId: sigImageDefinitionId
-  runOutputName: !empty(sigImageDefinitionId) ? '${split(sigImageDefinitionId, '/')[10]}-SharedImage' : 'SharedImage'
+  runOutputName: !empty(sigImageDefinitionId) ? '${last(split(sigImageDefinitionId, '/'))}-SharedImage' : 'SharedImage'
   artifactTags: {
     sourceType: imageSource.type
     sourcePublisher: contains(imageSource, 'publisher') ? imageSource.publisher : null


### PR DESCRIPTION
# Description

- Adjusted a 'split' in the template to be more robust

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![VirtualMachineImages: ImageTemplates](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml/badge.svg?branch=users%2Falsehr%2FImageTemplateRef)](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
