### PR TITLE
[Fixes] `resourceGroupResources` leftover

### DIFF
--- a/docs/wiki/The library - Module design.md
+++ b/docs/wiki/The library - Module design.md
@@ -582,7 +582,7 @@ Test file (`deploy.test.bicep`) guidelines:
   - Each file should also provide a `location` parameter that may default to the deployments default location
 - It is recommended to define all major resource names in the `deploy.test.bicep` file as it makes later maintenance easier. To implement this, make sure to pass all resource names to any referenced module.
 - Further, for any test file (including the `dependencies.bicep` file), the usage of variables should be reduced to the absolute minimum. In other words: You should only use variables if you must use them in more than one place. The idea is to keep the test files as simple as possible
-- References to dependencies should be implemented using resource references in combination with outputs. In other words: You should not hardcode any references into the module template's deployment. Instead use references such as `resourceGroupResources.outputs.managedIdentityPrincipalId`
+- References to dependencies should be implemented using resource references in combination with outputs. In other words: You should not hardcode any references into the module template's deployment. Instead use references such as `nestedDependencies.outputs.managedIdentityPrincipalId`
 - If any diagnostic resources (e.g., a Log Analytics workspace) are required for a test scenario, you can reference the centralized `modules/.shared/dependencyConstructs/diagnostic.dependencies.bicep` template. It will also provide you with all outputs you'd need.
 
 > :scroll: [Example of test file](https://github.com/Azure/ResourceModules/blob/main/modules/Microsoft.AnalysisServices/servers/.test/common/deploy.test.bicep)

--- a/modules/Microsoft.SignalRService/signalR/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.SignalRService/signalR/.test/common/deploy.test.bicep
@@ -27,7 +27,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   location: location
 }
 
-module resourceGroupResources 'dependencies.bicep' = {
+module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-paramNested'
   params: {
@@ -77,11 +77,11 @@ module testDeployment '../../deploy.bicep' = {
       {
         privateDnsZoneGroup: {
           privateDNSResourceIds: [
-            resourceGroupResources.outputs.privateDNSResourceId
+            nestedDependencies.outputs.privateDNSResourceId
           ]
         }
         service: 'signalr'
-        subnetResourceId: resourceGroupResources.outputs.subnetResourceId
+        subnetResourceId: nestedDependencies.outputs.subnetResourceId
       }
     ]
     resourceLogConfigurationsToEnable: [
@@ -90,7 +90,7 @@ module testDeployment '../../deploy.bicep' = {
     roleAssignments: [
       {
         principalIds: [
-          resourceGroupResources.outputs.managedIdentityPrincipalId
+          nestedDependencies.outputs.managedIdentityPrincipalId
         ]
         roleDefinitionIdOrName: 'Reader'
       }

--- a/modules/Microsoft.Web/sites/.test/webAppCommon/deploy.test.bicep
+++ b/modules/Microsoft.Web/sites/.test/webAppCommon/deploy.test.bicep
@@ -80,10 +80,10 @@ module testDeployment '../../deploy.bicep' = {
         privateEndpoints: [
           {
             service: 'sites'
-            subnetResourceId: resourceGroupResources.outputs.subnetResourceId
+            subnetResourceId: nestedDependencies.outputs.subnetResourceId
             privateDnsZoneGroup: {
               privateDNSResourceIds: [
-                resourceGroupResources.outputs.privateDNSZoneResourceId
+                nestedDependencies.outputs.privateDNSZoneResourceId
               ]
             }
           }
@@ -92,7 +92,7 @@ module testDeployment '../../deploy.bicep' = {
           {
             roleDefinitionIdOrName: 'Reader'
             principalIds: [
-              resourceGroupResources.outputs.managedIdentityPrincipalId
+              nestedDependencies.outputs.managedIdentityPrincipalId
             ]
             principalType: 'ServicePrincipal'
           }


### PR DESCRIPTION
# Description

Replace resourceGroupResources leftovers with nestedDependencies
Fixes Web Sites static validation

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Web: Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg?branch=users%2Ferikag%2Fsites-fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml) |
| [![SignalR Service: SignalR](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml/badge.svg?branch=users%2Ferikag%2Fsites-fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
