### PR TITLE
[Modules] Updated Azure Policy Definitions - mode to support 'Microsoft.Network.Data'

### DIFF
--- a/modules/Microsoft.Authorization/policyDefinitions/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyDefinitions/deploy.bicep
@@ -18,6 +18,7 @@ param description string = ''
   'Microsoft.KeyVault.Data'
   'Microsoft.ContainerService.Data'
   'Microsoft.Kubernetes.Data'
+  'Microsoft.Network.Data'
 ])
 param mode string = 'All'
 

--- a/modules/Microsoft.Authorization/policyDefinitions/managementGroup/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyDefinitions/managementGroup/deploy.bicep
@@ -18,6 +18,7 @@ param description string = ''
   'Microsoft.KeyVault.Data'
   'Microsoft.ContainerService.Data'
   'Microsoft.Kubernetes.Data'
+  'Microsoft.Network.Data'
 ])
 param mode string = 'All'
 

--- a/modules/Microsoft.Authorization/policyDefinitions/managementGroup/readme.md
+++ b/modules/Microsoft.Authorization/policyDefinitions/managementGroup/readme.md
@@ -33,7 +33,7 @@ With this module you can create policy definitions on a management group level.
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `location` | string | `[deployment().location]` |  | Location deployment metadata. |
 | `metadata` | object | `{object}` |  | The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
-| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
+| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data, Microsoft.Network.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
 | `parameters` | object | `{object}` |  | The policy definition parameters that can be used in policy definition references. |
 
 

--- a/modules/Microsoft.Authorization/policyDefinitions/readme.md
+++ b/modules/Microsoft.Authorization/policyDefinitions/readme.md
@@ -36,7 +36,7 @@ With this module you can create policy definitions across the management group o
 | `location` | string | `[deployment().location]` |  | Location deployment metadata. |
 | `managementGroupId` | string | `[managementGroup().name]` |  | The group ID of the Management Group (Scope). If not provided, will use the current scope for deployment. |
 | `metadata` | object | `{object}` |  | The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
-| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
+| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data, Microsoft.Network.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
 | `parameters` | object | `{object}` |  | The policy definition parameters that can be used in policy definition references. |
 | `subscriptionId` | string | `''` |  | The subscription ID of the subscription (Scope). Cannot be used with managementGroupId. |
 

--- a/modules/Microsoft.Authorization/policyDefinitions/subscription/deploy.bicep
+++ b/modules/Microsoft.Authorization/policyDefinitions/subscription/deploy.bicep
@@ -18,6 +18,7 @@ param description string = ''
   'Microsoft.KeyVault.Data'
   'Microsoft.ContainerService.Data'
   'Microsoft.Kubernetes.Data'
+  'Microsoft.Network.Data'
 ])
 param mode string = 'All'
 

--- a/modules/Microsoft.Authorization/policyDefinitions/subscription/readme.md
+++ b/modules/Microsoft.Authorization/policyDefinitions/subscription/readme.md
@@ -33,7 +33,7 @@ With this module you can create policy definitions on a subscription level.
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `location` | string | `[deployment().location]` |  | Location deployment metadata. |
 | `metadata` | object | `{object}` |  | The policy Definition metadata. Metadata is an open ended object and is typically a collection of key-value pairs. |
-| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
+| `mode` | string | `'All'` | `[All, Indexed, Microsoft.ContainerService.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data, Microsoft.Network.Data]` | The policy definition mode. Default is All, Some examples are All, Indexed, Microsoft.KeyVault.Data. |
 | `parameters` | object | `{object}` |  | The policy definition parameters that can be used in policy definition references. |
 
 


### PR DESCRIPTION
# Description

Added the new mode type `Microsoft.Network.Data` used for Azure Virtual Network Manager - Network Groups that use dynamic memberships.

See [Policy Definitions Mode Type](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure#resource-provider-modes) and [Configuring Virtual Network Manager Network Groups using Azure Policy](https://learn.microsoft.com/en-us/azure/virtual-network-manager/concept-azure-policy-integration#policy-definition) for more details.

## Pipeline references

| Pipeline |
| - |
| [![Authorization: PolicyDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml/badge.svg?branch=users%2Fahmad%2FpolicyDefModeUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml)|

# Type of Change

- [ ] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
