### PR TITLE
[Fixes] CI environment - Skip static and deployment validation feature

### DIFF
--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -67,7 +67,6 @@ runs:
           $workflowInput = @{}
           foreach($parameterName in $parameters.Keys) {
             Write-Verbose ('Passing output [{0}] with value [{1}]' -f $parameterName, $parameters[$parameterName]) -Verbose
-            Write-Verbose ($parameters[$parameterName].getType()) -Verbose
             $workflowInput[$parameterName] = $parameters[$parameterName]
           }
           Write-Output ('{0}={1}' -f 'workflowInput', ($workflowInput | ConvertTo-Json -Compress)) >> $env:GITHUB_OUTPUT
@@ -90,7 +89,6 @@ runs:
           $workflowInput = @{}
           foreach($parameterName in $workflowParameters.Keys) {
             Write-Verbose ('Passing output [{0}] with value [{1}]' -f $parameterName, $workflowParameters[$parameterName]) -Verbose
-            Write-Verbose ($workflowParameters[$parameterName].getType()) -Verbose
             $workflowInput[$parameterName] = $workflowParameters[$parameterName].toString()
           }
           Write-Output ('{0}={1}' -f 'workflowInput', ($workflowInput | ConvertTo-Json -Compress)) >> $env:GITHUB_OUTPUT

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -67,6 +67,7 @@ runs:
           $workflowInput = @{}
           foreach($parameterName in $parameters.Keys) {
             Write-Verbose ('Passing output [{0}] with value [{1}]' -f $parameterName, $parameters[$parameterName]) -Verbose
+            Write-Verbose ($parameters[$parameterName].getType()) -Verbose
             $workflowInput[$parameterName] = $parameters[$parameterName]
           }
           Write-Output ('{0}={1}' -f 'workflowInput', ($workflowInput | ConvertTo-Json -Compress)) >> $env:GITHUB_OUTPUT
@@ -89,6 +90,7 @@ runs:
           $workflowInput = @{}
           foreach($parameterName in $workflowParameters.Keys) {
             Write-Verbose ('Passing output [{0}] with value [{1}]' -f $parameterName, $workflowParameters[$parameterName]) -Verbose
+            Write-Verbose ($workflowParameters[$parameterName].getType()) -Verbose
             $workflowInput[$parameterName] = $workflowParameters[$parameterName]
           }
           Write-Output ('{0}={1}' -f 'workflowInput', ($workflowInput | ConvertTo-Json -Compress)) >> $env:GITHUB_OUTPUT

--- a/.github/actions/templates/getWorkflowInput/action.yml
+++ b/.github/actions/templates/getWorkflowInput/action.yml
@@ -91,7 +91,7 @@ runs:
           foreach($parameterName in $workflowParameters.Keys) {
             Write-Verbose ('Passing output [{0}] with value [{1}]' -f $parameterName, $workflowParameters[$parameterName]) -Verbose
             Write-Verbose ($workflowParameters[$parameterName].getType()) -Verbose
-            $workflowInput[$parameterName] = $workflowParameters[$parameterName]
+            $workflowInput[$parameterName] = $workflowParameters[$parameterName].toString()
           }
           Write-Output ('{0}={1}' -f 'workflowInput', ($workflowInput | ConvertTo-Json -Compress)) >> $env:GITHUB_OUTPUT
         }

