### PR TITLE
[CI Environment] Implemented name shortening for TemplateSpecs artifacts & extended docs

### DIFF
--- a/docs/wiki/The CI environment - Publishing.md
+++ b/docs/wiki/The CI environment - Publishing.md
@@ -54,7 +54,7 @@ The names of published modules differ slighly depending on the location they are
 
 - Make lowercase
 - Replace all `\` or `/` with `.`
-- Add the `bicep\modules` prefix
+- Add the `bicep/modules` prefix
 
 **Examples**
 

--- a/docs/wiki/The CI environment - Publishing.md
+++ b/docs/wiki/The CI environment - Publishing.md
@@ -31,6 +31,7 @@ The names of published modules differ slighly depending on the location they are
 
 **Actions**
 
+- Remove the root folder name `modules` from provided module reference
 - Make lowercase
 - Replace `Microsoft` with `MS`
 - Replace all `\` or `/` with `.`
@@ -52,6 +53,7 @@ The names of published modules differ slighly depending on the location they are
 
 **Actions**
 
+- Remove the root folder name `modules` from provided module reference
 - Make lowercase
 - Replace all `\` or `/` with `.`
 - Add the `bicep/modules` prefix
@@ -72,6 +74,7 @@ The names of published modules differ slighly depending on the location they are
 
 **Actions**
 
+- Remove the root folder name `modules` from provided module reference
 - Make lowercase
 - Replace all `\` or `/` with `.`
 

--- a/docs/wiki/The CI environment - Publishing.md
+++ b/docs/wiki/The CI environment - Publishing.md
@@ -39,10 +39,10 @@ The names of published modules differ slighly depending on the location they are
 **Examples**
 
   - Vaults
-    - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+    - Before: `modules\Microsoft.RecoveryServices\vaults`
     - After: `ms.recoveryservices.vaults`
   - ReplicationProtectionContainerMappings
-    - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+    - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings`
     - After: `ms.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.mappings`
 
 </details>
@@ -59,10 +59,10 @@ The names of published modules differ slighly depending on the location they are
 **Examples**
 
 - Vaults
-   - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+   - Before: `modules\Microsoft.RecoveryServices\vaults`
    - After: `bicep/modules/microsoft.recoveryservices.vaults`
 - ReplicationProtectionContainerMappings
-   - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+   - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings`
    - After: `bicep/modules/microsoft.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.replicationprotectioncontainermappings`
 
 </details>
@@ -78,10 +78,10 @@ The names of published modules differ slighly depending on the location they are
 **Examples**
 
 - Vaults
-  - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+  - Before: `modules\Microsoft.RecoveryServices\vaults`
   - After: `microsoft.recoveryservices.vaults`
 - ReplicationProtectionContainerMappings
-  - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+  - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings`
   - After: `microsoft.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.replicationprotectioncontainermappings`
 
 </details>

