### PR TITLE
[Modules] Update Azure Policy Assignment Module API to '2022-06-01', enabling the Resource Selectors and Overrides

### DIFF
--- a/modules/Microsoft.Authorization/policyAssignments/.test/mg.common/deploy.test.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/.test/mg.common/deploy.test.bicep
@@ -21,7 +21,7 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '<<namePrefix>>${serviceShort}001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
     enforcementMode: 'DoNotEnforce'
@@ -41,15 +41,49 @@ module testDeployment '../../deploy.bicep' = {
       '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg'
     ]
     parameters: {
-      tagName: {
-        value: 'env'
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
-      tagValue: {
-        value: 'prod'
+      effect: {
+        value: 'Disabled'
       }
     }
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    ]
+    overrides: [
+      {
+        kind: 'policyEffect'
+        value: 'Disabled'
+        selectors: [
+          {
+            kind: 'policyDefinitionReferenceId'
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+          }
+        ]
+      }
+    ]
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            kind: 'resourceType'
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+          }
+          {
+            kind: 'resourceLocation'
+            in: [
+              'westeurope'
+            ]
+          }
+        ]
+      }
     ]
   }
 }

--- a/modules/Microsoft.Authorization/policyAssignments/.test/rg.common/deploy.test.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/.test/rg.common/deploy.test.bicep
@@ -46,7 +46,7 @@ module testDeployment '../../resourceGroup/deploy.bicep' = {
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '<<namePrefix>>${serviceShort}001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
     enforcementMode: 'DoNotEnforce'
@@ -65,16 +65,50 @@ module testDeployment '../../resourceGroup/deploy.bicep' = {
       resourceGroupResources.outputs.keyVaultResourceId
     ]
     parameters: {
-      tagName: {
-        value: 'env'
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
-      tagValue: {
-        value: 'prod'
+      effect: {
+        value: 'Disabled'
       }
     }
     resourceGroupName: resourceGroup.name
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    ]
+    overrides: [
+      {
+        kind: 'policyEffect'
+        value: 'Disabled'
+        selectors: [
+          {
+            kind: 'policyDefinitionReferenceId'
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+          }
+        ]
+      }
+    ]
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            kind: 'resourceType'
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+          }
+          {
+            kind: 'resourceLocation'
+            in: [
+              'westeurope'
+            ]
+          }
+        ]
+      }
     ]
     subscriptionId: subscription().subscriptionId
     userAssignedIdentityId: resourceGroupResources.outputs.managedIdentityResourceId

--- a/modules/Microsoft.Authorization/policyAssignments/.test/sub.common/deploy.test.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/.test/sub.common/deploy.test.bicep
@@ -44,7 +44,7 @@ module testDeployment '../../subscription/deploy.bicep' = {
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '<<namePrefix>>${serviceShort}001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
     enforcementMode: 'DoNotEnforce'
@@ -63,15 +63,49 @@ module testDeployment '../../subscription/deploy.bicep' = {
       '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg'
     ]
     parameters: {
-      tagName: {
-        value: 'env'
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
-      tagValue: {
-        value: 'prod'
+      effect: {
+        value: 'Disabled'
       }
     }
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    ]
+    overrides: [
+      {
+        kind: 'policyEffect'
+        value: 'Disabled'
+        selectors: [
+          {
+            kind: 'policyDefinitionReferenceId'
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+          }
+        ]
+      }
+    ]
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            kind: 'resourceType'
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+          }
+          {
+            kind: 'resourceLocation'
+            in: [
+              'westeurope'
+            ]
+          }
+        ]
+      }
     ]
     subscriptionId: subscription().subscriptionId
     userAssignedIdentityId: resourceGroupResources.outputs.managedIdentityResourceId

--- a/modules/Microsoft.Authorization/policyAssignments/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/deploy.bicep
@@ -58,6 +58,12 @@ param notScopes array = []
 @sys.description('Optional. Location for all resources.')
 param location string = deployment().location
 