--- a/.github/workflows/ms.aad.domainservices.yml
+++ b/.github/workflows/ms.aad.domainservices.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.aad.domainservices.yml
+++ b/.github/workflows/ms.aad.domainservices.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.analysisservices.servers.yml
+++ b/.github/workflows/ms.analysisservices.servers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.analysisservices.servers.yml
+++ b/.github/workflows/ms.analysisservices.servers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.apimanagement.service.yml
+++ b/.github/workflows/ms.apimanagement.service.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.apimanagement.service.yml
+++ b/.github/workflows/ms.apimanagement.service.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.appconfiguration.configurationstores.yml
+++ b/.github/workflows/ms.appconfiguration.configurationstores.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.appconfiguration.configurationstores.yml
+++ b/.github/workflows/ms.appconfiguration.configurationstores.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.locks.yml
+++ b/.github/workflows/ms.authorization.locks.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.locks.yml
+++ b/.github/workflows/ms.authorization.locks.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.policyassignments.yml
+++ b/.github/workflows/ms.authorization.policyassignments.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.policyassignments.yml
+++ b/.github/workflows/ms.authorization.policyassignments.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.policydefinitions.yml
+++ b/.github/workflows/ms.authorization.policydefinitions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.policydefinitions.yml
+++ b/.github/workflows/ms.authorization.policydefinitions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.policyexemptions.yml
+++ b/.github/workflows/ms.authorization.policyexemptions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.policyexemptions.yml
+++ b/.github/workflows/ms.authorization.policyexemptions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.policysetdefinitions.yml
+++ b/.github/workflows/ms.authorization.policysetdefinitions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.policysetdefinitions.yml
+++ b/.github/workflows/ms.authorization.policysetdefinitions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.roleassignments.yml
+++ b/.github/workflows/ms.authorization.roleassignments.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.roleassignments.yml
+++ b/.github/workflows/ms.authorization.roleassignments.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.authorization.roledefinitions.yml
+++ b/.github/workflows/ms.authorization.roledefinitions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.authorization.roledefinitions.yml
+++ b/.github/workflows/ms.authorization.roledefinitions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.automation.automationaccounts.yml
+++ b/.github/workflows/ms.automation.automationaccounts.yml
@@ -70,7 +70,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.automation.automationaccounts.yml
+++ b/.github/workflows/ms.automation.automationaccounts.yml
@@ -96,7 +96,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.batch.batchaccounts.yml
+++ b/.github/workflows/ms.batch.batchaccounts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.batch.batchaccounts.yml
+++ b/.github/workflows/ms.batch.batchaccounts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.cache.redis.yml
+++ b/.github/workflows/ms.cache.redis.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.cache.redis.yml
+++ b/.github/workflows/ms.cache.redis.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.cdn.profiles.yml
+++ b/.github/workflows/ms.cdn.profiles.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.cdn.profiles.yml
+++ b/.github/workflows/ms.cdn.profiles.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.cognitiveservices.accounts.yml
+++ b/.github/workflows/ms.cognitiveservices.accounts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.cognitiveservices.accounts.yml
+++ b/.github/workflows/ms.cognitiveservices.accounts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.availabilitysets.yml
+++ b/.github/workflows/ms.compute.availabilitysets.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.availabilitysets.yml
+++ b/.github/workflows/ms.compute.availabilitysets.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.diskencryptionsets.yml
+++ b/.github/workflows/ms.compute.diskencryptionsets.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.diskencryptionsets.yml
+++ b/.github/workflows/ms.compute.diskencryptionsets.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&lowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.diskencryptionsets.yml
+++ b/.github/workflows/ms.compute.diskencryptionsets.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&lowInput)).deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.disks.yml
+++ b/.github/workflows/ms.compute.disks.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.disks.yml
+++ b/.github/workflows/ms.compute.disks.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.galleries.yml
+++ b/.github/workflows/ms.compute.galleries.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.galleries.yml
+++ b/.github/workflows/ms.compute.galleries.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.images.yml
+++ b/.github/workflows/ms.compute.images.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.images.yml
+++ b/.github/workflows/ms.compute.images.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.proximityplacementgroups.yml
+++ b/.github/workflows/ms.compute.proximityplacementgroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.proximityplacementgroups.yml
+++ b/.github/workflows/ms.compute.proximityplacementgroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.virtualmachines.yml
+++ b/.github/workflows/ms.compute.virtualmachines.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.virtualmachines.yml
+++ b/.github/workflows/ms.compute.virtualmachines.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.compute.virtualmachinescalesets.yml
+++ b/.github/workflows/ms.compute.virtualmachinescalesets.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.compute.virtualmachinescalesets.yml
+++ b/.github/workflows/ms.compute.virtualmachinescalesets.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.consumption.budgets.yml
+++ b/.github/workflows/ms.consumption.budgets.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.consumption.budgets.yml
+++ b/.github/workflows/ms.consumption.budgets.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.containerinstance.containergroups.yml
+++ b/.github/workflows/ms.containerinstance.containergroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.containerinstance.containergroups.yml
+++ b/.github/workflows/ms.containerinstance.containergroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.containerregistry.registries.yml
+++ b/.github/workflows/ms.containerregistry.registries.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.containerregistry.registries.yml
+++ b/.github/workflows/ms.containerregistry.registries.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.containerservice.managedclusters.yml
+++ b/.github/workflows/ms.containerservice.managedclusters.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.containerservice.managedclusters.yml
+++ b/.github/workflows/ms.containerservice.managedclusters.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.databricks.workspaces.yml
+++ b/.github/workflows/ms.databricks.workspaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.databricks.workspaces.yml
+++ b/.github/workflows/ms.databricks.workspaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.datafactory.factories.yml
+++ b/.github/workflows/ms.datafactory.factories.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.datafactory.factories.yml
+++ b/.github/workflows/ms.datafactory.factories.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.dataprotection.backupvaults.yml
+++ b/.github/workflows/ms.dataprotection.backupvaults.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.dataprotection.backupvaults.yml
+++ b/.github/workflows/ms.dataprotection.backupvaults.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.dbforpostgresql.flexibleservers.yml
+++ b/.github/workflows/ms.dbforpostgresql.flexibleservers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.dbforpostgresql.flexibleservers.yml
+++ b/.github/workflows/ms.dbforpostgresql.flexibleservers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.applicationgroups.yml
+++ b/.github/workflows/ms.desktopvirtualization.applicationgroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.desktopvirtualization.applicationgroups.yml
+++ b/.github/workflows/ms.desktopvirtualization.applicationgroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,8 +105,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      ${{ always() }} &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    # ${{ always() }} &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} &&
+      needs.job_module_static_validation.conclusion != 'failed'
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,9 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: ${{ always() }} && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: |
+      ${{ always() }} &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: 'Execute static validation'
         required: false
-        default: false
+        default: true
       deploymentValidation:
         type: boolean
         description: 'Execute deployment validation'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: 'Execute static validation'
         required: false
-        default: false
+        default: true
       deploymentValidation:
         type: boolean
         description: 'Execute deployment validation'
@@ -106,7 +106,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == true &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,8 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: |
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} && (needs.job_module_static_validation.conclusion != 'failed')
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -106,8 +106,7 @@ jobs:
     name: 'Deploying'
     if: |
       always()
-    # &&
-    # ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+      && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     # &&
     # (needs.job_module_static_validation.conclusion != 'failed')
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -106,7 +106,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}  &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}  &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation }}
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation
     needs:
       - job_initialize_pipeline
     steps:
