### PR TITLE
[Modules] Added AADLoginForWindows extension and configuration

### DIFF
--- a/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/linux/deploy.test.bicep
@@ -190,6 +190,9 @@ module testDeployment '../../deploy.bicep' = {
         VolumeType: 'All'
       }
     }
+    extensionAadJoinConfig: {
+      enabled: true
+    }
     extensionDSCConfig: {
       enabled: false
     }

--- a/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/.test/windows/deploy.test.bicep
@@ -211,6 +211,9 @@ module testDeployment '../../deploy.bicep' = {
         VolumeType: 'All'
       }
     }
+    extensionAadJoinConfig: {
+      enabled: true
+    }
     extensionDSCConfig: {
       enabled: true
     }

--- a/modules/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -330,9 +330,10 @@ var accountSasProperties = {
   signedResourceTypes: 'o'
   signedProtocol: 'https'
 }
-// change SystemAssignedIdentity to True if AADJoin is enabled.
-var varsystemAssignedIdentity = extensionAadJoinConfig.enabled ? true : systemAssignedIdentity
-var identityType = varsystemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
+
+@description('change SystemAssignedIdentity to True if AADJoin is enabled.')
+var systemAssignedIdentityVar = extensionAadJoinConfig.enabled ? true : systemAssignedIdentity
+var identityType = systemAssignedIdentityVar ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
 
 var identity = identityType != 'None' ? {
   type: identityType
@@ -656,6 +657,7 @@ module vm_backup '../../Microsoft.RecoveryServices/vaults/protectionContainers/p
   }
   scope: az.resourceGroup(backupVaultResourceGroup)
   dependsOn: [
+    vm_aadJoinExtension
     vm_domainJoinExtension
     vm_microsoftMonitoringAgentExtension
     vm_microsoftAntiMalwareExtension

--- a/modules/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/modules/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -488,12 +488,12 @@ resource vm_configurationProfileAssignment 'Microsoft.Automanage/configurationPr
 }
 
 module vm_aadJoinExtension 'extensions/deploy.bicep' = if (extensionAadJoinConfig.enabled) {
-  name: '${uniqueString(deployment().name, location)}-VM-AADLoginForWindows'
+  name: '${uniqueString(deployment().name, location)}-VM-AADLogin'
   params: {
     virtualMachineName: vm.name
-    name: 'AADLoginForWindows'
+    name: 'AADLogin'
     publisher: 'Microsoft.Azure.ActiveDirectory'
-    type: 'AADLoginForWindows'
+    type: osType == 'Windows' ? 'AADLoginForWindows' : 'AADSSHLoginforLinux'
     typeHandlerVersion: contains(extensionAadJoinConfig, 'typeHandlerVersion') ? extensionAadJoinConfig.typeHandlerVersion : '1.0'
     autoUpgradeMinorVersion: contains(extensionAadJoinConfig, 'autoUpgradeMinorVersion') ? extensionAadJoinConfig.autoUpgradeMinorVersion : true
     enableAutomaticUpgrade: contains(extensionAadJoinConfig, 'enableAutomaticUpgrade') ? extensionAadJoinConfig.enableAutomaticUpgrade : false

--- a/modules/Microsoft.Compute/virtualMachines/readme.md
+++ b/modules/Microsoft.Compute/virtualMachines/readme.md
@@ -73,6 +73,7 @@ This module deploys one Virtual Machine with one or multiple NICs and optionally
 | `extensionCustomScriptConfig` | object | `{object}` |  | The configuration for the [Custom Script] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionCustomScriptProtectedSetting` | secureObject | `{object}` |  | Any object that contains the extension specific protected settings. |
 | `extensionDependencyAgentConfig` | object | `{object}` |  | The configuration for the [Dependency Agent] extension. Must at least contain the ["enabled": true] property to be executed. |
+| `extensionAadJoinConfig` | object | `{object}` |  | The configuration for the [AADLoginforWindows] extension. Must at least contain the ["enabled": true] property to be executed. Automatically enables the System Assigned Managed Identity. |
 | `extensionDomainJoinConfig` | object | `{object}` |  | The configuration for the [Domain Join] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionDomainJoinPassword` | secureString | `''` |  | Required if name is specified. Password of the user specified in user parameter. |
 | `extensionDSCConfig` | object | `{object}` |  | The configuration for the [Desired State Configuration] extension. Must at least contain the ["enabled": true] property to be executed. |
@@ -495,6 +496,42 @@ configurationProfileAssignments: [
     '/providers/Microsoft.Automanage/bestPractices/AzureBestPracticesProduction'
     '/providers/Microsoft.Automanage/bestPractices/AzureBestPracticesDevTest'
 ]
+```
+
+</details>
+<p>
+
+### Parameter Usage: `extensionAadJoinConfig`
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"extensionAadJoinConfig": {
+  "value": {
+    "enabled": true,
+    "settings": {
+      "mdmId": "0000000a-0000-0000-c000-000000000000" // This enables Intune Enrollment., Do not set mdmId to disable Intune Enrollment.
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+extensionAadJoinConfig: {
+    enabled: true
+    settings: {
+      mdmId: '0000000a-0000-0000-c000-000000000000' // This enables Intune Enrollment., Do not set mdmId to disable Intune Enrollment.
+    }
+}
+
 ```
 
 </details>

--- a/modules/Microsoft.Compute/virtualMachines/readme.md
+++ b/modules/Microsoft.Compute/virtualMachines/readme.md
@@ -68,12 +68,12 @@ This module deploys one Virtual Machine with one or multiple NICs and optionally
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `enableEvictionPolicy` | bool | `False` |  | Specifies the eviction policy for the low priority virtual machine. Will result in 'Deallocate' eviction policy. |
 | `encryptionAtHost` | bool | `True` |  | This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs. |
+| `extensionAadJoinConfig` | object | `{object}` |  | The configuration for the [AAD Join] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionAntiMalwareConfig` | object | `{object}` |  | The configuration for the [Anti Malware] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionAzureDiskEncryptionConfig` | object | `{object}` |  | The configuration for the [Azure Disk Encryption] extension. Must at least contain the ["enabled": true] property to be executed. Restrictions: Cannot be enabled on disks that have encryption at host enabled. Managed disks encrypted using Azure Disk Encryption cannot be encrypted using customer-managed keys. |
 | `extensionCustomScriptConfig` | object | `{object}` |  | The configuration for the [Custom Script] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionCustomScriptProtectedSetting` | secureObject | `{object}` |  | Any object that contains the extension specific protected settings. |
 | `extensionDependencyAgentConfig` | object | `{object}` |  | The configuration for the [Dependency Agent] extension. Must at least contain the ["enabled": true] property to be executed. |
-| `extensionAadJoinConfig` | object | `{object}` |  | The configuration for the [AADLoginforWindows] extension. Must at least contain the ["enabled": true] property to be executed. Automatically enables the System Assigned Managed Identity. |
 | `extensionDomainJoinConfig` | object | `{object}` |  | The configuration for the [Domain Join] extension. Must at least contain the ["enabled": true] property to be executed. |
 | `extensionDomainJoinPassword` | secureString | `''` |  | Required if name is specified. Password of the user specified in user parameter. |
 | `extensionDSCConfig` | object | `{object}` |  | The configuration for the [Desired State Configuration] extension. Must at least contain the ["enabled": true] property to be executed. |
@@ -1176,6 +1176,9 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
     disablePasswordAuthentication: true
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     encryptionAtHost: false
+    extensionAadJoinConfig: {
+      enabled: true
+    }
     extensionAzureDiskEncryptionConfig: {
       enabled: true
       settings: {
@@ -1384,6 +1387,11 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
     },
     "encryptionAtHost": {
       "value": false
+    },
+    "extensionAadJoinConfig": {
+      "value": {
+        "enabled": true
+      }
     },
     "extensionAzureDiskEncryptionConfig": {
       "value": {
@@ -1865,6 +1873,9 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     encryptionAtHost: false
+    extensionAadJoinConfig: {
+      enabled: true
+    }
     extensionAntiMalwareConfig: {
       enabled: true
       settings: {
@@ -2086,6 +2097,11 @@ module virtualMachines './Microsoft.Compute/virtualMachines/deploy.bicep' = {
     },
     "encryptionAtHost": {
       "value": false
+    },
+    "extensionAadJoinConfig": {
+      "value": {
+        "enabled": true
+      }
     },
     "extensionAntiMalwareConfig": {
       "value": {


### PR DESCRIPTION
# Description

Added the AADLoginForWindows extension as a new module and a new object parameter 'extensionAadJoinConfig' for configuring the extension. This extension requires that there is a System Assigned Identity so the systemAssignedIdentity value is automatically set to true via the variables section if the extensionAadJoinConfig.enabled value = true. I'm not sure if this is the correct way to configure dependencies/relationships between parameters. This extension also conflicts with the Domain Join extension, but nothing is configured to prevent them both from being enabled in the template.

The following parameters are to be configured for the extensionAadJoinConfig value if Intune Enrollment is desired:

extensionAadJoinConfig: {
     enabled: true
     settings: {mdmId: '0000000a-0000-0000-c000-000000000000'}
}
or the following parameters if Intune Enrollment is not desired
extensionAadJoinConfig: {
     enabled: true
     settings: {}
}


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code