+@sys.description('Optional. The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition.')
+param overrides array = []
+
+@sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
+param resourceSelectors array = []
+
 @sys.description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
@@ -94,6 +100,8 @@ module policyAssignment_mg 'managementGroup/deploy.bicep' = if (empty(subscripti
     notScopes: !empty(notScopes) ? notScopes : []
     managementGroupId: managementGroupId
     location: location
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }
@@ -116,6 +124,8 @@ module policyAssignment_sub 'subscription/deploy.bicep' = if (!empty(subscriptio
     notScopes: !empty(notScopes) ? notScopes : []
     subscriptionId: subscriptionId
     location: location
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }
@@ -138,6 +148,8 @@ module policyAssignment_rg 'resourceGroup/deploy.bicep' = if (!empty(resourceGro
     notScopes: !empty(notScopes) ? notScopes : []
     subscriptionId: subscriptionId
     location: location
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }

--- a/modules/Microsoft.Authorization/policyAssignments/managementGroup/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/managementGroup/deploy.bicep
@@ -53,6 +53,12 @@ param notScopes array = []
 @sys.description('Optional. Location for all resources.')
 param location string = deployment().location
 
+@sys.description('Optional. The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition.')
+param overrides array = []
+
+@sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
+param resourceSelectors array = []
+
 @sys.description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
@@ -78,7 +84,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
   name: name
   location: location
   properties: {
@@ -90,6 +96,8 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
     nonComplianceMessages: !empty(nonComplianceMessages) ? nonComplianceMessages : []
     enforcementMode: enforcementMode
     notScopes: !empty(notScopes) ? notScopes : []
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
   }
   identity: identityVar
 }

--- a/modules/Microsoft.Authorization/policyAssignments/managementGroup/readme.md
+++ b/modules/Microsoft.Authorization/policyAssignments/managementGroup/readme.md
@@ -13,7 +13,7 @@ With this module you can perform policy assignments on a management group level.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyAssignments` | [2021-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2021-06-01/policyAssignments) |
+| `Microsoft.Authorization/policyAssignments` | [2022-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-06-01/policyAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 
 ## Parameters
@@ -39,7 +39,9 @@ With this module you can perform policy assignments on a management group level.
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessages` | array | `[]` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes. |
+| `overrides` | array | `[]` |  | The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition. |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
+| `resourceSelectors` | array | `[]` |  | The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. |
 | `roleDefinitionIds` | array | `[]` |  | The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition. |
 | `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
 

--- a/modules/Microsoft.Authorization/policyAssignments/readme.md
+++ b/modules/Microsoft.Authorization/policyAssignments/readme.md
@@ -15,7 +15,7 @@ With this module you can perform policy assignments across the management group,
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyAssignments` | [2021-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2021-06-01/policyAssignments) |
+| `Microsoft.Authorization/policyAssignments` | [2022-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-06-01/policyAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 
 ## Parameters
@@ -41,8 +41,10 @@ With this module you can perform policy assignments across the management group,
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessages` | array | `[]` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes. |
+| `overrides` | array | `[]` |  | The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition. |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
 | `resourceGroupName` | string | `''` |  | The Target Scope for the Policy. The name of the resource group for the policy assignment. |
+| `resourceSelectors` | array | `[]` |  | The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. |
 | `roleDefinitionIds` | array | `[]` |  | The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition. |
 | `subscriptionId` | string | `''` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. |
 | `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |
@@ -192,7 +194,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
   params: {
     // Required parameters
     name: '<<namePrefix>>apamgcom001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
@@ -213,14 +215,48 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
     notScopes: [
       '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg'
     ]
-    parameters: {
-      tagName: {
-        value: 'env'
+    overrides: [
+      {
+        kind: 'policyEffect'
+        selectors: [
+          {
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+            kind: 'policyDefinitionReferenceId'
+          }
+        ]
+        value: 'Disabled'
       }
-      tagValue: {
-        value: 'prod'
+    ]
+    parameters: {
+      effect: {
+        value: 'Disabled'
+      }
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
     }
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+            kind: 'resourceType'
+          }
+          {
+            in: [
+              'westeurope'
+            ]
+            kind: 'resourceLocation'
+          }
+        ]
+      }
+    ]
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
     ]
@@ -245,7 +281,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
       "value": "<<namePrefix>>apamgcom001"
     },
     "policyDefinitionId": {
-      "value": "/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26"
+      "value": "/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611"
     },
     // Non-required parameters
     "description": {
@@ -287,15 +323,53 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
         "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg"
       ]
     },
