### PR TITLE
[Wiki] Added sorting to wiki module table

### DIFF
--- a/utilities/tools/Get-ModulesFeatureOutline.ps1
+++ b/utilities/tools/Get-ModulesFeatureOutline.ps1
@@ -159,7 +159,7 @@ function Get-ModulesFeatureOutline {
 
         # Add table data
         $counter = 1
-        foreach ($module in $moduleData) {
+        foreach ($module in ($moduleData | Sort-Object { $_.Module })) {
             $line = '| {0} | {1} |' -f $counter, (($moduleData[0].Keys | ForEach-Object { $module[$_] }) -join ' | ')
             $line = $line -replace 'True', ':white_check_mark:'
             $line = $line -replace 'False', ''


### PR DESCRIPTION
# Description

- Added sorting to [wiki module table](https://github.com/Azure/ResourceModules/wiki/The%20library%20-%20Module%20overview) which previously was somewhat random in order

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