--- a/docs/wiki/The CI environment - Publishing.md
+++ b/docs/wiki/The CI environment - Publishing.md
@@ -1,6 +1,7 @@
 This section provides an overview of the principles the publishing is built upon, how it is set up, and how you can interact with it.
 
 - [Publishing overview](#publishing-overview)
+- [Module identifiers](#module-identifiers)
 - [How it works](#how-it-works)
   - [Example scenario](#example-scenario)
   - [Output example](#output-example)
@@ -17,10 +18,13 @@ The publishing phase concludes each module's pipeline. If all previous tests suc
 
 Besides the publishing phase's runtime, there is also the possibility to set the switch `Publish prerelease module`. This switch makes it possible to publish a prerelease version in every workflow run that is not based on `main` or `master`. This can be controlled when running the module pipeline leveraging [Module pipeline inputs](./The%20CI%20environment%20-%20Pipeline%20design#module-pipeline-inputs).
 
-> **Note**<br>
-> The `version` used for publishing any artifact is the same for all three target locations, which reduces the maintenance effort.
+> **Note**: The `version` used for publishing any artifact is the same for all three target locations, which reduces the maintenance effort.
 
 > **Note:** The orchestration options described in the [solution creation](./Solution%20creation) section work differently well with the publishing locations we offer in CARML. To help you select the best location for your use case, we provide further information [here](./Solution%20creation#publish-location-considerations) section.
+
+## Module identifiers
+
+The names of published modules differ slighly depending on the location they are published to. This is rooted in the different requirements per target location. In the following you can find the rules applied for each:
 
 # How it works
 
@@ -36,6 +40,7 @@ The publishing works as follows:
          > Example: Using the Bicep registry, the reference to a `major.minor` could look like: `br/modules:microsoft.resources.resourcegroups:0.4` which means that the template will always consume whatever the potentially overwritten/updated version `0.4` contains.
    1. For a changed child module, the direct parent hierarchy is also registered for an update, following the same procedure as above.
    1. The list of module files paths and their versions are passed on as a array list.
+1. The [Get-ModulesMissingFrom*.ps1](https://github.com/Azure/ResourceModules/tree/main/utilities/pipelines/resourcePublish) scripts further check if a given module is missing from the corresponding target location (e.g., Azure Container Registry) and adds each missing entry to to aforementioned array - using the version specified in the module's `version.json` file.
 1. The different publishing scripts run (Artifact, Template Spec or Bicep Registry) and publish the module to the respective target location for each item on the list.
 
 ## Example scenario

--- a/docs/wiki/The CI environment - Publishing.md
+++ b/docs/wiki/The CI environment - Publishing.md
@@ -26,6 +26,68 @@ Besides the publishing phase's runtime, there is also the possibility to set the
 
 The names of published modules differ slighly depending on the location they are published to. This is rooted in the different requirements per target location. In the following you can find the rules applied for each:
 
+<details>
+<summary>Template Specs</summary>
+
+**Actions**
+
+- Make lowercase
+- Replace `Microsoft` with `MS`
+- Replace all `\` or `/` with `.`
+- Remove all duplications in the path. For example, the path `virtualNetwork/virtualNetworkPeerings` would be shortened to `virtualNetwork/peerings`
+
+**Examples**
+
+  - Vaults
+    - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+    - After: `ms.recoveryservices.vaults`
+  - ReplicationProtectionContainerMappings
+    - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+    - After: `ms.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.mappings`
+
+</details>
+
+<details>
+<summary>Private Bicep Registry (Azure Container Registry)</summary>
+
+**Actions**
+
+- Make lowercase
+- Replace all `\` or `/` with `.`
+- Add the `bicep\modules` prefix
+
+**Examples**
+
+- Vaults
+   - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+   - After: `bicep/modules/microsoft.recoveryservices.vaults`
+- ReplicationProtectionContainerMappings
+   - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+   - After: `bicep/modules/microsoft.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.replicationprotectioncontainermappings`
+
+</details>
+
+<details>
+<summary>Azure DevOps Universal Packages</summary>
+
+**Actions**
+
+- Make lowercase
+- Replace all `\` or `/` with `.`
+
+**Examples**
+
+- Vaults
+  - Before: `modules\Microsoft.RecoveryServices\vaults\deploy.bicep`
+  - After: `microsoft.recoveryservices.vaults`
+- ReplicationProtectionContainerMappings
+  - Before: `modules\Microsoft.RecoveryServices\vaults\replicationFabrics\replicationProtectionContainers\replicationProtectionContainerMappings\deploy.bicep`
+  - After: `microsoft.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.replicationprotectioncontainermappings`
+
+</details>
+
+<p>
+
 # How it works
 
 The publishing works as follows:

--- a/settings.yml
+++ b/settings.yml
@@ -55,7 +55,6 @@ variables:
 
   publishLatest: true # [Only for Template-Specs & Bicep Registry] Publish an absolute latest version. Note: This version may include breaking changes and is not recommended for production environments
 
-
   # Template-Spec settings #
   # ---------------------- #
 

--- a/settings.yml
+++ b/settings.yml
@@ -55,6 +55,7 @@ variables:
 
   publishLatest: true # [Only for Template-Specs & Bicep Registry] Publish an absolute latest version. Note: This version may include breaking changes and is not recommended for production environments
 
+
   # Template-Spec settings #
   # ---------------------- #
 

--- a/utilities/pipelines/resourcePublish/Get-UniversalArtifactsName.ps1
+++ b/utilities/pipelines/resourcePublish/Get-UniversalArtifactsName.ps1
@@ -24,7 +24,7 @@ function Get-UniversalArtifactsName {
 
     $ModuleFolderPath = Split-Path $TemplateFilePath -Parent
     $universalPackageModuleName = $ModuleFolderPath.Replace('\', '/').Split('/modules/')[1]
-    $universalPackageModuleName = ($universalPackageModuleName.Replace('\', '.').Replace('/', '.').toLower() -Replace '[^a-z0-9\.\-_]')[0..255] -join ''
+    $universalPackageModuleName = $universalPackageModuleName.Replace('\', '.').Replace('/', '.').toLower()
 
     return $universalPackageModuleName
 }


### PR DESCRIPTION
# Description

- Implemented name shortening for TemplateSpecs artifacts
- Extended docs
- Removed some old code from the ADO Artifacts generation that would, for example, cut their name at 255 characters

Successfull RSV publishing with shortened name:
![image](https://user-images.githubusercontent.com/5365358/213707758-d99254dd-3ff2-461c-a535-460a2cd77897.png)


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![KeyVault: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Falsehr%2F1172_publish)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml) |
| [![RecoveryServices: Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml/badge.svg?branch=users%2Falsehr%2F1172_publish)](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