+    "overrides": {
+      "value": [
+        {
+          "kind": "policyEffect",
+          "selectors": [
+            {
+              "in": [
+                "ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent",
+                "ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent"
+              ],
+              "kind": "policyDefinitionReferenceId"
+            }
+          ],
+          "value": "Disabled"
+        }
+      ]
+    },
     "parameters": {
       "value": {
-        "tagName": {
-          "value": "env"
+        "effect": {
+          "value": "Disabled"
         },
-        "tagValue": {
-          "value": "prod"
+        "enableCollectionOfSqlQueriesForSecurityResearch": {
+          "value": false
         }
       }
+    },
+    "resourceSelectors": {
+      "value": [
+        {
+          "name": "resourceSelector-test",
+          "selectors": [
+            {
+              "in": [
+                "Microsoft.Compute/virtualMachines"
+              ],
+              "kind": "resourceType"
+            },
+            {
+              "in": [
+                "westeurope"
+              ],
+              "kind": "resourceLocation"
+            }
+          ]
+        }
+      ]
     },
     "roleDefinitionIds": {
       "value": [
@@ -370,7 +444,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
   params: {
     // Required parameters
     name: '<<namePrefix>>apargcom001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
@@ -390,15 +464,49 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
     notScopes: [
       '<keyVaultResourceId>'
     ]
-    parameters: {
-      tagName: {
-        value: 'env'
+    overrides: [
+      {
+        kind: 'policyEffect'
+        selectors: [
+          {
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+            kind: 'policyDefinitionReferenceId'
+          }
+        ]
+        value: 'Disabled'
       }
-      tagValue: {
-        value: 'prod'
+    ]
+    parameters: {
+      effect: {
+        value: 'Disabled'
+      }
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
     }
     resourceGroupName: '<resourceGroupName>'
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+            kind: 'resourceType'
+          }
+          {
+            in: [
+              'westeurope'
+            ]
+            kind: 'resourceLocation'
+          }
+        ]
+      }
+    ]
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
     ]
@@ -425,7 +533,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
       "value": "<<namePrefix>>apargcom001"
     },
     "policyDefinitionId": {
-      "value": "/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26"
+      "value": "/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611"
     },
     // Non-required parameters
     "description": {
@@ -464,18 +572,56 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
         "<keyVaultResourceId>"
       ]
     },
+    "overrides": {
+      "value": [
+        {
+          "kind": "policyEffect",
+          "selectors": [
+            {
+              "in": [
+                "ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent",
+                "ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent"
+              ],
+              "kind": "policyDefinitionReferenceId"
+            }
+          ],
+          "value": "Disabled"
+        }
+      ]
+    },
     "parameters": {
       "value": {
-        "tagName": {
-          "value": "env"
+        "effect": {
+          "value": "Disabled"
         },
-        "tagValue": {
-          "value": "prod"
+        "enableCollectionOfSqlQueriesForSecurityResearch": {
+          "value": false
         }
       }
     },
     "resourceGroupName": {
       "value": "<resourceGroupName>"
+    },
+    "resourceSelectors": {
+      "value": [
+        {
+          "name": "resourceSelector-test",
+          "selectors": [
+            {
+              "in": [
+                "Microsoft.Compute/virtualMachines"
+              ],
+              "kind": "resourceType"
+            },
+            {
+              "in": [
+                "westeurope"
+              ],
+              "kind": "resourceLocation"
+            }
+          ]
+        }
+      ]
     },
     "roleDefinitionIds": {
       "value": [
@@ -560,7 +706,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
   params: {
     // Required parameters
     name: '<<namePrefix>>apasubcom001'
-    policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26'
+    policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
@@ -580,14 +726,48 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
     notScopes: [
       '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg'
     ]
-    parameters: {
-      tagName: {
-        value: 'env'
+    overrides: [
+      {
+        kind: 'policyEffect'
+        selectors: [
+          {
+            in: [
+              'ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent'
+              'ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent'
+            ]
+            kind: 'policyDefinitionReferenceId'
+          }
+        ]
+        value: 'Disabled'
       }
-      tagValue: {
-        value: 'prod'
+    ]
+    parameters: {
+      effect: {
+        value: 'Disabled'
+      }
+      enableCollectionOfSqlQueriesForSecurityResearch: {
+        value: false
       }
     }
+    resourceSelectors: [
+      {
+        name: 'resourceSelector-test'
+        selectors: [
+          {
+            in: [
+              'Microsoft.Compute/virtualMachines'
+            ]
+            kind: 'resourceType'
+          }
+          {
+            in: [
+              'westeurope'
+            ]
+            kind: 'resourceLocation'
+          }
+        ]
+      }
+    ]
     roleDefinitionIds: [
       '/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
     ]
@@ -614,7 +794,7 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
       "value": "<<namePrefix>>apasubcom001"
     },
     "policyDefinitionId": {
-      "value": "/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26"
+      "value": "/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611"
     },
     // Non-required parameters
     "description": {
@@ -653,15 +833,53 @@ module policyAssignments './Microsoft.Authorization/policyAssignments/deploy.bic
         "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg"
       ]
     },
+    "overrides": {
+      "value": [
+        {
+          "kind": "policyEffect",
+          "selectors": [
+            {
+              "in": [
+                "ASC_DeployAzureDefenderForSqlAdvancedThreatProtectionWindowsAgent",
+                "ASC_DeployAzureDefenderForSqlVulnerabilityAssessmentWindowsAgent"
+              ],
+              "kind": "policyDefinitionReferenceId"
+            }
+          ],
+          "value": "Disabled"
+        }
+      ]
+    },
     "parameters": {
       "value": {
-        "tagName": {
-          "value": "env"
+        "effect": {
+          "value": "Disabled"
         },
-        "tagValue": {
-          "value": "prod"
+        "enableCollectionOfSqlQueriesForSecurityResearch": {
+          "value": false
         }
       }
+    },
+    "resourceSelectors": {
+      "value": [
+        {
+          "name": "resourceSelector-test",
+          "selectors": [
+            {
+              "in": [
+                "Microsoft.Compute/virtualMachines"
+              ],
+              "kind": "resourceType"
+            },
+            {
+              "in": [
+                "westeurope"
+              ],
+              "kind": "resourceLocation"
+            }
+          ]
+        }
+      ]
     },
     "roleDefinitionIds": {
       "value": [

--- a/modules/Microsoft.Authorization/policyAssignments/resourceGroup/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/resourceGroup/deploy.bicep
@@ -50,6 +50,12 @@ param notScopes array = []
 @sys.description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
+@sys.description('Optional. The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition.')
+param overrides array = []
+
+@sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
+param resourceSelectors array = []
+
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')
 param subscriptionId string = subscription().subscriptionId
 
@@ -80,7 +86,7 @@ var identityVar = identity == 'SystemAssigned' ? {
   }
 } : null
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
   name: name
   location: location
   properties: {
@@ -92,6 +98,8 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
     nonComplianceMessages: !empty(nonComplianceMessages) ? nonComplianceMessages : []
     enforcementMode: enforcementMode
     notScopes: !empty(notScopes) ? notScopes : []
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
   }
   identity: identityVar
 }

--- a/modules/Microsoft.Authorization/policyAssignments/resourceGroup/readme.md
+++ b/modules/Microsoft.Authorization/policyAssignments/resourceGroup/readme.md
@@ -13,7 +13,7 @@ With this module you can perform policy assignments on a resource group level
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyAssignments` | [2021-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2021-06-01/policyAssignments) |
+| `Microsoft.Authorization/policyAssignments` | [2022-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-06-01/policyAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 
 ## Parameters
@@ -38,8 +38,10 @@ With this module you can perform policy assignments on a resource group level
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessages` | array | `[]` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes. |
+| `overrides` | array | `[]` |  | The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition. |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
 | `resourceGroupName` | string | `[resourceGroup().name]` |  | The Target Scope for the Policy. The name of the resource group for the policy assignment. If not provided, will use the current scope for deployment. |
+| `resourceSelectors` | array | `[]` |  | The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. |
 | `roleDefinitionIds` | array | `[]` |  | The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition. |
 | `subscriptionId` | string | `[subscription().subscriptionId]` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment. |
 | `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |

--- a/modules/Microsoft.Authorization/policyAssignments/subscription/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyAssignments/subscription/deploy.bicep
@@ -50,6 +50,12 @@ param notScopes array = []
 @sys.description('Optional. Location for all resources.')
 param location string = deployment().location
 
+@sys.description('Optional. The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition.')
+param overrides array = []
+
+@sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
+param resourceSelectors array = []
+
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')
 param subscriptionId string = subscription().subscriptionId
 
@@ -78,7 +84,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
   name: name
   location: location
   properties: {
@@ -90,6 +96,8 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2021-06-01'
     nonComplianceMessages: !empty(nonComplianceMessages) ? nonComplianceMessages : []
     enforcementMode: enforcementMode
     notScopes: !empty(notScopes) ? notScopes : []
+    overrides: !empty(overrides) ? overrides : []
+    resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
   }
   identity: identityVar
 }

--- a/modules/Microsoft.Authorization/policyAssignments/subscription/readme.md
+++ b/modules/Microsoft.Authorization/policyAssignments/subscription/readme.md
@@ -13,7 +13,7 @@ With this module you can perform policy assignments on a subscription level.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyAssignments` | [2021-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2021-06-01/policyAssignments) |
+| `Microsoft.Authorization/policyAssignments` | [2022-06-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-06-01/policyAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 
 ## Parameters
@@ -38,7 +38,9 @@ With this module you can perform policy assignments on a subscription level.
 | `metadata` | object | `{object}` |  | The policy assignment metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
 | `nonComplianceMessages` | array | `[]` |  | The messages that describe why a resource is non-compliant with the policy. |
 | `notScopes` | array | `[]` |  | The policy excluded scopes. |
+| `overrides` | array | `[]` |  | The policy property value override. Allows changing the effect of a policy definition without modifying the underlying policy definition or using a parameterized effect in the policy definition. |
 | `parameters` | object | `{object}` |  | Parameters for the policy assignment if needed. |
+| `resourceSelectors` | array | `[]` |  | The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. |
 | `roleDefinitionIds` | array | `[]` |  | The IDs Of the Azure Role Definition list that is used to assign permissions to the identity. You need to provide either the fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles for the list IDs for built-in Roles. They must match on what is on the policy definition. |
 | `subscriptionId` | string | `[subscription().subscriptionId]` |  | The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment. |
 | `userAssignedIdentityId` | string | `''` |  | The Resource ID for the user assigned identity to assign to the policy assignment. |


### PR DESCRIPTION
Closes #2524 

# Description

Update the Policy Assignments module API version to support Resource Selectors and Overrides.

- Updated API version to 2022-06-01
- Change the policy definition to an initiative to support the override parameter

## Pipeline references

| Pipeline |
| - |
|[![Authorization: PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Fahmad%2F2524_policyAssignmentUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml) |

# Type of Change

- [ ] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
