### PR TITLE
[Modules] Updated Disk Encryption Set to latest published API version (2022-07-02)

### DIFF
--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
@@ -7,6 +7,11 @@ param keyVaultName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+    name: managedIdentityName
+    location: location
+}
+
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     name: keyVaultName
     location: location
@@ -16,7 +21,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
             name: 'standard'
         }
         tenantId: tenant().tenantId
-        enablePurgeProtection: true
+        enablePurgeProtection: true // Required by disk encryption set
+        softDeleteRetentionInDays: 7
         enabledForTemplateDeployment: true
         enabledForDiskEncryption: true
         enabledForDeployment: true
@@ -32,13 +38,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
-    name: managedIdentityName
-    location: location
-}
-
 resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-    name: guid('msi-${keyVault::key.id}-${location}-${managedIdentity.id}-KeyVault-Reader-RoleAssignment.')
+    name: guid('msi-${keyVault::key.id}-${location}-${managedIdentity.id}-Key-Reader-RoleAssignment')
     scope: keyVault::key
     properties: {
         principalId: managedIdentity.properties.principalId

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
@@ -16,7 +16,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
             name: 'standard'
         }
         tenantId: tenant().tenantId
-        enablePurgeProtection: null
+        enablePurgeProtection: true
         enabledForTemplateDeployment: true
         enabledForDiskEncryption: true
         enabledForDeployment: true
@@ -55,3 +55,6 @@ output keyName string = keyVault::key.name
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId
+
+@description('The resource ID of the created Managed Identity.')
+output managedIdentityResourceId string = managedIdentity.id

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
@@ -32,8 +32,8 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
-    keyVaultName: 'dep-hook-kv-${serviceShort}'
-    managedIdentityName: 'dep-hook-msi-${serviceShort}'
+    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}'
+    managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
   }
 }
 
@@ -46,7 +46,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
-    name: 'hook${serviceShort}001'
+    name: '<<namePrefix>>${serviceShort}001'
     keyName: nestedDependencies.outputs.keyName
     keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
     roleAssignments: [

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
@@ -32,8 +32,8 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
-    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}'
-    managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
+    keyVaultName: 'dep-hook-kv-${serviceShort}'
+    managedIdentityName: 'dep-hook-msi-${serviceShort}'
   }
 }
 
@@ -46,7 +46,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
-    name: '<<namePrefix>>${serviceShort}001'
+    name: 'hook${serviceShort}001'
     keyName: nestedDependencies.outputs.keyName
     keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
     roleAssignments: [
@@ -58,5 +58,9 @@ module testDeployment '../../deploy.bicep' = {
         principalType: 'ServicePrincipal'
       }
     ]
+    systemAssignedIdentity: true
+    userAssignedIdentities: {
+      '${nestedDependencies.outputs.managedIdentityResourceId}': {}
+    }
   }
 }

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/deploy.test.bicep
@@ -14,6 +14,9 @@ param location string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'cdescom'
 
+@description('Generated. Used as a basis for unique resource names.')
+param baseTime string = utcNow('u')
+
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
@@ -32,7 +35,8 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
-    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}'
+    // Adding base time to make the name unique as purge protection must be enabled (but may not be longer than 24 characters total)
+    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
     managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
   }
 }

--- a/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
@@ -20,7 +20,7 @@ param keyVersion string = ''
 ])
 param encryptionType string = 'EncryptionAtRestWithPlatformAndCustomerKeys'
 
-@description('Optional. Multi-tenant application client id to access key vault in a different tenant. Setting the value to "None" will clear the property.')
+@description('Optional. Multi-tenant application client ID to access key vault in a different tenant. Setting the value to "None" will clear the property.')
 param federatedClientId string = 'None'
 
 @description('Optional. Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.')

--- a/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
@@ -20,8 +20,17 @@ param keyVersion string = ''
 ])
 param encryptionType string = 'EncryptionAtRestWithPlatformAndCustomerKeys'
 
+@description('Optional. Multi-tenant application client id to access key vault in a different tenant. Setting the value to "None" will clear the property.')
+param federatedClientId string = 'None'
+
 @description('Optional. Set this flag to true to enable auto-updating of this disk encryption set to the latest key version.')
 param rotationToLatestKeyVersionEnabled bool = false
+
+@description('Optional. Enables system assigned managed identity on the resource.')
+param systemAssignedIdentity bool = true
+
+@description('Optional. The ID(s) to assign to the resource.')
+param userAssignedIdentities object = {}
 
 @description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
 param roleAssignments array = []
@@ -31,6 +40,13 @@ param tags object = {}
 
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
+
+var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
+
+var identity = identityType != 'None' ? {
+  type: identityType
+  userAssignedIdentities: !empty(userAssignedIdentities) ? userAssignedIdentities : null
+} : null
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
   name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
@@ -49,13 +65,11 @@ resource keyVaultKey 'Microsoft.KeyVault/vaults/keys@2021-10-01' existing = {
   scope: resourceGroup(split(keyVaultResourceId, '/')[2], split(keyVaultResourceId, '/')[4])
 }
 
-resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2021-04-01' = {
+resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2022-07-02' = {
   name: name
   location: location
   tags: tags