@@ -108,11 +108,6 @@ jobs:
       !cancelled() &&
       (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation &&
       needs.job_module_static_validation.conclusion != 'failed'
-  # if: fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation && (needs.job_module_static_validation.conclusion != 'failed')
-  #  if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
-  # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
-  # ${{ always() }} &&
-  # && needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         description: 'Execute deployment validation'
         required: false
-        default: true
+        default: false
       removeDeployment:
         type: boolean
         description: 'Remove deployed module'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+      (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: 'Execute static validation'
         required: false
-        default: true
+        default: false
       deploymentValidation:
         type: boolean
         description: 'Execute deployment validation'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,7 +105,6 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-    # ${{ always() }} &&
       ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} &&
       needs.job_module_static_validation.conclusion != 'failed'
   # ${{ always() }} &&

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'True' }}
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == True }}
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,8 +104,8 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: |
-      (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+  # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} && (needs.job_module_static_validation.conclusion != 'failed')
+    if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,8 +105,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} &&
-      needs.job_module_static_validation.conclusion != 'failed'
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,8 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: |
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,8 +105,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      always() &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+      always()
+    # &&
+    # ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     # &&
     # (needs.job_module_static_validation.conclusion != 'failed')
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -26,7 +26,6 @@ on:
   push:
     branches:
       - main
-      - users/erikag/skip-jobs
     paths:
       - '.github/actions/templates/**'
       - '.github/workflows/ms.desktopvirtualization.hostpools.yml'
@@ -88,15 +87,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # - name: Set environment variables
-      #   uses: ./.github/actions/templates/setEnvironmentVariables
-      #   with:
-      #     variablesPath: ${{ env.variablesPath }}
-      # - name: 'Run tests'
-      #   uses: ./.github/actions/templates/validateModulePester
-      #   with:
-      #     modulePath: '${{ env.modulePath }}'
-      #     moduleTestFilePath: '${{ env.moduleTestFilePath }}'
+      - name: Set environment variables
+        uses: ./.github/actions/templates/setEnvironmentVariables
+        with:
+          variablesPath: ${{ env.variablesPath }}
+      - name: 'Run tests'
+        uses: ./.github/actions/templates/validateModulePester
+        with:
+          modulePath: '${{ env.modulePath }}'
+          moduleTestFilePath: '${{ env.moduleTestFilePath }}'
 
   #############################
   #   Deployment validation   #
@@ -120,18 +119,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # - name: Set environment variables
-      #   uses: ./.github/actions/templates/setEnvironmentVariables
-      #   with:
-      #     variablesPath: ${{ env.variablesPath }}
-      # - name: 'Using test file [${{ matrix.moduleTestFilePaths }}]'
-      #   uses: ./.github/actions/templates/validateModuleDeployment
-      #   with:
-      #     templateFilePath: '${{ env.modulePath }}/${{ matrix.moduleTestFilePaths }}'
-      #     location: '${{ env.location }}'
-      #     subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-      #     managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-      #     removeDeployment: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).removeDeployment }}'
+      - name: Set environment variables
+        uses: ./.github/actions/templates/setEnvironmentVariables
+        with:
+          variablesPath: ${{ env.variablesPath }}
+      - name: 'Using test file [${{ matrix.moduleTestFilePaths }}]'
+        uses: ./.github/actions/templates/validateModuleDeployment
+        with:
+          templateFilePath: '${{ env.modulePath }}/${{ matrix.moduleTestFilePaths }}'
+          location: '${{ env.location }}'
+          subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+          managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+          removeDeployment: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).removeDeployment }}'
 
   ##################
   #   Publishing   #

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -107,8 +107,7 @@ jobs:
     if: |
       always()
       && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
-    # &&
-    # (needs.job_module_static_validation.conclusion != 'failed')
+      && (needs.job_module_static_validation.result != 'failure')
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -26,6 +26,7 @@ on:
   push:
     branches:
       - main
+      - users/erikag/skip-jobs
     paths:
       - '.github/actions/templates/**'
       - '.github/workflows/ms.desktopvirtualization.hostpools.yml'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == true
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -7,12 +7,12 @@ on:
         type: boolean
         description: 'Execute static validation'
         required: false
-        default: false
+        default: true
       deploymentValidation:
         type: boolean
         description: 'Execute deployment validation'
         required: false
-        default: true
+        default: false
       removeDeployment:
         type: boolean
         description: 'Remove deployed module'
@@ -105,9 +105,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      ${{ always() }} &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} &&
-      needs.job_module_static_validation.conclusion != 'failed'
+    # ${{ always() }} &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    # && needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true' }}
+    if: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true' }}'
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -26,7 +26,6 @@ on:
   push:
     branches:
       - main
-      - users/erikag/skip-jobs
     paths:
       - '.github/actions/templates/**'
       - '.github/workflows/ms.desktopvirtualization.hostpools.yml'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true' }}'
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true' }}
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -106,8 +106,9 @@ jobs:
     name: 'Deploying'
     if: |
       always() &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}  &&
-      (needs.job_module_static_validation.conclusion != 'failed')
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    # &&
+    # (needs.job_module_static_validation.conclusion != 'failed')
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: (needs.job_module_static_validation.conclusion != 'failed') && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -7,12 +7,12 @@ on:
         type: boolean
         description: 'Execute static validation'
         required: false
-        default: true
+        default: false
       deploymentValidation:
         type: boolean
         description: 'Execute deployment validation'
         required: false
-        default: true
+        default: false
       removeDeployment:
         type: boolean
         description: 'Remove deployed module'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,10 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: (needs.job_module_static_validation.conclusion != 'failed') && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: |
