### PR TITLE
[Modules] Storage account - Enable LargeFileShares feature

### DIFF
--- a/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
@@ -64,6 +64,7 @@ module testDeployment '../../deploy.bicep' = {
     storageAccountSku: 'Standard_LRS'
     allowBlobPublicAccess: false
     requireInfrastructureEncryption: true
+    largeFileSharesState: 'Enabled'
     lock: 'CanNotDelete'
     enableHierarchicalNamespace: true
     enableSftp: true
@@ -112,7 +113,6 @@ module testDeployment '../../deploy.bicep' = {
         ]
       }
     ]
-
     blobServices: {
       diagnosticLogsRetentionInDays: 7
       diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId
@@ -164,7 +164,7 @@ module testDeployment '../../deploy.bicep' = {
         }
         {
           name: 'avdprofiles2'
-          shareQuota: 5120
+          shareQuota: 102400
         }
       ]
     }

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -48,7 +48,7 @@ param storageAccountAccessTier string = 'Hot'
   'Disabled'
   'Enabled'
 ])
-@description('Optional. Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled.')
+@description('Optional. Allow large file shares if sets to \'Enabled\'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares).')
 param largeFileSharesState string = 'Disabled'
 
 @description('Optional. Provides the identity based authentication settings for Azure Files.')

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -245,7 +245,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
     isHnsEnabled: enableHierarchicalNamespace ? enableHierarchicalNamespace : null
     isSftpEnabled: enableSftp
     isNfsV3Enabled: enableNfsV3
