### PR TITLE
[Fixes] Solve issue with WAF config in Application Gateway

### DIFF
--- a/modules/Microsoft.Network/applicationGateways/deploy.bicep
+++ b/modules/Microsoft.Network/applicationGateways/deploy.bicep
@@ -323,10 +323,11 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
       trustedClientCertificates: trustedClientCertificates
       trustedRootCertificates: trustedRootCertificates
       urlPathMaps: urlPathMaps
-      webApplicationFirewallConfiguration: webApplicationFirewallConfiguration
     }, (enableFips ? {
       enableFips: enableFips
-    } : {}), {})
+    } : {}),
+    (empty(webApplicationFirewallConfiguration) ? {} : { webApplicationFirewallConfiguration: webApplicationFirewallConfiguration })
+  )
   zones: zones
 }
 

--- a/modules/Microsoft.Network/applicationGateways/deploy.bicep
+++ b/modules/Microsoft.Network/applicationGateways/deploy.bicep
@@ -326,7 +326,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
     }, (enableFips ? {
       enableFips: enableFips
     } : {}),
-    (empty(webApplicationFirewallConfiguration) ? {} : { webApplicationFirewallConfiguration: webApplicationFirewallConfiguration })
+    (!empty(webApplicationFirewallConfiguration) ? { webApplicationFirewallConfiguration: webApplicationFirewallConfiguration }: {})
   )
   zones: zones
 }


### PR DESCRIPTION
# Description

When you deploy the Application Gateway with the SKU of 'VpnGwAZ' then this means the Application Gateway doesn't support WAF. 

With the current implementation, when no WAF setting are provided to the module the parameter is still added to the resources but with a 'null' value. When you try to deploy the module in this way, you will get an error that WAF is not supported in the SKU, even if the property is 'null'.

Solved this by not including the WAF config tag to the service when the module parameter is empty. This way you can deploy the Application Gateway with SKU of 'VpnGwV2' not including any WAF.

No dependencies required for this change.  

## Pipeline references

No pipeline changes

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
