### PR TITLE
[Fixes] Fix deployment error with flexible server configurations

### DIFF
--- a/modules/Microsoft.DBforPostgreSQL/flexibleServers/deploy.bicep
+++ b/modules/Microsoft.DBforPostgreSQL/flexibleServers/deploy.bicep
@@ -276,6 +276,9 @@ module flexibleServer_firewallRules 'firewallRules/deploy.bicep' = [for (firewal
     endIpAddress: firewallRule.endIpAddress
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
+  dependsOn: [
+    flexibleServer_databases
+  ]
 }]
 
 module flexibleServer_configurations 'configurations/deploy.bicep' = [for (configuration, index) in configurations: {
@@ -287,6 +290,9 @@ module flexibleServer_configurations 'configurations/deploy.bicep' = [for (confi
     value: contains(configuration, 'value') ? configuration.value : ''
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
+  dependsOn: [
+    flexibleServer_firewallRules
+  ]
 }]
 
 resource flexibleServer_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if ((!empty(diagnosticStorageAccountId)) || (!empty(diagnosticWorkspaceId)) || (!empty(diagnosticEventHubAuthorizationRuleId)) || (!empty(diagnosticEventHubName))) {


### PR DESCRIPTION
# Description

After creating the databases, firewall rules are created. These must be deployed before configurations can be created, otherwise a deployment error may occur. [Failed Pipeline](https://github.com/Azure/ResourceModules/actions/runs/3577153479)
See also: https://learn.microsoft.com/en-us/answers/questions/1078895/deploying-postgresql-flexible-server-with-azureext.html

### Solution:
Add dependsOn to the sub resources

## Pipeline references

| Pipeline |
| - |
| [![DbForPostgreSQL: FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml/badge.svg?branch=users%2Fjpeasier%2FfixDeploymentErrorWithFlexibleServerConfigurations)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml) |

# Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
