### PR TITLE
[Fixes] Fixed template spec name gen & added documentation

### DIFF
--- a/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
+++ b/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
@@ -37,7 +37,7 @@ function Get-TemplateSpecsName {
 
             # If a name is replicated in a path, it is usually plural in the parent, and singular in the child path.
             # For example: /virtualNetworks/ (plural) & /virtualNetworks/virtualNetworkPeerings/ (singular)
-            # In this case we want to remove the signular version from the subsequent string & format it accordingly
+            # In this case we want to remove the singular version from the subsequent string & format it accordingly
             if ($stringToRemove.EndsWith('s') -and $stringToCheck.StartsWith($stringToRemove.Substring(0, $stringToRemove.length - 1))) {
                 $singularString = $stringToRemove.Substring(0, $stringToRemove.length - 1)
                 $rest = $stringToCheck.length - $singularString.Length

--- a/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
+++ b/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
@@ -29,7 +29,7 @@ function Get-TemplateSpecsName {
     # This is requried as certain modules generate names such as `MS.RecoveryServices.vaults.replicationFabrics.replicationProtectionContainers.replicationProtectionContainerMappings` which are longer than the allowed 90 characters for template specs
     # Using the logic below, the name is shortened to `MS.RecoveryServices.vaults.replicationFabrics.replicationProtectionContainers.Mappings` which has 'only' 86 characters
     $nameElems = $templateSpecIdentifier -split '\.'
-    # Staring at index 2 to skip the resource provider
+    # Starting at index 2 to skip the resource provider
     for ($index = 2; $index -lt $nameElems.Count; $index++) {
         if ($index -lt ($nameElems.count - 1)) {
             $stringToRemove = $nameElems[($index)]

--- a/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
+++ b/utilities/pipelines/resourcePublish/Get-TemplateSpecsName.ps1
@@ -29,11 +29,15 @@ function Get-TemplateSpecsName {
     # This is requried as certain modules generate names such as `MS.RecoveryServices.vaults.replicationFabrics.replicationProtectionContainers.replicationProtectionContainerMappings` which are longer than the allowed 90 characters for template specs
     # Using the logic below, the name is shortened to `MS.RecoveryServices.vaults.replicationFabrics.replicationProtectionContainers.Mappings` which has 'only' 86 characters
     $nameElems = $templateSpecIdentifier -split '\.'
-    for ($index = 0; $index -lt $nameElems.Count; $index++) {
+    # Staring at index 2 to skip the resource provider
+    for ($index = 2; $index -lt $nameElems.Count; $index++) {
         if ($index -lt ($nameElems.count - 1)) {
             $stringToRemove = $nameElems[($index)]
             $stringToCheck = $nameElems[($index + 1)]
 
+            # If a name is replicated in a path, it is usually plural in the parent, and singular in the child path.
+            # For example: /virtualNetworks/ (plural) & /virtualNetworks/virtualNetworkPeerings/ (singular)
+            # In this case we want to remove the signular version from the subsequent string & format it accordingly
             if ($stringToRemove.EndsWith('s') -and $stringToCheck.StartsWith($stringToRemove.Substring(0, $stringToRemove.length - 1))) {
                 $singularString = $stringToRemove.Substring(0, $stringToRemove.length - 1)
                 $rest = $stringToCheck.length - $singularString.Length


### PR DESCRIPTION
# Description

- Update the TemplateSpec name generation to bypass the ProviderNamespace as it caused issues for some resource types
- Added some documentation

<details>
<summary>Test run</summary>

- ms.aad.domainservices
- ms.analysisservices.servers
- ms.apimanagement.service
- ms.apimanagement.service.apis
- ms.apimanagement.service.apis.policies
- ms.apimanagement.service.apiversionsets
- ms.apimanagement.service.authorizationservers
- ms.apimanagement.service.backends
- ms.apimanagement.service.caches
- ms.apimanagement.service.identityproviders
- ms.apimanagement.service.namedvalues
- ms.apimanagement.service.policies
- ms.apimanagement.service.portalsettings
- ms.apimanagement.service.products
- ms.apimanagement.service.products.apis
- ms.apimanagement.service.products.groups
- ms.apimanagement.service.subscriptions
- ms.appconfiguration.configurationstores
- ms.appconfiguration.configurationstores.keyvalues
- ms.authorization.locks
- ms.authorization.locks.resourcegroup
- ms.authorization.locks.subscription
- ms.authorization.policyassignments
- ms.authorization.policyassignments.managementgroup
- ms.authorization.policyassignments.resourcegroup
- ms.authorization.policyassignments.subscription
- ms.authorization.policydefinitions
- ms.authorization.policydefinitions.managementgroup
- ms.authorization.policydefinitions.subscription
- ms.authorization.policyexemptions
- ms.authorization.policyexemptions.managementgroup
- ms.authorization.policyexemptions.resourcegroup
- ms.authorization.policyexemptions.subscription
- ms.authorization.policysetdefinitions
- ms.authorization.policysetdefinitions.managementgroup
- ms.authorization.policysetdefinitions.subscription
- ms.authorization.roleassignments
- ms.authorization.roleassignments.managementgroup
- ms.authorization.roleassignments.resourcegroup
- ms.authorization.roleassignments.subscription
- ms.authorization.roledefinitions
- ms.authorization.roledefinitions.managementgroup
- ms.authorization.roledefinitions.resourcegroup
- ms.authorization.roledefinitions.subscription
- ms.automation.automationaccounts
- ms.automation.automationaccounts.jobschedules
- ms.automation.automationaccounts.modules
- ms.automation.automationaccounts.runbooks
- ms.automation.automationaccounts.schedules
- ms.automation.automationaccounts.softwareupdateconfigurations
- ms.automation.automationaccounts.variables
- ms.batch.batchaccounts
- ms.cache.redis
- ms.cdn.profiles
- ms.cdn.profiles.endpoints
- ms.cdn.profiles.endpoints.origins
- ms.cognitiveservices.accounts
- ms.compute.availabilitysets
- ms.compute.diskencryptionsets
- ms.compute.disks
- ms.compute.galleries
- ms.compute.galleries.applications
- ms.compute.galleries.images
- ms.compute.images
- ms.compute.proximityplacementgroups
- ms.compute.virtualmachines
- ms.compute.virtualmachines.extensions
- ms.compute.virtualmachinescalesets
- ms.compute.virtualmachinescalesets.extensions
- ms.consumption.budgets
- ms.containerinstance.containergroups
- ms.containerregistry.registries
- ms.containerregistry.registries.replications
- ms.containerregistry.registries.webhooks
- ms.containerservice.managedclusters
- ms.containerservice.managedclusters.agentpools
- ms.databricks.workspaces
- ms.datafactory.factories
- ms.datafactory.factories.integrationruntimes
- ms.datafactory.factories.managedvirtualnetworks
- ms.datafactory.factories.managedvirtualnetworks.managedprivateendpoints
- ms.dataprotection.backupvaults
- ms.dataprotection.backupvaults.backuppolicies
- ms.dbforpostgresql.flexibleservers
- ms.dbforpostgresql.flexibleservers.configurations
- ms.dbforpostgresql.flexibleservers.databases
- ms.dbforpostgresql.flexibleservers.firewallrules
- ms.desktopvirtualization.applicationgroups
- ms.desktopvirtualization.applicationgroups.applications
- ms.desktopvirtualization.hostpools
- ms.desktopvirtualization.scalingplans
- ms.desktopvirtualization.workspaces
- ms.devtestlab.labs
- ms.devtestlab.labs.artifactsources
- ms.devtestlab.labs.costs
- ms.devtestlab.labs.notificationchannels
- ms.devtestlab.labs.policysets.policies
- ms.devtestlab.labs.schedules
- ms.devtestlab.labs.virtualnetworks
- ms.documentdb.databaseaccounts
- ms.documentdb.databaseaccounts.gremlindatabases
- ms.documentdb.databaseaccounts.gremlindatabases.graphs
- ms.documentdb.databaseaccounts.mongodbdatabases
- ms.documentdb.databaseaccounts.mongodbdatabases.collections
- ms.documentdb.databaseaccounts.sqldatabases
- ms.documentdb.databaseaccounts.sqldatabases.containers
- ms.eventgrid.domains
- ms.eventgrid.eventsubscriptions
- ms.eventgrid.systemtopics
- ms.eventgrid.topics
- ms.eventhub.namespaces
- ms.eventhub.namespaces.authorizationrules
- ms.eventhub.namespaces.disasterrecoveryconfigs
- ms.eventhub.namespaces.eventhubs
- ms.eventhub.namespaces.eventhubs.authorizationrules
- ms.eventhub.namespaces.eventhubs.consumergroups
- ms.eventhub.namespaces.networkrulesets
- ms.healthbot.healthbots
- ms.insights.actiongroups
- ms.insights.activitylogalerts
- ms.insights.components
- ms.insights.diagnosticsettings
- ms.insights.metricalerts
- ms.insights.privatelinkscopes
- ms.insights.privatelinkscopes.scopedresources
- ms.insights.scheduledqueryrules
- ms.keyvault.vaults
- ms.keyvault.vaults.accesspolicies
- ms.keyvault.vaults.keys
- ms.keyvault.vaults.secrets
- ms.kubernetesconfiguration.extensions
- ms.kubernetesconfiguration.fluxconfigurations
- ms.logic.workflows
- ms.machinelearningservices.workspaces
- ms.machinelearningservices.workspaces.computes
- ms.maintenance.maintenanceconfigurations
- ms.managedidentity.userassignedidentities
- ms.managedservices.registrationdefinitions
- ms.management.managementgroups
- ms.netapp.netappaccounts
- ms.netapp.netappaccounts.capacitypools
- ms.netapp.netappaccounts.capacitypools.volumes
- ms.network.applicationgateways
- ms.network.applicationgatewaywebapplicationfirewallpolicies
- ms.network.applicationsecuritygroups
- ms.network.azurefirewalls
- ms.network.bastionhosts
- ms.network.connections
- ms.network.ddosprotectionplans
- ms.network.dnsresolvers
- ms.network.expressroutecircuits
- ms.network.firewallpolicies
- ms.network.firewallpolicies.rulecollectiongroups
- ms.network.frontdoors
- ms.network.ipgroups
- ms.network.loadbalancers
- ms.network.loadbalancers.backendaddresspools
- ms.network.loadbalancers.inboundnatrules
- ms.network.localnetworkgateways
- ms.network.natgateways
- ms.network.networkinterfaces
- ms.network.networkmanagers
- ms.network.networkmanagers.connectivityconfigurations
- ms.network.networkmanagers.networkgroups
- ms.network.networkmanagers.networkgroups.staticmembers
- ms.network.networkmanagers.scopeconnections
- ms.network.networkmanagers.securityadminconfigurations
- ms.network.networkmanagers.securityadminconfigurations.rulecollections
- ms.network.networkmanagers.securityadminconfigurations.rulecollections.rules
- ms.network.networksecuritygroups
- ms.network.networksecuritygroups.securityrules
- ms.network.networkwatchers
- ms.network.networkwatchers.connectionmonitors
- ms.network.networkwatchers.flowlogs
- ms.network.privatednszones
- ms.network.privatednszones.a
- ms.network.privatednszones.aaaa
- ms.network.privatednszones.cname
- ms.network.privatednszones.mx
- ms.network.privatednszones.ptr
- ms.network.privatednszones.soa
- ms.network.privatednszones.srv
- ms.network.privatednszones.txt
- ms.network.privatednszones.virtualnetworklinks
- ms.network.privateendpoints
- ms.network.privateendpoints.privatednszonegroups
- ms.network.privatelinkservices
- ms.network.publicipaddresses
- ms.network.publicipprefixes
- ms.network.routetables
- ms.network.trafficmanagerprofiles
- ms.network.virtualhubs
- ms.network.virtualhubs.hubroutetables
- ms.network.virtualhubs.hubvirtualnetworkconnections
- ms.network.virtualnetworkgateways
- ms.network.virtualnetworks
- ms.network.virtualnetworks.subnets
- ms.network.virtualnetworks.peerings
- ms.network.virtualwans
- ms.network.vpngateways
- ms.network.vpngateways.connections
- ms.network.vpngateways.natrules
- ms.network.vpnsites
- ms.operationalinsights.workspaces
- ms.operationalinsights.workspaces.datasources
- ms.operationalinsights.workspaces.linkedservices
- ms.operationalinsights.workspaces.linkedstorageaccounts
- ms.operationalinsights.workspaces.savedsearches
- ms.operationalinsights.workspaces.storageinsightconfigs
- ms.operationsmanagement.solutions
- ms.policyinsights.remediations
- ms.policyinsights.remediations.managementgroup
- ms.policyinsights.remediations.resourcegroup
- ms.policyinsights.remediations.subscription
- ms.powerbidedicated.capacities
- ms.recoveryservices.vaults
- ms.recoveryservices.vaults.backupconfig
- ms.recoveryservices.vaults.backuppolicies
- ms.recoveryservices.vaults.backupstorageconfig
- ms.recoveryservices.vaults.protectioncontainers
- ms.recoveryservices.vaults.protectioncontainers.protecteditems
- ms.recoveryservices.vaults.replicationalertsettings
- ms.recoveryservices.vaults.replicationfabrics
- ms.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers
- ms.recoveryservices.vaults.replicationfabrics.replicationprotectioncontainers.mappings
- ms.recoveryservices.vaults.replicationpolicies
- ms.resources.deploymentscripts
- ms.resources.resourcegroups
- ms.resources.tags
- ms.resources.tags.resourcegroups
- ms.resources.tags.subscriptions
- ms.security.azuresecuritycenter
- ms.servicebus.namespaces
- ms.servicebus.namespaces.authorizationrules
- ms.servicebus.namespaces.disasterrecoveryconfigs
- ms.servicebus.namespaces.migrationconfigurations
- ms.servicebus.namespaces.networkrulesets
- ms.servicebus.namespaces.queues
- ms.servicebus.namespaces.queues.authorizationrules
- ms.servicebus.namespaces.topics
- ms.servicebus.namespaces.topics.authorizationrules
- ms.servicefabric.clusters
- ms.servicefabric.clusters.applicationtypes
- ms.signalrservice.signalr
- ms.signalrservice.webpubsub
- ms.sql.managedinstances
- ms.sql.managedinstances.administrators
- ms.sql.managedinstances.databases
- ms.sql.managedinstances.databases.backuplongtermretentionpolicies
- ms.sql.managedinstances.databases.backupshorttermretentionpolicies
- ms.sql.managedinstances.encryptionprotector
- ms.sql.managedinstances.keys
- ms.sql.managedinstances.securityalertpolicies
- ms.sql.managedinstances.vulnerabilityassessments
- ms.sql.servers
- ms.sql.servers.databases
- ms.sql.servers.elasticpools
- ms.sql.servers.firewallrules
- ms.sql.servers.keys
- ms.sql.servers.securityalertpolicies
- ms.sql.servers.virtualnetworkrules
- ms.sql.servers.vulnerabilityassessments
- ms.storage.storageaccounts
- ms.storage.storageaccounts.blobservices
- ms.storage.storageaccounts.blobservices.containers
- ms.storage.storageaccounts.blobservices.containers.immutabilitypolicies
- ms.storage.storageaccounts.fileservices
- ms.storage.storageaccounts.fileservices.shares
- ms.storage.storageaccounts.localusers
- ms.storage.storageaccounts.managementpolicies
- ms.storage.storageaccounts.queueservices
- ms.storage.storageaccounts.queueservices.queues
- ms.storage.storageaccounts.tableservices
- ms.storage.storageaccounts.tableservices.tables
- ms.synapse.privatelinkhubs
- ms.synapse.workspaces
- ms.synapse.workspaces.keys
- ms.virtualmachineimages.imagetemplates
- ms.web.connections
- ms.web.hostingenvironments
- ms.web.serverfarms
- ms.web.sites
- ms.web.sites.config-appsettings
- ms.web.sites.config-authsettingsv2
- ms.web.sites.slots
- ms.web.sites.slots.config-appsettings
- ms.web.sites.slots.config-authsettingsv2
- ms.web.staticsites
- ms.web.staticsites.config
- ms.web.staticsites.customdomains
- ms.web.staticsites.linkedbackends

</details>

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network: NetworkWatchers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkwatchers.yml/badge.svg?branch=users%2Falsehr%2F2595_name)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkwatchers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
