### PR TITLE
Enabled RBAC role assignment for disk encrpytion set key

### DIFF
--- a/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_keyVaultPermissions.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_keyVaultPermissions.bicep
@@ -1,0 +1,51 @@
+@description('Required. A boolean to specify whether or not the used Key Vault has RBAC authentication enabled or not.')
+param rbacAuthorizationEnabled bool = true
+
+@description('Required. The principal to assign permissions to.')
+param principalId string
+
+@description('Optional. Resource location.')
+param location string = resourceGroup().location
+
+@description('Required. Resource ID of the KeyVault containing the key or secret.')
+param keyVaultResourceId string
+
+@description('Required. Key URL (with version) pointing to a key or secret in KeyVault.')
+param keyName string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
+  name: last(split(keyVaultResourceId, '/'))!
+
+  resource key 'keys@2021-10-01' existing = {
+    name: keyName
+  }
+}
+
+resource keyVaultKeyRBAC 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacAuthorizationEnabled == true) {
+  name: guid('msi-${keyVault::key.id}-${location}-${principalId}-Key-Reader-RoleAssignment')
+  scope: keyVault::key
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424') // Key Vault Crypto User
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource accessPolicies 'Microsoft.KeyVault/vaults/accessPolicies@2022-07-01' = if (rbacAuthorizationEnabled != true) {
+  name: '${uniqueString(deployment().name, location)}-DiskEncrSet-KVAccessPolicies'
+  properties: {
+    accessPolicies: [
+      {
+        objectId: principalId
+        permissions: {
+          keys: [
+            'get'
+            'wrapKey'
+            'unwrapKey'
+          ]
+        }
+        tenantId: subscription().tenantId
+      }
+    ]
+  }
+}

--- a/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_keyVaultPermissions.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_keyVaultPermissions.bicep
@@ -47,7 +47,7 @@ resource keyVaultKeyRBAC 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
 // Access Policy //
 // ============= //
 
-module keyVaultAccessPolicies '../../../Microsoft.KeyVault/vaults/accessPolicies/deploy.bicep' = {
+module keyVaultAccessPolicies '../../../Microsoft.KeyVault/vaults/accessPolicies/deploy.bicep' = if (rbacAuthorizationEnabled != true) {
   name: '${uniqueString(deployment().name, location)}-DiskEncrSet-KVAccessPolicies'
   params: {
     keyVaultName: last(split(keyVaultResourceId, '/'))!

--- a/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_managedIdentityReference.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_managedIdentityReference.bicep
@@ -1,0 +1,12 @@
+@description('Required. The name of the User Assigned Identity to fetch the principal ID from.')
+param userAssignedIdentityName string
+
+@description('Optional. Resource location.')
+param location string = resourceGroup().location
+
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: userAssignedIdentityName
+  location: location
+}
+
+output principalId string = userAssignedIdentity.properties.principalId

--- a/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_roleAssignments.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.bicep/nested_roleAssignments.bicep
@@ -69,7 +69,7 @@ var builtInRoleNames = {
 }
 
 resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2020-12-01' existing = {
-  name: last(split(resourceId, '/'))
+  name: last(split(resourceId, '/'))!
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/accessPolicies/dependencies.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/accessPolicies/dependencies.bicep
@@ -1,0 +1,51 @@
+@description('Optional. The location to deploy to.')
+param location string = resourceGroup().location
+
+@description('Required. The name of the Key Vault to create.')
+param keyVaultName string
+
+@description('Required. The name of the Managed Identity to create.')
+param managedIdentityName string
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+    name: managedIdentityName
+    location: location
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+    name: keyVaultName
+    location: location
+    properties: {
+        sku: {
+            family: 'A'
+            name: 'standard'
+        }
+        tenantId: tenant().tenantId
+        enablePurgeProtection: true // Required by disk encryption set
+        softDeleteRetentionInDays: 7
+        enabledForTemplateDeployment: true
+        enabledForDiskEncryption: true
+        enabledForDeployment: true
+        enableRbacAuthorization: false
+        accessPolicies: []
+    }
+
+    resource key 'keys@2022-07-01' = {
+        name: 'keyEncryptionKey'
+        properties: {
+            kty: 'RSA'
+        }
+    }
+}
+
+@description('The resource ID of the created Key Vault.')
+output keyVaultResourceId string = keyVault.id
+
+@description('The name of the created encryption key.')
+output keyName string = keyVault::key.name
+
+@description('The principal ID of the created Managed Identity.')
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId
+
+@description('The resource ID of the created Managed Identity.')
+output managedIdentityResourceId string = managedIdentity.id

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/accessPolicies/deploy.test.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/accessPolicies/deploy.test.bicep
@@ -1,0 +1,70 @@
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'ms.compute.diskencryptionsets-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param location string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'cdesap'
+
+@description('Generated. Used as a basis for unique resource names.')
+param baseTime string = utcNow('u')
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module nestedDependencies 'dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-nestedDependencies'
+  params: {
+    // Adding base time to make the name unique as purge protection must be enabled (but may not be longer than 24 characters total)
+    keyVaultName: 'dep-<<namePrefix>>-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
+    managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
+  }
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../deploy.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  params: {
+    enableDefaultTelemetry: enableDefaultTelemetry
+    name: '<<namePrefix>>${serviceShort}001'
+    keyName: nestedDependencies.outputs.keyName
+    keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+    roleAssignments: [
+      {
+        roleDefinitionIdOrName: 'Reader'
+        principalIds: [
+          nestedDependencies.outputs.managedIdentityPrincipalId
+        ]
+        principalType: 'ServicePrincipal'
+      }
+    ]
+    systemAssignedIdentity: true
+    userAssignedIdentities: {
+      '${nestedDependencies.outputs.managedIdentityResourceId}': {}
+    }
+  }
+}

--- a/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/.test/common/dependencies.bicep
@@ -38,16 +38,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     }
 }
 
-resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-    name: guid('msi-${keyVault::key.id}-${location}-${managedIdentity.id}-Key-Reader-RoleAssignment')
-    scope: keyVault::key
-    properties: {
-        principalId: managedIdentity.properties.principalId
-        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424') // Key Vault Crypto User
-        principalType: 'ServicePrincipal'
-    }
-}
-
 @description('The resource ID of the created Key Vault.')
 output keyVaultResourceId string = keyVault.id
 

--- a/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
+++ b/modules/Microsoft.Compute/diskEncryptionSets/deploy.bicep
@@ -69,7 +69,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' existing = {
   }
 }
 
-// Note: This is only enabled for user-assigned identities and the service's system-assigned identity isn't available during its intitial deployment
+// Note: This is only enabled for user-assigned identities as the service's system-assigned identity isn't available during its initial deployment
 module keyVaultPermissions '.bicep/nested_keyVaultPermissions.bicep' = [for (userAssignedIdentityId, index) in items(userAssignedIdentities): {
   name: '${uniqueString(deployment().name, location)}-DiskEncrSet-KVPermissions-${index}'
   params: {

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -192,7 +192,11 @@ userAssignedIdentities: {
 
 ## Cross-referenced modules
 
-_None_
+This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `Microsoft.KeyVault/vaults/accessPolicies` | Local reference |
 
 ## Deployment examples
 
@@ -201,7 +205,92 @@ The following module usage examples are retrieved from the content of the files 
 
    >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
 
-<h3>Example 1: Common</h3>
+<h3>Example 1: Accesspolicies</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module diskEncryptionSets './Microsoft.Compute/diskEncryptionSets/deploy.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-test-cdesap'
+  params: {
+    // Required parameters
+    keyName: '<keyName>'
+    keyVaultResourceId: '<keyVaultResourceId>'
+    name: '<<namePrefix>>cdesap001'
+    // Non-required parameters
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    roleAssignments: [
+      {
+        principalIds: [
+          '<managedIdentityPrincipalId>'
+        ]
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'Reader'
+      }
+    ]
+    systemAssignedIdentity: true
+    userAssignedIdentities: {
+      '<managedIdentityResourceId>': {}
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "keyName": {
+      "value": "<keyName>"
+    },
+    "keyVaultResourceId": {
+      "value": "<keyVaultResourceId>"
+    },
+    "name": {
+      "value": "<<namePrefix>>cdesap001"
+    },
+    // Non-required parameters
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
+    "roleAssignments": {
+      "value": [
+        {
+          "principalIds": [
+            "<managedIdentityPrincipalId>"
+          ],
+          "principalType": "ServicePrincipal",
+          "roleDefinitionIdOrName": "Reader"
+        }
+      ]
+    },
+    "systemAssignedIdentity": {
+      "value": true
+    },
+    "userAssignedIdentities": {
+      "value": {
+        "<managedIdentityResourceId>": {}
+      }
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<h3>Example 2: Common</h3>
 
 <details>
 

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -181,20 +181,17 @@ userAssignedIdentities: {
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
+| `identities` | object | The idenities of the disk encryption set. |
 | `keyVaultName` | string | The name of the key vault with the disk encryption key. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the disk encryption set. |
+| `principalId` | string | The principal ID of the disk encryption set. |
 | `resourceGroupName` | string | The resource group the disk encryption set was deployed into. |
 | `resourceId` | string | The resource ID of the disk encryption set. |
-| `systemAssignedPrincipalId` | string | The principal ID of the disk encryption set. |
 
 ## Cross-referenced modules
 
-This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
-
-| Reference | Type |
-| :-- | :-- |
-| `Microsoft.KeyVault/vaults/accessPolicies` | Local reference |
+_None_
 
 ## Deployment examples
 

--- a/modules/Microsoft.Compute/diskEncryptionSets/readme.md
+++ b/modules/Microsoft.Compute/diskEncryptionSets/readme.md
@@ -17,6 +17,7 @@ This template deploys a disk encryption set.
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Compute/diskEncryptionSets` | [2022-07-02](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-07-02/diskEncryptionSets) |
 | `Microsoft.KeyVault/vaults/accessPolicies` | [2022-07-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults/accessPolicies) |
+| `Microsoft.ManagedIdentity/userAssignedIdentities` | [2018-11-30](https://docs.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2018-11-30/userAssignedIdentities) |
 
 ## Parameters
 


### PR DESCRIPTION
# Description

- Enabled RBAC authorization of the Key used in the Disk Encryption Set. Before it was limited to RBAC.
> NOTE: The solution works with User-Assigned Identities only. The reason is that the System-Assigned identity is not yet available when the role assignment would need to happen

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Compute: DiskEncryptionSets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml/badge.svg?branch=users%2Falsehr%2F2683_rbac)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
