### PR TITLE
[Fixes] Replace 'adp' naming prefix across modules

### DIFF
--- a/modules/Microsoft.Network/bastionHosts/.test/custompip/deploy.test.bicep
+++ b/modules/Microsoft.Network/bastionHosts/.test/custompip/deploy.test.bicep
@@ -57,7 +57,7 @@ module testDeployment '../../deploy.bicep' = {
       diagnosticMetricsToEnable: [
         'AllMetrics'
       ]
-      name: 'adp-<<namePrefix>>-az-pip-custom-x-bas'
+      name: '<<namePrefix>>${serviceShort}001-pip'
       publicIPAllocationMethod: 'Static'
       publicIPPrefixResourceId: ''
       roleAssignments: [

--- a/modules/Microsoft.Network/bastionHosts/readme.md
+++ b/modules/Microsoft.Network/bastionHosts/readme.md
@@ -447,7 +447,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
       diagnosticMetricsToEnable: [
         'AllMetrics'
       ]
-      name: 'adp-<<namePrefix>>-az-pip-custom-x-bas'
+      name: '<<namePrefix>>nbhctmpip001-pip'
       publicIPAllocationMethod: 'Static'
       publicIPPrefixResourceId: ''
       roleAssignments: [
@@ -499,7 +499,7 @@ module bastionHosts './Microsoft.Network/bastionHosts/deploy.bicep' = {
         "diagnosticMetricsToEnable": [
           "AllMetrics"
         ],
-        "name": "adp-<<namePrefix>>-az-pip-custom-x-bas",
+        "name": "<<namePrefix>>nbhctmpip001-pip",
         "publicIPAllocationMethod": "Static",
         "publicIPPrefixResourceId": "",
         "roleAssignments": [

--- a/modules/Microsoft.Sql/servers/.test/pe/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/pe/deploy.test.bicep
@@ -36,7 +36,7 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
-    virtualNetworkName: 'adp-<<namePrefix>>-vnet-${serviceShort}'
+    virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
     location: location
   }
 }


### PR DESCRIPTION
# Description

Fixing naming, removing old `adp` ref

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network: BastionHosts](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml/badge.svg?branch=users%2Ferikag%2Fadp-cleanup)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
