### PR TITLE
[CI Environment] Create/Comment/Close issues for failing pipelines

### DIFF
--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -21,7 +21,7 @@ jobs:
         shell: pwsh
         run: |
           # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'manageIssueForFailingPipelines' 'New-IssuesForFailingPipelines.ps1')
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'manageIssueForFailingPipelines' 'New-IssuesForFailingPipelines.ps1')
 
           $functionInput = @{
             repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,12 +1,8 @@
 name: 'create/update/close issues for failing pipelines in main'
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - users/rahalan/AddIssueCreator
-  # schedule:
-  #   - cron:  '30 5 * * *'
+  schedule:
+    - cron: '30 5 * * *'
 jobs:
   manage-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,7 +1,10 @@
 name: 'create/update/close issues for failing pipelines in main'
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+  push:
+    branches:
+      - users/rahalan/AddIssueCreator
   # schedule:
   #   - cron:  '30 5 * * *'
 jobs:

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,8 +1,9 @@
 name: 'create/update/close issues for failing pipelines in main'
 
-on:
-  schedule:
-    - cron: '30 5 * * *'
+on: workflow_dispatch
+# on:
+#   schedule:
+#     - cron: '30 5 * * *'
 jobs:
   manage-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -20,10 +20,10 @@ jobs:
           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'manageIssueForFailingPipelines' 'New-IssuesForFailingPipelines.ps1')
 
           $functionInput = @{
-            repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
-            limitNumberOfRuns = 500
-            limitInDays = 2
-            ignorePipelines = @('AAD: DomainServices')
+            Repo              = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+            LimitNumberOfRuns = 500
+            LimitInDays       = 2
+            IgnoreWorkflows   = @('AAD: DomainServices')
           }
 
           Write-Verbose "Invoke task with" -Verbose

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -25,11 +25,11 @@ jobs:
 
           $functionInput = @{
             repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
-            limitNumberOfRuns = 10000
-            limitInDays = 70
+            limitNumberOfRuns = 500
+            limitInDays = 2
           }
 
           Write-Verbose "Invoke task with" -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          New-IssuesForFailingPipelines @functionInput -Verbose -WhatIf
+          New-IssuesForFailingPipelines @functionInput -Verbose # -WhatIf

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -17,7 +17,7 @@ jobs:
         shell: pwsh
         run: |
           # Load used functions
-          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'manageIssueForFailingPipelines' 'New-IssuesForFailingPipelines.ps1')
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'manageIssueForFailingPipelines' 'Set-IssueForWorkflow.ps1')
 
           $functionInput = @{
             Repo              = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
@@ -29,4 +29,4 @@ jobs:
           Write-Verbose "Invoke task with" -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          New-IssuesForFailingPipelines @functionInput -Verbose # -WhatIf
+          Set-IssueForWorkflow @functionInput -Verbose # -WhatIf

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,6 +1,9 @@
 name: 'create/update/close issues for failing pipelines in main'
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - users/rahalan/AddIssueCreator
 # on:
 #   schedule:
 #     - cron: '30 5 * * *'

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.PLATFORM_PROJECT_TOKEN }}
         name: Manage issues
         shell: pwsh
         run: |

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,0 +1,32 @@
+name: 'create/update/close issues for failing pipelines in main'
+
+on:
+  workflow_dispatch
+  # schedule:
+  #   - cron:  '30 5 * * *'
+jobs:
+  manage-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        name: Manage issues
+        shell: pwsh
+        run: |
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'manageIssueForFailingPipelines' 'New-IssuesForFailingPipelines.ps1')
+
+          $functionInput = @{
+            repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
+            limitNumberOfRuns = 100
+            limitInDays = 2
+          }
+
+          Write-Verbose "Invoke task with" -Verbose
+          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+
+          New-IssuesForFailingPipelines @functionInput -Verbose -WhatIf

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -25,8 +25,8 @@ jobs:
 
           $functionInput = @{
             repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
-            limitNumberOfRuns = 100
-            limitInDays = 2
+            limitNumberOfRuns = 10000
+            limitInDays = 70
           }
 
           Write-Verbose "Invoke task with" -Verbose

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,4 +1,4 @@
-name: 'create/update/close issues for failing pipelines in main'
+name: '.Platform: Manage issues for failing pipelines'
 
 on:
   schedule:

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -2,7 +2,7 @@ name: 'create/update/close issues for failing pipelines in main'
 
 on:
   schedule:
-    - cron: '30 5 * * *'
+    - cron: '30 5 * * *' # Every day at 5:30 am
 jobs:
   manage-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -1,12 +1,8 @@
 name: 'create/update/close issues for failing pipelines in main'
 
 on:
-  push:
-    branches:
-      - users/rahalan/AddIssueCreator
-# on:
-#   schedule:
-#     - cron: '30 5 * * *'
+  schedule:
+    - cron: '30 5 * * *'
 jobs:
   manage-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/platform.ManageIssueForFailingPipelines.yml
+++ b/.github/workflows/platform.ManageIssueForFailingPipelines.yml
@@ -23,6 +23,7 @@ jobs:
             repo = "${{ github.repository_owner }}/${{ github.event.repository.name }}"
             limitNumberOfRuns = 500
             limitInDays = 2
+            ignorePipelines = @('AAD: DomainServices')
           }
 
           Write-Verbose "Invoke task with" -Verbose

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -45,9 +45,7 @@ function New-IssuesForFailingPipelines {
 
         if (($run.headBranch -eq 'main') -and ($runStartTime -gt (Get-Date).AddDays(-$limitInDays))) {
             $runId = $run.url.Split('/') | Select-Object -Last 1
-            Write-Verbose '#2'
-            $runDetails = gh run view $runId --json conclusion, number --repo $repo | ConvertFrom-Json -Depth 100
-            Write-Verbose '#3'
+            $runDetails = gh run view $runId --json 'conclusion,number' --repo $repo | ConvertFrom-Json -Depth 100
 
             if (!$workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
                 $workflowRun = New-Object PSObject -Property @{

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -33,8 +33,8 @@ function New-IssuesForFailingPipelines {
         [int] $limitInDays = 2
     )
 
-    $issues = gh issue list --state open --label 'automation,bug' --json title, url, body, comments --repo $repo | ConvertFrom-Json -Depth 100
-    $runs = gh run list --json url, workflowName, headBranch, startedAt --limit $limitNumberOfRuns --repo $repo | ConvertFrom-Json -Depth 100
+    $issues = gh issue list --state open --label 'automation,bug' --json title,url,body,comments --repo $repo | ConvertFrom-Json -Depth 100
+    $runs = gh run list --json url,workflowName,headBranch,startedAt --limit $limitNumberOfRuns --repo $repo | ConvertFrom-Json -Depth 100
     $workflowRuns = @{}
     $issuesCreated = 0
     $issuesCommented = 0

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -76,7 +76,7 @@ function New-IssuesForFailingPipelines {
             $failedrun = "failed run: $($workflowRun.url)"
 
             if ($issues.title -notcontains $issueName) {
-                if ($PSCmdlet.ShouldProcess("$issueName", 'create')) {
+                if ($PSCmdlet.ShouldProcess("Issue [$issueName]", 'Create')) {
                     gh issue create --title "$issueName" --body "$failedrun" --label 'automation,bug' --repo $repo
                 }
 

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -5,13 +5,13 @@ Check for failing pipelines and create issues for those, that are failing.
 .DESCRIPTION
 If a pipeline fails, a new issue will be created, with a link to the failed pipeline. If the issue is already existing, a comment will be added, if a new run failed (with the link for the new failed run). If a pipeline run succeeds and an issue is open for the failed run, it will be closed (and a link to the successful run is added to the issue).
 
-.PARAMETER repo
-Needs to have the structure "owner/repositioryName"
+.PARAMETER Repo
+Mandatory. The name of the respository to scan. Needs to have the structure "<owner>/<repositioryName>"
 
-.PARAMETER limitNumberOfRuns
+.PARAMETER LimitNumberOfRuns
 Optional. Number of recent runs to scan for failed runs. Default is 100.
 
-.PARAMETER limitInDays
+.PARAMETER LimitInDays
 Optional. Only runs in the past selected days will be analyzed. Default is 2.
 
 .PARAMETER ignorePipelines

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -1,0 +1,114 @@
+﻿<#
+.SYNOPSIS
+Check for failing pipelines and create issues for those, that are failing.
+
+.DESCRIPTION
+If a pipeline fails, a new issue will be created, with a link to the failed pipeline. If the issue is already existing, a comment will be added, if a new run failed (with the link for the new failed run). If a pipeline run succeeds and a issue is open for the failed run, it will be closed (and a link to the successful run is added to the issue).
+
+.PARAMETER repo
+Needs to have the structure "owner/repositioryName"
+
+.PARAMETER limitNumberOfRuns
+Optional. Number of recent runs to scan for failed runs. Default is 100.
+
+.PARAMETER limitInDays
+Optional. Only runs in the past selected days will be analyzed. Default is 2.
+
+.EXAMPLE
+New-IssuesForFailingPipelines -repo 'owner/repo01' -limitNumberOfRuns 100 -limitInDays 2 -Verbose -WhatIf
+
+.NOTES
+The function supports -WhatIf
+#>
+function New-IssuesForFailingPipelines {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $repo,
+
+        [Parameter(Mandatory = $false)]
+        [int] $limitNumberOfRuns = 100,
+
+        [Parameter(Mandatory = $false)]
+        [int] $limitInDays = 2
+    )
+
+    $issues = gh issue list --state open --label 'automation,bug' --json title, url, body, comments --repo $repo | ConvertFrom-Json -Depth 100
+    $runs = gh run list --json url, workflowName, headBranch, startedAt --limit $limitNumberOfRuns --repo $repo | ConvertFrom-Json -Depth 100
+    $workflowRuns = @{}
+    $issuesCreated = 0
+    $issuesCommented = 0
+    $issuesClosed = 0
+
+    foreach ($run in $runs) {
+        $runStartTime = [Datetime]::ParseExact($run.startedAt, 'MM/dd/yyyy HH:mm:ss', $null)
+
+        if (($run.headBranch -eq 'main') -and ($runStartTime -gt (Get-Date).AddDays(-$limitInDays))) {
+            $runId = $run.url.Split('/') | Select-Object -Last 1
+            $runDetails = gh run view $runId --json conclusion, number --repo $repo | ConvertFrom-Json -Depth 100
+
+            if (!$workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
+                $workflowRun = New-Object PSObject -Property @{
+                    workflowName = $run.workflowName
+                    number       = $runDetails.number
+                    url          = $run.url
+                    conclusion   = $runDetails.conclusion
+                }
+
+                if (!$workflowRuns.ContainsKey($run.workflowName)) {
+                    $workflowRuns.Add($run.workflowName, $workflowRun)
+                } else {
+                    $workflowRuns[$run.workflowName] = $workflowRun
+                }
+            }
+        }
+    }
+
+    foreach ($workflowRun in $workflowRuns.values) {
+        if ($workflowRun.conclusion -eq 'failure') {
+            $issueName = "[Failed pipeline] $($workflowRun.workflowName)"
+            $failedrun = "failed run: $($workflowRun.url)"
+
+            if ($issues.title -notcontains $issueName) {
+                if ($PSCmdlet.ShouldProcess("$issueName", 'create')) {
+                    gh issue create --title "$issueName" --body "$failedrun" --label 'automation,bug' --repo $repo
+                }
+
+                $issuesCreated++
+            } else {
+                $issue = ($issues | Where-Object { $_.title -eq $issueName })[0]
+
+                if (!$issue.body.Contains($failedrun)) {
+                    if ($issue.comments.length -eq 0) {
+                        if ($PSCmdlet.ShouldProcess("$issueName", 'comment')) {
+                            gh issue comment $issue.url --body $failedrun --repo $repo
+                        }
+
+                        $issuesCommented++
+                    } else {
+                        if (!$issue.comments.body.Contains($failedrun)) {
+                            if ($PSCmdlet.ShouldProcess("$issueName", 'close')) {
+                                gh issue comment $issue.url --body $failedrun --repo $repo
+                            }
+
+                            $issuesCommented++
+                        }
+                    }
+                }
+            }
+        } else {
+            $issueName = "[Failed pipeline] $($workflowRun.workflowName)"
+
+            if ($issues.title -contains $issueName) {
+                $issue = ($issues | Where-Object { $_.title -eq $issueName })[0]
+                $successfulrun = "successful run: $($workflowRun.url)"
+                gh issue close $issue.url --comment $successfulrun --repo $repo
+                $issuesClosed++
+            }
+        }
+    }
+
+    Write-Verbose ('[{0}] issue(s){1} created' -f $issuesCreated, $($WhatIfPreference ? ' would have been' : ''))
+    Write-Verbose ('[{0}] issue(s){1} commented' -f $issuesCommented, $($WhatIfPreference ? ' would have been' : ''))
+    Write-Verbose ('[{0}] issue(s){1} closed' -f $issuesClosed, $($WhatIfPreference ? ' would have been' : ''))
+}

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -19,9 +19,6 @@ Optional. List of pipeline names that should be ignored (even if they fail, no t
 
 .EXAMPLE
 New-IssuesForFailingPipelines -repo 'owner/repo01' -limitNumberOfRuns 100 -limitInDays 2 -Verbose -WhatIf
-
-.NOTES
-The function supports -WhatIf
 #>
 function New-IssuesForFailingPipelines {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -3,7 +3,7 @@
 Check for failing pipelines and create issues for those, that are failing.
 
 .DESCRIPTION
-If a pipeline fails, a new issue will be created, with a link to the failed pipeline. If the issue is already existing, a comment will be added, if a new run failed (with the link for the new failed run). If a pipeline run succeeds and a issue is open for the failed run, it will be closed (and a link to the successful run is added to the issue).
+If a pipeline fails, a new issue will be created, with a link to the failed pipeline. If the issue is already existing, a comment will be added, if a new run failed (with the link for the new failed run). If a pipeline run succeeds and an issue is open for the failed run, it will be closed (and a link to the successful run is added to the issue).
 
 .PARAMETER repo
 Needs to have the structure "owner/repositioryName"

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -86,7 +86,7 @@ function New-IssuesForFailingPipelines {
 
                 if (!$issue.body.Contains($failedrun)) {
                     if ($issue.comments.length -eq 0) {
-                        if ($PSCmdlet.ShouldProcess("$issueName", 'comment')) {
+                        if ($PSCmdlet.ShouldProcess("Issue [$issueName]", 'Add comment')) {
                             gh issue comment $issue.url --body $failedrun --repo $repo
                         }
 

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -50,7 +50,7 @@ function New-IssuesForFailingPipelines {
             $runId = $run.url.Split('/') | Select-Object -Last 1
             $runDetails = gh run view $runId --json 'conclusion,number' --repo $repo | ConvertFrom-Json -Depth 100
 
-            if (!$workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
+            if (-not $workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
                 $workflowRun = New-Object PSObject -Property @{
                     workflowName = $run.workflowName
                     number       = $runDetails.number

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -39,7 +39,6 @@ function New-IssuesForFailingPipelines {
     $issuesCreated = 0
     $issuesCommented = 0
     $issuesClosed = 0
-    Write-Verbose '#1'
 
     foreach ($run in $runs) {
         $runStartTime = [Datetime]::ParseExact($run.startedAt, 'MM/dd/yyyy HH:mm:ss', $null)
@@ -48,6 +47,7 @@ function New-IssuesForFailingPipelines {
             $runId = $run.url.Split('/') | Select-Object -Last 1
             Write-Verbose '#2'
             $runDetails = gh run view $runId --json conclusion, number --repo $repo | ConvertFrom-Json -Depth 100
+            Write-Verbose '#3'
 
             if (!$workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
                 $workflowRun = New-Object PSObject -Property @{
@@ -58,10 +58,8 @@ function New-IssuesForFailingPipelines {
                 }
 
                 if (!$workflowRuns.ContainsKey($run.workflowName)) {
-                    Write-Verbose '#3'
                     $workflowRuns.Add($run.workflowName, $workflowRun)
                 } else {
-                    Write-Verbose '#4'
                     $workflowRuns[$run.workflowName] = $workflowRun
                 }
             }
@@ -69,7 +67,6 @@ function New-IssuesForFailingPipelines {
     }
 
     foreach ($workflowRun in $workflowRuns.values) {
-        Write-Verbose '#5'
         if ($workflowRun.conclusion -eq 'failure') {
             $issueName = "[Failed pipeline] $($workflowRun.workflowName)"
             $failedrun = "failed run: $($workflowRun.url)"

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -93,7 +93,7 @@ function New-IssuesForFailingPipelines {
                         $issuesCommented++
                     } else {
                         if (!$issue.comments.body.Contains($failedrun)) {
-                            if ($PSCmdlet.ShouldProcess("$issueName", 'close')) {
+                            if ($PSCmdlet.ShouldProcess("Issue [$issueName]", 'Close')) {
                                 gh issue comment $issue.url --body $failedrun --repo $repo
                             }
 

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -33,8 +33,8 @@ function New-IssuesForFailingPipelines {
         [int] $limitInDays = 2
     )
 
-    $issues = gh issue list --state open --label 'automation,bug' --json title,url,body,comments --repo $repo | ConvertFrom-Json -Depth 100
-    $runs = gh run list --json url,workflowName,headBranch,startedAt --limit $limitNumberOfRuns --repo $repo | ConvertFrom-Json -Depth 100
+    $issues = gh issue list --state open --label 'automation,bug' --json 'title,url,body,comments' --repo $repo | ConvertFrom-Json -Depth 100
+    $runs = gh run list --json 'url,workflowName,headBranch,startedAt' --limit $limitNumberOfRuns --repo $repo | ConvertFrom-Json -Depth 100
     $workflowRuns = @{}
     $issuesCreated = 0
     $issuesCommented = 0

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -39,12 +39,14 @@ function New-IssuesForFailingPipelines {
     $issuesCreated = 0
     $issuesCommented = 0
     $issuesClosed = 0
+    Write-Verbose '#1'
 
     foreach ($run in $runs) {
         $runStartTime = [Datetime]::ParseExact($run.startedAt, 'MM/dd/yyyy HH:mm:ss', $null)
 
         if (($run.headBranch -eq 'main') -and ($runStartTime -gt (Get-Date).AddDays(-$limitInDays))) {
             $runId = $run.url.Split('/') | Select-Object -Last 1
+            Write-Verbose '#2'
             $runDetails = gh run view $runId --json conclusion, number --repo $repo | ConvertFrom-Json -Depth 100
 
             if (!$workflowRuns.ContainsKey($run.workflowName) -or $runDetails.number -gt $workflowRuns[$run.workflowName].number) {
@@ -56,8 +58,10 @@ function New-IssuesForFailingPipelines {
                 }
 
                 if (!$workflowRuns.ContainsKey($run.workflowName)) {
+                    Write-Verbose '#3'
                     $workflowRuns.Add($run.workflowName, $workflowRun)
                 } else {
+                    Write-Verbose '#4'
                     $workflowRuns[$run.workflowName] = $workflowRun
                 }
             }
@@ -65,6 +69,7 @@ function New-IssuesForFailingPipelines {
     }
 
     foreach ($workflowRun in $workflowRuns.values) {
+        Write-Verbose '#5'
         if ($workflowRun.conclusion -eq 'failure') {
             $issueName = "[Failed pipeline] $($workflowRun.workflowName)"
             $failedrun = "failed run: $($workflowRun.url)"

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -20,6 +20,8 @@ Optional. List of workflow names that should be ignored (even if they fail, no t
 .EXAMPLE
 New-IssuesForFailingPipelines -Repo 'owner/repo01' -LimitNumberOfRuns 100 -LimitInDays 2 -IgnoreWorkflows @('Pipeline 01')
 
+Check the last 100 workflow runs in the repository 'owner/repo01' that happened in the last 2 days. If the workflow name is 'Pipeline 01', then ignore the workflow run.
+
 .NOTES
 The function requires GitHub CLI to be installed.
 #>

--- a/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/New-IssuesForFailingPipelines.ps1
@@ -58,7 +58,7 @@ function New-IssuesForFailingPipelines {
                     conclusion   = $runDetails.conclusion
                 }
 
-                if (!$workflowRuns.ContainsKey($run.workflowName)) {
+                if (-not $workflowRuns.ContainsKey($run.workflowName)) {
                     $workflowRuns.Add($run.workflowName, $workflowRun)
                 } else {
                     $workflowRuns[$run.workflowName] = $workflowRun

--- a/utilities/pipelines/manageIssueForFailingPipelines/Set-IssueForWorkflow.ps1
+++ b/utilities/pipelines/manageIssueForFailingPipelines/Set-IssueForWorkflow.ps1
@@ -18,14 +18,14 @@ Optional. Only runs in the past selected days will be analyzed. Default is 2.
 Optional. List of workflow names that should be ignored (even if they fail, no ticket will be created). Default is an empty array.
 
 .EXAMPLE
-New-IssuesForFailingPipelines -Repo 'owner/repo01' -LimitNumberOfRuns 100 -LimitInDays 2 -IgnoreWorkflows @('Pipeline 01')
+Set-IssueForWorkflow -Repo 'owner/repo01' -LimitNumberOfRuns 100 -LimitInDays 2 -IgnoreWorkflows @('Pipeline 01')
 
 Check the last 100 workflow runs in the repository 'owner/repo01' that happened in the last 2 days. If the workflow name is 'Pipeline 01', then ignore the workflow run.
 
 .NOTES
 The function requires GitHub CLI to be installed.
 #>
-function New-IssuesForFailingPipelines {
+function Set-IssueForWorkflow {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
# Description

Adding a new pipeline that will run once a day and create issues for failing pipelines. If the issue is already in place, then a comment will be added, if it is a newer failed run. If the pipeline succeeds and an issue is open, it will be closed. See #2287 

## Pipeline references

| Pipeline |
| - |
| [![create/update/close issues for failing pipelines in main](https://github.com/Azure/ResourceModules/actions/workflows/platform.ManageIssueForFailingPipelines.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/platform.ManageIssueForFailingPipelines.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