-  identity: {
-    type: 'SystemAssigned'
-  }
+  identity: identity
   properties: {
     activeKey: {
       sourceVault: {
@@ -64,6 +78,7 @@ resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2021-04-01' = {
       keyUrl: !empty(keyVersion) ? '${keyVaultKey.properties.keyUri}/${keyVersion}' : keyVaultKey.properties.keyUriWithVersion
     }
     encryptionType: encryptionType
+    federatedClientId: federatedClientId
     rotationToLatestKeyVersionEnabled: rotationToLatestKeyVersionEnabled
   }
 }

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -15,8 +15,8 @@ This template deploys a disk encryption set.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Compute/diskEncryptionSets` | [2021-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2021-04-01/diskEncryptionSets) |
-| `Microsoft.KeyVault/vaults/accessPolicies` | [2021-06-01-preview](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2021-06-01-preview/vaults/accessPolicies) |
+| `Microsoft.Compute/diskEncryptionSets` | [2022-07-02](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-07-02/diskEncryptionSets) |
+| `Microsoft.KeyVault/vaults/accessPolicies` | [2022-07-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults/accessPolicies) |
 
 ## Parameters
 
@@ -34,11 +34,14 @@ This template deploys a disk encryption set.
 | :-- | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `encryptionType` | string | `'EncryptionAtRestWithPlatformAndCustomerKeys'` | `[EncryptionAtRestWithCustomerKey, EncryptionAtRestWithPlatformAndCustomerKeys]` | The type of key used to encrypt the data of the disk. For security reasons, it is recommended to set encryptionType to EncryptionAtRestWithPlatformAndCustomerKeys. |
+| `federatedClientId` | string | `'None'` |  | Multi-tenant application client id to access key vault in a different tenant. Setting the value to "None" will clear the property. |
 | `keyVersion` | string | `''` |  | The version of the customer managed key to reference for encryption. If not provided, the latest key version is used. |
 | `location` | string | `[resourceGroup().location]` |  | Resource location. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `rotationToLatestKeyVersionEnabled` | bool | `False` |  | Set this flag to true to enable auto-updating of this disk encryption set to the latest key version. |
+| `systemAssignedIdentity` | bool | `True` |  | Enables system assigned managed identity on the resource. |
 | `tags` | object | `{object}` |  | Tags of the disk encryption resource. |
+| `userAssignedIdentities` | object | `{object}` |  | The ID(s) to assign to the resource. |
 
 
 ### Parameter Usage: `roleAssignments`
@@ -141,6 +144,39 @@ tags: {
 </details>
 <p>
 
+### Parameter Usage: `userAssignedIdentities`
+
+You can specify multiple user assigned identities to a resource by providing additional resource IDs using the following format:
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"userAssignedIdentities": {
+    "value": {
+        "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-001": {},
+        "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-002": {}
+    }
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+userAssignedIdentities: {
+    '/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-001': {}
+    '/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-002': {}
+}
+```
+
+</details>
+<p>
+
 ## Outputs
 
 | Output Name | Type | Description |
@@ -192,6 +228,10 @@ module diskEncryptionSets './Microsoft.Compute/diskEncryptionSets/deploy.bicep' 
         roleDefinitionIdOrName: 'Reader'
       }
     ]
+    systemAssignedIdentity: true
+    userAssignedIdentities: {
+      '<managedIdentityResourceId>': {}
+    }
   }
 }
 ```
@@ -232,6 +272,14 @@ module diskEncryptionSets './Microsoft.Compute/diskEncryptionSets/deploy.bicep' 
           "roleDefinitionIdOrName": "Reader"
         }
       ]
+    },
+    "systemAssignedIdentity": {
+      "value": true
+    },
+    "userAssignedIdentities": {
+      "value": {
+        "<managedIdentityResourceId>": {}
+      }
     }
   }
 }

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -34,7 +34,7 @@ This template deploys a disk encryption set.
 | :-- | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `encryptionType` | string | `'EncryptionAtRestWithPlatformAndCustomerKeys'` | `[EncryptionAtRestWithCustomerKey, EncryptionAtRestWithPlatformAndCustomerKeys]` | The type of key used to encrypt the data of the disk. For security reasons, it is recommended to set encryptionType to EncryptionAtRestWithPlatformAndCustomerKeys. |
-| `federatedClientId` | string | `'None'` |  | Multi-tenant application client id to access key vault in a different tenant. Setting the value to "None" will clear the property. |
+| `federatedClientId` | string | `'None'` |  | Multi-tenant application client ID to access key vault in a different tenant. Setting the value to "None" will clear the property. |
 | `keyVersion` | string | `''` |  | The version of the customer managed key to reference for encryption. If not provided, the latest key version is used. |
 | `location` | string | `[resourceGroup().location]` |  | Resource location. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |


### PR DESCRIPTION
Closes #2632 

# Description

Updated the DES module to the latest API version to fix failing pipeline: 

Added support for:
- federatedClientId: Multi-tenant application client id to access key vault in a different tenant. 
- User Assigned Managed Identity support. Set the system assigned to default to true.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
|[![Compute: DiskEncryptionSets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml/badge.svg?branch=users%2Fahmad%2FpipelineFixes)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml) |

# Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