-    largeFileSharesState: largeFileSharesState
+    largeFileSharesState: (storageAccountSku == 'Standard_LRS') || (storageAccountSku == 'Standard_ZRS') ? largeFileSharesState : null
     minimumTlsVersion: minimumTlsVersion
     networkAcls: !empty(networkAcls) ? {
       bypass: contains(networkAcls, 'bypass') ? networkAcls.bypass : null

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -44,6 +44,13 @@ param storageAccountSku string = 'Standard_GRS'
 @description('Optional. Storage Account Access Tier.')
 param storageAccountAccessTier string = 'Hot'
 
+@allowed([
+  'Disabled'
+  'Enabled'
+])
+@description('Optional. Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled.')
+param largeFileSharesState string = 'Disabled'
+
 @description('Optional. Provides the identity based authentication settings for Azure Files.')
 param azureFilesIdentityBasedAuthentication object = {}
 
@@ -238,6 +245,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
     isHnsEnabled: enableHierarchicalNamespace ? enableHierarchicalNamespace : null
     isSftpEnabled: enableSftp
     isNfsV3Enabled: enableNfsV3
+    largeFileSharesState: largeFileSharesState
     minimumTlsVersion: minimumTlsVersion
     networkAcls: !empty(networkAcls) ? {
       bypass: contains(networkAcls, 'bypass') ? networkAcls.bypass : null

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/deploy.bicep
@@ -137,7 +137,7 @@ module fileServices_shares 'shares/deploy.bicep' = [for (share, index) in shares
     name: share.name
     enabledProtocols: contains(share, 'enabledProtocols') ? share.enabledProtocols : 'SMB'
     rootSquash: contains(share, 'rootSquash') ? share.rootSquash : 'NoRootSquash'
-    sharedQuota: contains(share, 'sharedQuota') ? share.sharedQuota : 5120
+    shareQuota: contains(share, 'shareQuota') ? share.shareQuota : 5120
     roleAssignments: contains(share, 'roleAssignments') ? share.roleAssignments : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
@@ -8,7 +8,7 @@ param fileServicesName string = 'default'
 @description('Required. The name of the file share to create.')
 param name string
 
-@description('Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400.')
+@description('Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5120 (5TB). For Large File Shares, the maximum size is 102400 (100TB).')
 param sharedQuota int = 5120
 
 @allowed([

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/shares/deploy.bicep
@@ -9,7 +9,7 @@ param fileServicesName string = 'default'
 param name string
 
 @description('Optional. The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5120 (5TB). For Large File Shares, the maximum size is 102400 (100TB).')
-param sharedQuota int = 5120
+param shareQuota int = 5120
 
 @allowed([
   'NFS'
@@ -56,7 +56,7 @@ resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2021-0
   name: name
   parent: storageAccount::fileService
   properties: {
-    shareQuota: sharedQuota
+    shareQuota: shareQuota
     rootSquash: enabledProtocols == 'NFS' ? rootSquash : null
     enabledProtocols: enabledProtocols
   }

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
@@ -39,7 +39,7 @@ This module deploys a storage account file share.
 | `enabledProtocols` | string | `'SMB'` | `[NFS, SMB]` | The authentication protocol that is used for the file share. Can only be specified when creating a share. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `rootSquash` | string | `'NoRootSquash'` | `[AllSquash, NoRootSquash, RootSquash]` | Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares. |
-| `sharedQuota` | int | `5120` |  | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5120 (5TB). For Large File Shares, the maximum size is 102400 (100TB). |
+| `shareQuota` | int | `5120` |  | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5120 (5TB). For Large File Shares, the maximum size is 102400 (100TB). |
 
 
 ### Parameter Usage: `roleAssignments`

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/shares/readme.md
@@ -39,7 +39,7 @@ This module deploys a storage account file share.
 | `enabledProtocols` | string | `'SMB'` | `[NFS, SMB]` | The authentication protocol that is used for the file share. Can only be specified when creating a share. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `rootSquash` | string | `'NoRootSquash'` | `[AllSquash, NoRootSquash, RootSquash]` | Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares. |
-| `sharedQuota` | int | `5120` |  | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400. |
+| `sharedQuota` | int | `5120` |  | The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5120 (5TB). For Large File Shares, the maximum size is 102400 (100TB). |
 
 
 ### Parameter Usage: `roleAssignments`

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/shares/version.json
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/shares/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }

--- a/modules/Microsoft.Storage/storageAccounts/fileServices/version.json
+++ b/modules/Microsoft.Storage/storageAccounts/fileServices/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -69,6 +69,7 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | `enableNfsV3` | bool | `False` |  | If true, enables NFS 3.0 support for the storage account. Requires enableHierarchicalNamespace to be true. |
 | `enableSftp` | bool | `False` |  | If true, enables Secure File Transfer Protocol for the storage account. Requires enableHierarchicalNamespace to be true. |
 | `fileServices` | _[fileServices](fileServices/readme.md)_ object | `{object}` |  | File service and shares to deploy. |
+| `largeFileSharesState` | string | `'Disabled'` | `[Disabled, Enabled]` | Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled. |
 | `localUsers` | _[localUsers](localUsers/readme.md)_ array | `[]` |  | Local users to deploy for SFTP authentication. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
@@ -483,10 +484,11 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
         }
         {
           name: 'avdprofiles2'
-          shareQuota: 5120
+          shareQuota: 102400
         }
       ]
     }
+    largeFileSharesState: 'Enabled'
     localUsers: [
       {
         hasSharedKey: false
@@ -692,10 +694,13 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
           },
           {
             "name": "avdprofiles2",
-            "shareQuota": 5120
+            "shareQuota": 102400
           }
         ]
       }
+    },
+    "largeFileSharesState": {
+      "value": "Enabled"
     },
     "localUsers": {
       "value": [

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -69,7 +69,7 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | `enableNfsV3` | bool | `False` |  | If true, enables NFS 3.0 support for the storage account. Requires enableHierarchicalNamespace to be true. |
 | `enableSftp` | bool | `False` |  | If true, enables Secure File Transfer Protocol for the storage account. Requires enableHierarchicalNamespace to be true. |
 | `fileServices` | _[fileServices](fileServices/readme.md)_ object | `{object}` |  | File service and shares to deploy. |
-| `largeFileSharesState` | string | `'Disabled'` | `[Disabled, Enabled]` | Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled. |
+| `largeFileSharesState` | string | `'Disabled'` | `[Disabled, Enabled]` | Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares). |
 | `localUsers` | _[localUsers](localUsers/readme.md)_ array | `[]` |  | Local users to deploy for SFTP authentication. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |

--- a/modules/Microsoft.Storage/storageAccounts/version.json
+++ b/modules/Microsoft.Storage/storageAccounts/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }


### PR DESCRIPTION
# Description

Adding option to enable Large File Shares only on Standard LRS and ZRS storage skus, where the option is supported
Fixing typo for quota parameter name on file shares child module
Updating common test to use the new parameter
Version update for storage, fileservices and shares due to input parameter renaming

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Storage: StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Ferikag%2F2570-largeshare)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