+    ${{ always() }} &&
+    (needs.job_module_static_validation.conclusion != 'failed') &&
+    ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,9 +105,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      !cancelled() &&
+      always() &&
       ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}  &&
-      needs.job_module_static_validation.conclusion != 'failed'
+      (needs.job_module_static_validation.conclusion != 'failed')
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,10 +104,9 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: |
-    # ${{ always() }} &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
-    # && needs.job_module_static_validation.conclusion != 'failed'
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+  # ${{ always() }} &&
+  # && needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-      always()
-      && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+      (always())
+      && (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }})
       && (needs.job_module_static_validation.result != 'failure')
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == True }}
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation }}
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,11 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: false && (needs.job_module_static_validation.conclusion != 'failed')
+    if: |
+      !cancelled() &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation &&
+      needs.job_module_static_validation.conclusion != 'failed'
+  # if: fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation && (needs.job_module_static_validation.conclusion != 'failed')
   #  if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -106,8 +106,8 @@ jobs:
     name: 'Deploying'
     if: |
       ${{ always() }} &&
-      (needs.job_module_static_validation.conclusion != 'failed') &&
       ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    # (needs.job_module_static_validation.conclusion != 'failed') &&
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == true
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
     needs:
       - job_initialize_pipeline
     steps:
@@ -106,7 +106,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == true &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,10 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: |
-      (always())
-      && (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }})
-      && (needs.job_module_static_validation.result != 'failure')
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -106,8 +106,8 @@ jobs:
     name: 'Deploying'
     if: |
       ${{ always() }} &&
-      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
-    # (needs.job_module_static_validation.conclusion != 'failed') &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} &&
+      needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+    if: ${{ always() }} && ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'
     needs:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         description: 'Execute deployment validation'
         required: false
-        default: false
+        default: true
       removeDeployment:
         type: boolean
         description: 'Remove deployed module'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,7 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: (${{ false }}) && (needs.job_module_static_validation.conclusion != 'failed')
+    if: false && (needs.job_module_static_validation.conclusion != 'failed')
   #  if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -105,9 +105,9 @@ jobs:
     runs-on: ubuntu-20.04
     name: 'Deploying'
     if: |
-    ${{ always() }} &&
-    (needs.job_module_static_validation.conclusion != 'failed') &&
-    ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
+      ${{ always() }} &&
+      (needs.job_module_static_validation.conclusion != 'failed') &&
+      ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}
     needs:
       - job_initialize_pipeline
       - job_module_static_validation

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -80,7 +80,7 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true' }}
+    if: ${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'True' }}
     needs:
       - job_initialize_pipeline
     steps:

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -104,7 +104,8 @@ jobs:
   job_module_deploy_validation:
     runs-on: ubuntu-20.04
     name: 'Deploying'
-    if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
+    if: (${{ false }}) && (needs.job_module_static_validation.conclusion != 'failed')
+  #  if: (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}) && (needs.job_module_static_validation.conclusion != 'failed')
   # (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }} == false)
   # ${{ always() }} &&
   # && needs.job_module_static_validation.conclusion != 'failed'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         description: 'Execute deployment validation'
         required: false
-        default: false
+        default: true
       removeDeployment:
         type: boolean
         description: 'Remove deployed module'
@@ -138,34 +138,34 @@ jobs:
       #     managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
       #     removeDeployment: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).removeDeployment }}'
 
-  # ##################
-  # #   Publishing   #
-  # ##################
-  # job_publish_module:
-  #   name: 'Publishing'
-  #   if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.event.inputs.prerelease == 'true'
-  #   runs-on: ubuntu-20.04
-  #   needs:
-  #     - job_module_deploy_validation
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Set environment variables
-  #       uses: ./.github/actions/templates/setEnvironmentVariables
-  #       with:
-  #         variablesPath: ${{ env.variablesPath }}
-  #     - name: 'Publishing'
-  #       uses: ./.github/actions/templates/publishModule
-  #       with:
-  #         templateFilePath: '${{ env.modulePath }}/deploy.bicep'
-  #         templateSpecsRGName: '${{ env.templateSpecsRGName }}'
-  #         templateSpecsRGLocation: '${{ env.templateSpecsRGLocation }}'
-  #         templateSpecsDescription: '${{ env.templateSpecsDescription }}'
-  #         templateSpecsDoPublish: '${{ env.templateSpecsDoPublish }}'
-  #         bicepRegistryName: '${{ env.bicepRegistryName }}'
-  #         bicepRegistryRGName: '${{ env.bicepRegistryRGName }}'
-  #         bicepRegistryRgLocation: '${{ env.bicepRegistryRgLocation }}'
-  #         bicepRegistryDoPublish: '${{ env.bicepRegistryDoPublish }}'
-  #         publishLatest: '${{ env.publishLatest }}'
+  ##################
+  #   Publishing   #
+  ##################
+  job_publish_module:
+    name: 'Publishing'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.event.inputs.prerelease == 'true'
+    runs-on: ubuntu-20.04
+    needs:
+      - job_module_deploy_validation
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set environment variables
+        uses: ./.github/actions/templates/setEnvironmentVariables
+        with:
+          variablesPath: ${{ env.variablesPath }}
+      - name: 'Publishing'
+        uses: ./.github/actions/templates/publishModule
+        with:
+          templateFilePath: '${{ env.modulePath }}/deploy.bicep'
+          templateSpecsRGName: '${{ env.templateSpecsRGName }}'
+          templateSpecsRGLocation: '${{ env.templateSpecsRGLocation }}'
+          templateSpecsDescription: '${{ env.templateSpecsDescription }}'
+          templateSpecsDoPublish: '${{ env.templateSpecsDoPublish }}'
+          bicepRegistryName: '${{ env.bicepRegistryName }}'
+          bicepRegistryRGName: '${{ env.bicepRegistryRGName }}'
+          bicepRegistryRgLocation: '${{ env.bicepRegistryRgLocation }}'
+          bicepRegistryDoPublish: '${{ env.bicepRegistryDoPublish }}'
+          publishLatest: '${{ env.publishLatest }}'

