### PR TITLE
[Fixes] Update rg roleAssignments name (guid) to use rg resourceID instead of rg name

### DIFF
--- a/modules/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
+++ b/modules/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
@@ -226,7 +226,7 @@ var builtInRoleNames = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
-  name: guid(last(split(resourceId, '/')), principalId, roleDefinitionIdOrName)
+  name: guid(resourceId, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/modules/Microsoft.Resources/resourceGroups/version.json
+++ b/modules/Microsoft.Resources/resourceGroups/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }

--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -156,8 +156,11 @@ function Set-EnvironmentOnAgent {
     # Bicep CLI is pre-installed on GitHub hosted runners.
     # https://github.com/actions/virtual-environments#available-environments
 
-    Write-Verbose 'Bicep CLI version:' -Verbose
+    Write-Verbose 'Bicep CLI version (bicep --version):' -Verbose
     bicep --version
+
+    Write-Verbose 'Bicep CLI version (az bicep version):' -Verbose
+    az bicep version
     <#
     Write-Verbose ("Install bicep start") -Verbose
     # Fetch the latest Bicep CLI binary

--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -158,7 +158,6 @@ function Set-EnvironmentOnAgent {
 
     Write-Verbose 'Bicep CLI version:' -Verbose
     bicep --version
-
     <#
     Write-Verbose ("Install bicep start") -Verbose
     # Fetch the latest Bicep CLI binary

--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -156,11 +156,9 @@ function Set-EnvironmentOnAgent {
     # Bicep CLI is pre-installed on GitHub hosted runners.
     # https://github.com/actions/virtual-environments#available-environments
 
-    Write-Verbose 'Bicep CLI version (bicep --version):' -Verbose
+    Write-Verbose 'Bicep CLI version:' -Verbose
     bicep --version
 
-    Write-Verbose 'Bicep CLI version (az bicep version):' -Verbose
-    az bicep version
     <#
     Write-Verbose ("Install bicep start") -Verbose
     # Fetch the latest Bicep CLI binary


### PR DESCRIPTION
# Description

From: [Create Azure RBAC resources by using Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/scenarios-rbac#name)
    
   _A role assignment's resource name must be a globally unique identifier (GUID).
It's a good practice to create a GUID that uses the scope, principal ID, and role ID together_

This PR is about using the resource ID instead of the resource name as the scope when calculating the RG role assignment name (GUID). This is also consistent with what done by nested_roleAssignment templates at resource scope for other modules.

This also fixes an error thrown by the Bicep compiler once upgrading Bicep to release 0.14.6
`Argument of type "null | string" is not assignable to parameter of type "string".bicep(BCP070)`

![image](https://user-images.githubusercontent.com/56914614/216112450-2d70242c-e155-45ca-a1fa-b641a8de4b02.png)


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Resources: ResourceGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml/badge.svg?branch=users%2Ferikag%2Frg-rbac)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
