### PR TITLE
[Fixes] Disable referenced modules telemetry for a few modules missing the functionality

### DIFF
--- a/modules/Microsoft.CDN/profiles/endpoints/deploy.bicep
+++ b/modules/Microsoft.CDN/profiles/endpoints/deploy.bicep
@@ -13,12 +13,10 @@ param endpointProperties object
 @description('Optional. Endpoint tags.')
 param tags object = {}
 
-resource profile 'Microsoft.Cdn/profiles@2021-06-01' existing = {
-  name: profileName
-}
-
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
+
+var enableReferencedModulesTelemetry = false
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
   name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
@@ -30,6 +28,10 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
       resources: []
     }
   }
+}
+
+resource profile 'Microsoft.Cdn/profiles@2021-06-01' existing = {
+  name: profileName
 }
 
 resource endpoint 'microsoft.cdn/profiles/endpoints@2021-06-01' = {
@@ -55,8 +57,8 @@ module endpoint_origins 'origins/deploy.bicep' = [for origin in endpointProperti
     originHostHeader: contains(origin.properties, 'originHostHeader') ? origin.properties.originHostHeader : ''
     privateLinkAlias: contains(origin.properties, 'privateLinkAlias') ? origin.properties.privateLinkAlias : ''
     privateLinkLocation: contains(origin.properties, 'privateLinkLocation') ? origin.properties.privateLinkLocation : ''
-    privateLinkResourceId: contains(origin.properties, 'privateLinkResourceId') ? origin.properties.privateLinkResourceId : ''    
-    enableDefaultTelemetry: enableDefaultTelemetry
+    privateLinkResourceId: contains(origin.properties, 'privateLinkResourceId') ? origin.properties.privateLinkResourceId : ''
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }]
 

--- a/modules/Microsoft.Network/bastionHosts/deploy.bicep
+++ b/modules/Microsoft.Network/bastionHosts/deploy.bicep
@@ -137,6 +137,8 @@ var ipConfigurations = [
   }
 ]
 
+var enableReferencedModulesTelemetry = false
+
 // ----------------------------------------------------------------------------
 
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
@@ -168,7 +170,7 @@ module publicIPAddress '../publicIPAddresses/deploy.bicep' = if (empty(azureBast
     diagnosticWorkspaceId: diagnosticWorkspaceId
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName
-    enableDefaultTelemetry: enableDefaultTelemetry
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
     location: location
     lock: lock
     publicIPAddressVersion: contains(publicIPAddressObject, 'publicIPAddressVersion') ? publicIPAddressObject.publicIPAddressVersion : 'IPv4'

--- a/modules/Microsoft.Network/virtualNetworkGateways/deploy.bicep
+++ b/modules/Microsoft.Network/virtualNetworkGateways/deploy.bicep
@@ -291,6 +291,8 @@ var vpnClientConfiguration = !empty(clientRootCertData) ? {
   ]
 } : null
 
+var enableReferencedModulesTelemetry = false
+
 // ================//
 // Deployments     //
 // ================//
@@ -310,7 +312,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
 @batchSize(1)
 module publicIPAddress '../publicIPAddresses/deploy.bicep' = [for (virtualGatewayPublicIpName, index) in virtualGatewayPipNameVar: {
   name: virtualGatewayPublicIpName
-  params :{
+  params: {
     name: virtualGatewayPublicIpName
     diagnosticLogCategoriesToEnable: publicIpdiagnosticLogCategoriesToEnable
     diagnosticMetricsToEnable: diagnosticMetricsToEnable
@@ -320,7 +322,7 @@ module publicIPAddress '../publicIPAddresses/deploy.bicep' = [for (virtualGatewa
     diagnosticEventHubAuthorizationRuleId: diagnosticEventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticEventHubName
     domainNameLabel: length(virtualGatewayPipNameVar) == length(domainNameLabel) ? domainNameLabel[index] : ''
-    enableDefaultTelemetry: enableDefaultTelemetry
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
     location: location
     lock: lock
     publicIPAllocationMethod: gatewayPipAllocationMethod

--- a/modules/Microsoft.RecoveryServices/vaults/protectionContainers/deploy.bicep
+++ b/modules/Microsoft.RecoveryServices/vaults/protectionContainers/deploy.bicep
@@ -49,6 +49,8 @@ param containerType string = ''
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
+var enableReferencedModulesTelemetry = false
+
 resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
   name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
   properties: {
@@ -81,7 +83,7 @@ module protectionContainer_protectedItems 'protectedItems/deploy.bicep' = [for (
     recoveryVaultName: recoveryVaultName
     sourceResourceId: protectedItem.sourceResourceId
     location: location
-    enableDefaultTelemetry: enableDefaultTelemetry
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
   dependsOn: [
     protectionContainer


### PR DESCRIPTION
# Description

Add `enableReferencedModulesTelemetry `variable and usage to disable by default telemetry on cross referenced resources

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![CDN: Profiles](https://github.com/Azure/ResourceModules/actions/workflows/ms.cdn.profiles.yml/badge.svg?branch=users%2Ferikag%2Ftelemetry-fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cdn.profiles.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