--- a/.github/workflows/ms.desktopvirtualization.hostpools.yml
+++ b/.github/workflows/ms.desktopvirtualization.hostpools.yml
@@ -98,40 +98,40 @@ jobs:
       #     modulePath: '${{ env.modulePath }}'
       #     moduleTestFilePath: '${{ env.moduleTestFilePath }}'
 
-  # #############################
-  # #   Deployment validation   #
-  # #############################
-  # job_module_deploy_validation:
-  #   runs-on: ubuntu-20.04
-  #   name: 'Deploying'
-  #   if: |
-  #     !cancelled() &&
-  #     (github.event.inputs.deploymentValidation == 'true' ||  &&
-  #     needs.job_module_static_validation.conclusion != 'failed'
-  #   needs:
-  #     - job_initialize_pipeline
-  #     - job_module_static_validation
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       moduleTestFilePaths: ${{ fromJson(needs.job_initialize_pipeline.outputs.moduleTestFilePaths) }}
-  #   steps:
-  #     - name: 'Checkout'
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Set environment variables
-  #       uses: ./.github/actions/templates/setEnvironmentVariables
-  #       with:
-  #         variablesPath: ${{ env.variablesPath }}
-  #     - name: 'Using test file [${{ matrix.moduleTestFilePaths }}]'
-  #       uses: ./.github/actions/templates/validateModuleDeployment
-  #       with:
-  #         templateFilePath: '${{ env.modulePath }}/${{ matrix.moduleTestFilePaths }}'
-  #         location: '${{ env.location }}'
-  #         subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
-  #         managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
-  #         removeDeployment: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).removeDeployment }}'
+  #############################
+  #   Deployment validation   #
+  #############################
+  job_module_deploy_validation:
+    runs-on: ubuntu-20.04
+    name: 'Deploying'
+    if: |
+      !cancelled() &&
+      (${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation }}  &&
+      needs.job_module_static_validation.conclusion != 'failed'
+    needs:
+      - job_initialize_pipeline
+      - job_module_static_validation
+    strategy:
+      fail-fast: false
+      matrix:
+        moduleTestFilePaths: ${{ fromJson(needs.job_initialize_pipeline.outputs.moduleTestFilePaths) }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # - name: Set environment variables
+      #   uses: ./.github/actions/templates/setEnvironmentVariables
+      #   with:
+      #     variablesPath: ${{ env.variablesPath }}
+      # - name: 'Using test file [${{ matrix.moduleTestFilePaths }}]'
+      #   uses: ./.github/actions/templates/validateModuleDeployment
+      #   with:
+      #     templateFilePath: '${{ env.modulePath }}/${{ matrix.moduleTestFilePaths }}'
+      #     location: '${{ env.location }}'
+      #     subscriptionId: '${{ secrets.ARM_SUBSCRIPTION_ID }}'
+      #     managementGroupId: '${{ secrets.ARM_MGMTGROUP_ID }}'
+      #     removeDeployment: '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).removeDeployment }}'
 
   # ##################
   # #   Publishing   #

--- a/.github/workflows/ms.desktopvirtualization.scalingplans.yml
+++ b/.github/workflows/ms.desktopvirtualization.scalingplans.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.desktopvirtualization.scalingplans.yml
+++ b/.github/workflows/ms.desktopvirtualization.scalingplans.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.desktopvirtualization.workspaces.yml
+++ b/.github/workflows/ms.desktopvirtualization.workspaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.desktopvirtualization.workspaces.yml
+++ b/.github/workflows/ms.desktopvirtualization.workspaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.devtestlab.labs.yml
+++ b/.github/workflows/ms.devtestlab.labs.yml
@@ -70,7 +70,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.devtestlab.labs.yml
+++ b/.github/workflows/ms.devtestlab.labs.yml
@@ -96,7 +96,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.documentdb.databaseaccounts.yml
+++ b/.github/workflows/ms.documentdb.databaseaccounts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.documentdb.databaseaccounts.yml
+++ b/.github/workflows/ms.documentdb.databaseaccounts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.eventgrid.domains.yml
+++ b/.github/workflows/ms.eventgrid.domains.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.eventgrid.domains.yml
+++ b/.github/workflows/ms.eventgrid.domains.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.eventgrid.eventsubscriptions.yml
+++ b/.github/workflows/ms.eventgrid.eventsubscriptions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.eventgrid.eventsubscriptions.yml
+++ b/.github/workflows/ms.eventgrid.eventsubscriptions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.eventgrid.systemtopics.yml
+++ b/.github/workflows/ms.eventgrid.systemtopics.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.eventgrid.systemtopics.yml
+++ b/.github/workflows/ms.eventgrid.systemtopics.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.eventgrid.topics.yml
+++ b/.github/workflows/ms.eventgrid.topics.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.eventgrid.topics.yml
+++ b/.github/workflows/ms.eventgrid.topics.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.eventhub.namespaces.yml
+++ b/.github/workflows/ms.eventhub.namespaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.eventhub.namespaces.yml
+++ b/.github/workflows/ms.eventhub.namespaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.healthbot.healthbots.yml
+++ b/.github/workflows/ms.healthbot.healthbots.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.healthbot.healthbots.yml
+++ b/.github/workflows/ms.healthbot.healthbots.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.actiongroups.yml
+++ b/.github/workflows/ms.insights.actiongroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.actiongroups.yml
+++ b/.github/workflows/ms.insights.actiongroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.activitylogalerts.yml
+++ b/.github/workflows/ms.insights.activitylogalerts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.activitylogalerts.yml
+++ b/.github/workflows/ms.insights.activitylogalerts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.components.yml
+++ b/.github/workflows/ms.insights.components.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.components.yml
+++ b/.github/workflows/ms.insights.components.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.datacollectionendpoints.yml
+++ b/.github/workflows/ms.insights.datacollectionendpoints.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.datacollectionendpoints.yml
+++ b/.github/workflows/ms.insights.datacollectionendpoints.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.datacollectionrules.yml
+++ b/.github/workflows/ms.insights.datacollectionrules.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.datacollectionrules.yml
+++ b/.github/workflows/ms.insights.datacollectionrules.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.diagnosticsettings.yml
+++ b/.github/workflows/ms.insights.diagnosticsettings.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.diagnosticsettings.yml
+++ b/.github/workflows/ms.insights.diagnosticsettings.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.metricalerts.yml
+++ b/.github/workflows/ms.insights.metricalerts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.metricalerts.yml
+++ b/.github/workflows/ms.insights.metricalerts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.privatelinkscopes.yml
+++ b/.github/workflows/ms.insights.privatelinkscopes.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.privatelinkscopes.yml
+++ b/.github/workflows/ms.insights.privatelinkscopes.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.insights.scheduledqueryrules.yml
+++ b/.github/workflows/ms.insights.scheduledqueryrules.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.insights.scheduledqueryrules.yml
+++ b/.github/workflows/ms.insights.scheduledqueryrules.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.keyvault.vaults.yml
+++ b/.github/workflows/ms.keyvault.vaults.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.keyvault.vaults.yml
+++ b/.github/workflows/ms.keyvault.vaults.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.kubernetesconfiguration.extensions.yml
+++ b/.github/workflows/ms.kubernetesconfiguration.extensions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.kubernetesconfiguration.extensions.yml
+++ b/.github/workflows/ms.kubernetesconfiguration.extensions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml
+++ b/.github/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml
+++ b/.github/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.logic.workflows.yml
+++ b/.github/workflows/ms.logic.workflows.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.logic.workflows.yml
+++ b/.github/workflows/ms.logic.workflows.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.machinelearningservices.workspaces.yml
+++ b/.github/workflows/ms.machinelearningservices.workspaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.machinelearningservices.workspaces.yml
+++ b/.github/workflows/ms.machinelearningservices.workspaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.maintenance.maintenanceconfigurations.yml
+++ b/.github/workflows/ms.maintenance.maintenanceconfigurations.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.maintenance.maintenanceconfigurations.yml
+++ b/.github/workflows/ms.maintenance.maintenanceconfigurations.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.managedidentity.userassignedidentities.yml
+++ b/.github/workflows/ms.managedidentity.userassignedidentities.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.managedidentity.userassignedidentities.yml
+++ b/.github/workflows/ms.managedidentity.userassignedidentities.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.managedservices.registrationdefinitions.yml
+++ b/.github/workflows/ms.managedservices.registrationdefinitions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.managedservices.registrationdefinitions.yml
+++ b/.github/workflows/ms.managedservices.registrationdefinitions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.management.managementgroups.yml
+++ b/.github/workflows/ms.management.managementgroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.management.managementgroups.yml
+++ b/.github/workflows/ms.management.managementgroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.netapp.netappaccounts.yml
+++ b/.github/workflows/ms.netapp.netappaccounts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.netapp.netappaccounts.yml
+++ b/.github/workflows/ms.netapp.netappaccounts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.applicationgateways.yml
+++ b/.github/workflows/ms.network.applicationgateways.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.applicationgateways.yml
+++ b/.github/workflows/ms.network.applicationgateways.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml
+++ b/.github/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml
+++ b/.github/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.applicationsecuritygroups.yml
+++ b/.github/workflows/ms.network.applicationsecuritygroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.applicationsecuritygroups.yml
+++ b/.github/workflows/ms.network.applicationsecuritygroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.azurefirewalls.yml
+++ b/.github/workflows/ms.network.azurefirewalls.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.azurefirewalls.yml
+++ b/.github/workflows/ms.network.azurefirewalls.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.bastionhosts.yml
+++ b/.github/workflows/ms.network.bastionhosts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.bastionhosts.yml
+++ b/.github/workflows/ms.network.bastionhosts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.connections.yml
+++ b/.github/workflows/ms.network.connections.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.connections.yml
+++ b/.github/workflows/ms.network.connections.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.ddosprotectionplans.yml
+++ b/.github/workflows/ms.network.ddosprotectionplans.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.ddosprotectionplans.yml
+++ b/.github/workflows/ms.network.ddosprotectionplans.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.dnsresolvers.yml
+++ b/.github/workflows/ms.network.dnsresolvers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.dnsresolvers.yml
+++ b/.github/workflows/ms.network.dnsresolvers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.expressroutecircuits.yml
+++ b/.github/workflows/ms.network.expressroutecircuits.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.expressroutecircuits.yml
+++ b/.github/workflows/ms.network.expressroutecircuits.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.firewallpolicies.yml
+++ b/.github/workflows/ms.network.firewallpolicies.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.firewallpolicies.yml
+++ b/.github/workflows/ms.network.firewallpolicies.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.frontdoors.yml
+++ b/.github/workflows/ms.network.frontdoors.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.frontdoors.yml
+++ b/.github/workflows/ms.network.frontdoors.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.ipgroups.yml
+++ b/.github/workflows/ms.network.ipgroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.ipgroups.yml
+++ b/.github/workflows/ms.network.ipgroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.loadbalancers.yml
+++ b/.github/workflows/ms.network.loadbalancers.yml
@@ -79,7 +79,11 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipelines.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.loadbalancers.yml
+++ b/.github/workflows/ms.network.loadbalancers.yml
@@ -81,8 +81,6 @@ jobs:
     name: 'Static validation'
     if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
     needs:
-      - job_initialize_pipelines.workflowInput)).staticValidation == 'true'
-    needs:
       - job_initialize_pipeline
     steps:
       - name: 'Checkout'

--- a/.github/workflows/ms.network.loadbalancers.yml
+++ b/.github/workflows/ms.network.loadbalancers.yml
@@ -107,7 +107,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.localnetworkgateways.yml
+++ b/.github/workflows/ms.network.localnetworkgateways.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.localnetworkgateways.yml
+++ b/.github/workflows/ms.network.localnetworkgateways.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.natgateways.yml
+++ b/.github/workflows/ms.network.natgateways.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.natgateways.yml
+++ b/.github/workflows/ms.network.natgateways.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.networkinterfaces.yml
+++ b/.github/workflows/ms.network.networkinterfaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.networkinterfaces.yml
+++ b/.github/workflows/ms.network.networkinterfaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.networkmanagers.yml
+++ b/.github/workflows/ms.network.networkmanagers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.networkmanagers.yml
+++ b/.github/workflows/ms.network.networkmanagers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.networksecuritygroups.yml
+++ b/.github/workflows/ms.network.networksecuritygroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.networksecuritygroups.yml
+++ b/.github/workflows/ms.network.networksecuritygroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.networkwatchers.yml
+++ b/.github/workflows/ms.network.networkwatchers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.networkwatchers.yml
+++ b/.github/workflows/ms.network.networkwatchers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.privatednszones.yml
+++ b/.github/workflows/ms.network.privatednszones.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.privatednszones.yml
+++ b/.github/workflows/ms.network.privatednszones.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.privateendpoints.yml
+++ b/.github/workflows/ms.network.privateendpoints.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.privateendpoints.yml
+++ b/.github/workflows/ms.network.privateendpoints.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.privatelinkservices.yml
+++ b/.github/workflows/ms.network.privatelinkservices.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.privatelinkservices.yml
+++ b/.github/workflows/ms.network.privatelinkservices.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.publicipaddresses.yml
+++ b/.github/workflows/ms.network.publicipaddresses.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.publicipaddresses.yml
+++ b/.github/workflows/ms.network.publicipaddresses.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.publicipprefixes.yml
+++ b/.github/workflows/ms.network.publicipprefixes.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.publicipprefixes.yml
+++ b/.github/workflows/ms.network.publicipprefixes.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.routetables.yml
+++ b/.github/workflows/ms.network.routetables.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.routetables.yml
+++ b/.github/workflows/ms.network.routetables.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.trafficmanagerprofiles.yml
+++ b/.github/workflows/ms.network.trafficmanagerprofiles.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.trafficmanagerprofiles.yml
+++ b/.github/workflows/ms.network.trafficmanagerprofiles.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.virtualhubs.yml
+++ b/.github/workflows/ms.network.virtualhubs.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.virtualhubs.yml
+++ b/.github/workflows/ms.network.virtualhubs.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.virtualnetworkgateways.yml
+++ b/.github/workflows/ms.network.virtualnetworkgateways.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.virtualnetworkgateways.yml
+++ b/.github/workflows/ms.network.virtualnetworkgateways.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.virtualnetworks.yml
+++ b/.github/workflows/ms.network.virtualnetworks.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.virtualnetworks.yml
+++ b/.github/workflows/ms.network.virtualnetworks.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.virtualwans.yml
+++ b/.github/workflows/ms.network.virtualwans.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.virtualwans.yml
+++ b/.github/workflows/ms.network.virtualwans.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.vpngateways.yml
+++ b/.github/workflows/ms.network.vpngateways.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.vpngateways.yml
+++ b/.github/workflows/ms.network.vpngateways.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.network.vpnsites.yml
+++ b/.github/workflows/ms.network.vpnsites.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.network.vpnsites.yml
+++ b/.github/workflows/ms.network.vpnsites.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.operationalinsights.workspaces.yml
+++ b/.github/workflows/ms.operationalinsights.workspaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.operationalinsights.workspaces.yml
+++ b/.github/workflows/ms.operationalinsights.workspaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.operationsmanagement.solutions.yml
+++ b/.github/workflows/ms.operationsmanagement.solutions.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.operationsmanagement.solutions.yml
+++ b/.github/workflows/ms.operationsmanagement.solutions.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.policyinsights.remediations.yml
+++ b/.github/workflows/ms.policyinsights.remediations.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.policyinsights.remediations.yml
+++ b/.github/workflows/ms.policyinsights.remediations.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.powerbidedicated.capacities.yml
+++ b/.github/workflows/ms.powerbidedicated.capacities.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.powerbidedicated.capacities.yml
+++ b/.github/workflows/ms.powerbidedicated.capacities.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.recoveryservices.vaults.yml
+++ b/.github/workflows/ms.recoveryservices.vaults.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.recoveryservices.vaults.yml
+++ b/.github/workflows/ms.recoveryservices.vaults.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.resources.deploymentscripts.yml
+++ b/.github/workflows/ms.resources.deploymentscripts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.resources.deploymentscripts.yml
+++ b/.github/workflows/ms.resources.deploymentscripts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.resources.resourcegroups.yml
+++ b/.github/workflows/ms.resources.resourcegroups.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.resources.resourcegroups.yml
+++ b/.github/workflows/ms.resources.resourcegroups.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.resources.tags.yml
+++ b/.github/workflows/ms.resources.tags.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.resources.tags.yml
+++ b/.github/workflows/ms.resources.tags.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.security.azuresecuritycenter.yml
+++ b/.github/workflows/ms.security.azuresecuritycenter.yml
@@ -95,7 +95,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.security.azuresecuritycenter.yml
+++ b/.github/workflows/ms.security.azuresecuritycenter.yml
@@ -69,7 +69,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.servicebus.namespaces.yml
+++ b/.github/workflows/ms.servicebus.namespaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.servicebus.namespaces.yml
+++ b/.github/workflows/ms.servicebus.namespaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.servicefabric.clusters.yml
+++ b/.github/workflows/ms.servicefabric.clusters.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.servicefabric.clusters.yml
+++ b/.github/workflows/ms.servicefabric.clusters.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.signalrservice.signalr.yml
+++ b/.github/workflows/ms.signalrservice.signalr.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.signalrservice.signalr.yml
+++ b/.github/workflows/ms.signalrservice.signalr.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.signalrservice.webpubsub.yml
+++ b/.github/workflows/ms.signalrservice.webpubsub.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.signalrservice.webpubsub.yml
+++ b/.github/workflows/ms.signalrservice.webpubsub.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.sql.managedinstances.yml
+++ b/.github/workflows/ms.sql.managedinstances.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.sql.managedinstances.yml
+++ b/.github/workflows/ms.sql.managedinstances.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.sql.servers.yml
+++ b/.github/workflows/ms.sql.servers.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.sql.servers.yml
+++ b/.github/workflows/ms.sql.servers.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.storage.storageaccounts.yml
+++ b/.github/workflows/ms.storage.storageaccounts.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.storage.storageaccounts.yml
+++ b/.github/workflows/ms.storage.storageaccounts.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.synapse.privatelinkhubs.yml
+++ b/.github/workflows/ms.synapse.privatelinkhubs.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.synapse.privatelinkhubs.yml
+++ b/.github/workflows/ms.synapse.privatelinkhubs.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.synapse.workspaces.yml
+++ b/.github/workflows/ms.synapse.workspaces.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.synapse.workspaces.yml
+++ b/.github/workflows/ms.synapse.workspaces.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
+++ b/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
@@ -79,7 +79,11 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipelines.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
+++ b/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
@@ -81,8 +81,6 @@ jobs:
     name: 'Static validation'
     if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
     needs:
-      - job_initialize_pipelines.workflowInput)).staticValidation == 'true'
-    needs:
       - job_initialize_pipeline
     steps:
       - name: 'Checkout'

--- a/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
+++ b/.github/workflows/ms.virtualmachineimages.imagetemplates.yml
@@ -107,7 +107,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.web.connections.yml
+++ b/.github/workflows/ms.web.connections.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.web.connections.yml
+++ b/.github/workflows/ms.web.connections.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.web.hostingenvironments.yml
+++ b/.github/workflows/ms.web.hostingenvironments.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.web.hostingenvironments.yml
+++ b/.github/workflows/ms.web.hostingenvironments.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.web.serverfarms.yml
+++ b/.github/workflows/ms.web.serverfarms.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.web.serverfarms.yml
+++ b/.github/workflows/ms.web.serverfarms.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.web.sites.yml
+++ b/.github/workflows/ms.web.sites.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.web.sites.yml
+++ b/.github/workflows/ms.web.sites.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline

--- a/.github/workflows/ms.web.staticsites.yml
+++ b/.github/workflows/ms.web.staticsites.yml
@@ -79,7 +79,9 @@ jobs:
   job_module_static_validation:
     runs-on: ubuntu-20.04
     name: 'Static validation'
-    if: github.event.inputs.staticValidation == 'true'
+    if: (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).staticValidation == 'true'
+    needs:
+      - job_initialize_pipeline
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/ms.web.staticsites.yml
+++ b/.github/workflows/ms.web.staticsites.yml
@@ -105,7 +105,7 @@ jobs:
     name: 'Deploying'
     if: |
       !cancelled() &&
-      github.event.inputs.deploymentValidation == 'true' &&
+      (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).deploymentValidation == 'true' &&
       needs.job_module_static_validation.conclusion != 'failed'
     needs:
       - job_initialize_pipeline


### PR DESCRIPTION
# Description

Fixing CI env feature allowing to skip static and deployment validation, previously working only for workflow dispatch runs and not on push
Updating getWorkflowInput action to support the feature. All pipeline input parameters are converted to string values
Static validation is now depending on the Initialize pipeline job for GH workflows
![image](https://user-images.githubusercontent.com/56914614/215522512-d4dcf21b-ed8c-4004-acd0-1d03eaa11c00.png)


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Insights: ActionGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml/badge.svg?branch=users%2Ferikag%2Fskip-jobs)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
