### PR TITLE
[Modules] Support for configuring backup retention policies for Azure SQL Database

### DIFF
--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -116,6 +116,8 @@ module testDeployment '../../deploy.bicep' = {
         diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
         diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
         elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/<<namePrefix>>-${serviceShort}/elasticPools/<<namePrefix>>-${serviceShort}-ep-001'
+        backupLogRetentionDays: 14
+        backupWeeklyRetention: 'P4W'
       }
     ]
     firewallRules: [

--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -116,7 +116,6 @@ module testDeployment '../../deploy.bicep' = {
         diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
         diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
         elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/<<namePrefix>>-${serviceShort}/elasticPools/<<namePrefix>>-${serviceShort}-ep-001'
-        backupLogRetentionDays: 14
         backupShortTermRetentionPolicy: {
           retentionDays: 14
         }

--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -117,10 +117,10 @@ module testDeployment '../../deploy.bicep' = {
         diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
         elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/<<namePrefix>>-${serviceShort}/elasticPools/<<namePrefix>>-${serviceShort}-ep-001'
         backupLogRetentionDays: 14
-        backupShortTermRetentionPolicies: {
+        backupShortTermRetentionPolicy: {
           retentionDays: 14
         }
-        backupLongTermRetentionPolicies: {
+        backupLongTermRetentionPolicy: {
           monthlyRetention: 'P6M'
         }
       }

--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -117,7 +117,12 @@ module testDeployment '../../deploy.bicep' = {
         diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
         elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/<<namePrefix>>-${serviceShort}/elasticPools/<<namePrefix>>-${serviceShort}-ep-001'
         backupLogRetentionDays: 14
-        backupWeeklyRetention: 'P4W'
+        backupShortTermRetentionPolicies: {
+          retentionDays: 14
+        }
+        backupLongTermRetentionPolicies: {
+          monthlyRetention: 'P6M'
+        }
       }
     ]
     firewallRules: [

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
@@ -36,5 +36,11 @@ resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLo
   }
 }
 
-@description('The resource group of the deployed azure sql backup policy.')
+@description('The resource group the long-term policy was deployed into.')
 output resourceGroupName string = resourceGroup().name
+
+@description('The name of the long-term policy.')
+output name string = backupLongTermRetentionPolicy.name
+
+@description('The resource ID of the long-term policy.')
+output resourceId string = backupLongTermRetentionPolicy.id

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
@@ -1,0 +1,40 @@
+@description('Required. The name of the parent SQL Server.')
+param serverName string
+
+@description('Required. The name of the parent database.')
+param databaseName string
+
+@description('Optional. Monthly retention in ISO 8601 duration format.')
+param weeklyRetention string = ''
+
+@description('Optional. Weekly retention in ISO 8601 duration format.')
+param monthlyRetention string = ''
+
+@description('Optional. Week of year backup to keep for yearly retention.')
+param weekOfYear int = 1
+
+@description('Optional. Yearly retention in ISO 8601 duration format.')
+param yearlyRetention string = ''
+
+resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+  name: serverName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2022-05-01-preview' existing = {
+  name: databaseName
+  parent: server
+}
+
+resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2022-05-01-preview' = {
+  name: 'default'
+  parent: database
+  properties: {
+    monthlyRetention: monthlyRetention
+    weeklyRetention: weeklyRetention
+    weekOfYear: weekOfYear
+    yearlyRetention: yearlyRetention
+  }
+}
+
+@description('The resource group of the deployed azure sql backup policy.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
@@ -1,0 +1,45 @@
+# SQL Server Database Long Term Backup Retention Policy `[Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies]`
+
+This module deploys a long term retention policy for a Azure SQL Database.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `databaseName` | string | The name of the parent database. |
+| `serverName` | string | The name of the parent SQL Server. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `monthlyRetention` | string | `''` | Weekly retention in ISO 8601 duration format. |
+| `weeklyRetention` | string | `''` | Monthly retention in ISO 8601 duration format. |
+| `weekOfYear` | int | `1` | Week of year backup to keep for yearly retention. |
+| `yearlyRetention` | string | `''` | Yearly retention in ISO 8601 duration format. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/version.json
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1"
+}

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
@@ -28,5 +28,11 @@ resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupS
   }
 }
 
-@description('The resource group of the deployed azure sql backup policy.')
+@description('The resource group the short-term policy was deployed into.')
 output resourceGroupName string = resourceGroup().name
+
+@description('The name of the short-term policy.')
+output name string = backupShortTermRetentionPolicy.name
+
+@description('The resource ID of the short-term policy.')
+output resourceId string = backupShortTermRetentionPolicy.id

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
@@ -1,0 +1,32 @@
+@description('Required. The name of the parent SQL Server.')
+param serverName string
+
+@description('Required. The name of the parent database.')
+param databaseName string
+
+@description('Optional. Differential backup interval in hours.')
+param diffBackupIntervalInHours int = 24
+
+@description('Optional. Poin-in-time retention in days.')
+param retentionDays int = 7
+
+resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+  name: serverName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2022-05-01-preview' existing = {
+  name: databaseName
+  parent: server
+}
+
+resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2022-05-01-preview' = {
+  name: 'default'
+  parent: database
+  properties: {
+    diffBackupIntervalInHours: diffBackupIntervalInHours
+    retentionDays: retentionDays
+  }
+}
+
+@description('The resource group of the deployed azure sql backup policy.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
@@ -1,0 +1,43 @@
+# SQL Server Database Short Term Backup Retention Policy `[Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies]`
+
+This module deploys a short term retention policy for a Azure SQL Database.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `databaseName` | string | The name of the parent database. |
+| `serverName` | string | The name of the parent SQL Server. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `diffBackupIntervalInHours` | int | `24` | Differential backup interval in hours. |
+| `retentionDays` | int | `7` | Poin-in-time retention in days. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/version.json
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1"
+}

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -158,26 +158,11 @@ param isLedgerOn bool = false
 @description('Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.')
 param maintenanceConfigurationId string = ''
 
-@description('Optional. Differential backup interval in hours.')
-param backupDifferentialInterval int = 24
+@description('Optional. The short term backup retention policies to create for the database.')
+param backupShortTermRetentionPolicies object = {}
 
-@description('Optional. Poin-in-time backup retention in days.')
-@maxValue(35)
-param backupLogRetentionDays int = 7
-
-@description('Optional. Monthly retention in ISO 8601 duration format.')
-param backupWeeklyRetention string = ''
-
-@description('Optional. Weekly retention in ISO 8601 duration format.')
-param backupMonthlyRetention string = ''
-
-@description('Optional. Backup week of year to keep for yearly retention.')
-@minValue(1)
-@maxValue(53)
-param backupYearlyRetentionWeek int = 1
-
-@description('Optional. Yearly retention in ISO 8601 duration format.')
-param backupYearlyRetention string = ''
+@description('Optional. The long term backup retention policies to create for the database.')
+param backupLongTermRetentionPolicies object = {}
 
 // The SKU object must be built in a variable
 // The alternative, 'null' as default values, leads to non-terminating deployments
@@ -249,8 +234,8 @@ module database_backupShortTermRetentionPolicies 'backupShortTermRetentionPolici
   params: {
     serverName: serverName
     databaseName: database.name
-    diffBackupIntervalInHours: backupDifferentialInterval
-    retentionDays: backupLogRetentionDays
+    diffBackupIntervalInHours: contains(backupShortTermRetentionPolicies, 'diffBackupIntervalInHours') ? backupShortTermRetentionPolicies.diffBackupIntervalInHours : 24
+    retentionDays: contains(backupShortTermRetentionPolicies, 'retentionDays') ? backupShortTermRetentionPolicies.retentionDays : 7
   }
 }
 
@@ -259,10 +244,10 @@ module database_backupLongTermRetentionPolicies 'backupLongTermRetentionPolicies
   params: {
     serverName: serverName
     databaseName: database.name
-    weeklyRetention: backupWeeklyRetention
-    monthlyRetention: backupMonthlyRetention
-    yearlyRetention: backupYearlyRetention
-    weekOfYear: backupYearlyRetentionWeek
+    weeklyRetention: contains(backupLongTermRetentionPolicies, 'weeklyRetention') ? backupLongTermRetentionPolicies.weeklyRetention : ''
+    monthlyRetention: contains(backupLongTermRetentionPolicies, 'monthlyRetention') ? backupLongTermRetentionPolicies.monthlyRetention : ''
+    yearlyRetention: contains(backupLongTermRetentionPolicies, 'yearlyRetention') ? backupLongTermRetentionPolicies.yearlyRetention : ''
+    weekOfYear: contains(backupLongTermRetentionPolicies, 'weekOfYear') ? backupLongTermRetentionPolicies.weekOfYear : 1
   }
 }
 

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -244,7 +244,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
   scope: database
 }
 
-module database_shortTermBackupRetention 'backupShortTermRetentionPolicies/deploy.bicep' = {
+module database_backupShortTermRetentionPolicies 'backupShortTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
   params: {
     serverName: serverName

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -254,7 +254,7 @@ module database_backupShortTermRetentionPolicies 'backupShortTermRetentionPolici
   }
 }
 
-module database_longTermBackupRetention 'backupLongTermRetentionPolicies/deploy.bicep' = {
+module database_backupLongTermRetentionPolicies 'backupLongTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
   params: {
     serverName: serverName

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -261,15 +261,12 @@ module database_longTermBackupRetention 'backupLongTermRetentionPolicies/deploy.
   name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
   params: {
     serverName: serverName
-    databaseName: name
+    databaseName: database.name
     weeklyRetention: backupWeeklyRetention
     monthlyRetention: backupMonthlyRetention
     yearlyRetention: backupYearlyRetention
     weekOfYear: backupYearlyRetentionWeek
   }
-  dependsOn: [
-    database
-  ]
 }
 
 @description('The name of the deployed database.')

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -248,13 +248,10 @@ module database_shortTermBackupRetention 'backupShortTermRetentionPolicies/deplo
   name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
   params: {
     serverName: serverName
-    databaseName: name
+    databaseName: database.name
     diffBackupIntervalInHours: backupDifferentialInterval
     retentionDays: backupLogRetentionDays
   }
-  dependsOn: [
-    database
-  ]
 }
 
 module database_longTermBackupRetention 'backupLongTermRetentionPolicies/deploy.bicep' = {

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -158,11 +158,11 @@ param isLedgerOn bool = false
 @description('Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.')
 param maintenanceConfigurationId string = ''
 
-@description('Optional. The short term backup retention policies to create for the database.')
-param backupShortTermRetentionPolicies object = {}
+@description('Optional. The short term backup retention policy to create for the database.')
+param backupShortTermRetentionPolicy object = {}
 
-@description('Optional. The long term backup retention policies to create for the database.')
-param backupLongTermRetentionPolicies object = {}
+@description('Optional. The long term backup retention policy to create for the database.')
+param backupLongTermRetentionPolicy object = {}
 
 // The SKU object must be built in a variable
 // The alternative, 'null' as default values, leads to non-terminating deployments
@@ -229,25 +229,25 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
   scope: database
 }
 
-module database_backupShortTermRetentionPolicies 'backupShortTermRetentionPolicies/deploy.bicep' = {
+module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
   params: {
     serverName: serverName
     databaseName: database.name
-    diffBackupIntervalInHours: contains(backupShortTermRetentionPolicies, 'diffBackupIntervalInHours') ? backupShortTermRetentionPolicies.diffBackupIntervalInHours : 24
-    retentionDays: contains(backupShortTermRetentionPolicies, 'retentionDays') ? backupShortTermRetentionPolicies.retentionDays : 7
+    diffBackupIntervalInHours: contains(backupShortTermRetentionPolicy, 'diffBackupIntervalInHours') ? backupShortTermRetentionPolicy.diffBackupIntervalInHours : 24
+    retentionDays: contains(backupShortTermRetentionPolicy, 'retentionDays') ? backupShortTermRetentionPolicy.retentionDays : 7
   }
 }
 
-module database_backupLongTermRetentionPolicies 'backupLongTermRetentionPolicies/deploy.bicep' = {
+module database_backupLongTermRetentionPolicy 'backupLongTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
   params: {
     serverName: serverName
     databaseName: database.name
-    weeklyRetention: contains(backupLongTermRetentionPolicies, 'weeklyRetention') ? backupLongTermRetentionPolicies.weeklyRetention : ''
-    monthlyRetention: contains(backupLongTermRetentionPolicies, 'monthlyRetention') ? backupLongTermRetentionPolicies.monthlyRetention : ''
-    yearlyRetention: contains(backupLongTermRetentionPolicies, 'yearlyRetention') ? backupLongTermRetentionPolicies.yearlyRetention : ''
-    weekOfYear: contains(backupLongTermRetentionPolicies, 'weekOfYear') ? backupLongTermRetentionPolicies.weekOfYear : 1
+    weeklyRetention: contains(backupLongTermRetentionPolicy, 'weeklyRetention') ? backupLongTermRetentionPolicy.weeklyRetention : ''
+    monthlyRetention: contains(backupLongTermRetentionPolicy, 'monthlyRetention') ? backupLongTermRetentionPolicy.monthlyRetention : ''
+    yearlyRetention: contains(backupLongTermRetentionPolicy, 'yearlyRetention') ? backupLongTermRetentionPolicy.yearlyRetention : ''
+    weekOfYear: contains(backupLongTermRetentionPolicy, 'weekOfYear') ? backupLongTermRetentionPolicy.weekOfYear : 1
   }
 }
 

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -244,7 +244,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
   scope: database
 }
 
-module database_shortTermBackupRetention 'backupShortTermRetentionPolicies/deploy.bicep' = if ((backupDifferentialInterval != 24) || (backupLogRetentionDays != 7)) {
+module database_shortTermBackupRetention 'backupShortTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
   params: {
     serverName: serverName
@@ -257,7 +257,7 @@ module database_shortTermBackupRetention 'backupShortTermRetentionPolicies/deplo
   ]
 }
 
-module database_longTermBackupRetention 'backupLongTermRetentionPolicies/deploy.bicep' = if ((!empty(backupWeeklyRetention)) || (!empty(backupMonthlyRetention)) || (!empty(backupYearlyRetention))) {
+module database_longTermBackupRetention 'backupLongTermRetentionPolicies/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
   params: {
     serverName: serverName

--- a/modules/Microsoft.Sql/servers/databases/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/readme.md
@@ -37,8 +37,8 @@ This module deploys an Azure SQL Server Database.
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `autoPauseDelay` | int | `0` |  | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
-| `backupLongTermRetentionPolicies` | _[backupLongTermRetentionPolicies](backupLongTermRetentionPolicies/readme.md)_ object | `{object}` |  | The long term backup retention policies to create for the database. |
-| `backupShortTermRetentionPolicies` | _[backupShortTermRetentionPolicies](backupShortTermRetentionPolicies/readme.md)_ object | `{object}` |  | The short term backup retention policies to create for the database. |
+| `backupLongTermRetentionPolicy` | object | `{object}` |  | The long term backup retention policy to create for the database. |
+| `backupShortTermRetentionPolicy` | object | `{object}` |  | The short term backup retention policy to create for the database. |
 | `collation` | string | `'SQL_Latin1_General_CP1_CI_AS'` |  | The collation of the database. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
 | `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |

--- a/modules/Microsoft.Sql/servers/databases/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/readme.md
@@ -37,12 +37,8 @@ This module deploys an Azure SQL Server Database.
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `autoPauseDelay` | int | `0` |  | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
-| `backupDifferentialInterval` | int | `24` |  | Differential backup interval in hours. |
-| `backupLogRetentionDays` | int | `7` |  | Poin-in-time backup retention in days. |
-| `backupMonthlyRetention` | string | `''` |  | Weekly retention in ISO 8601 duration format. |
-| `backupWeeklyRetention` | string | `''` |  | Monthly retention in ISO 8601 duration format. |
-| `backupYearlyRetention` | string | `''` |  | Yearly retention in ISO 8601 duration format. |
-| `backupYearlyRetentionWeek` | int | `1` |  | Backup week of year to keep for yearly retention. |
+| `backupLongTermRetentionPolicies` | _[backupLongTermRetentionPolicies](backupLongTermRetentionPolicies/readme.md)_ object | `{object}` |  | The long term backup retention policies to create for the database. |
+| `backupShortTermRetentionPolicies` | _[backupShortTermRetentionPolicies](backupShortTermRetentionPolicies/readme.md)_ object | `{object}` |  | The short term backup retention policies to create for the database. |
 | `collation` | string | `'SQL_Latin1_General_CP1_CI_AS'` |  | The collation of the database. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
 | `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |

--- a/modules/Microsoft.Sql/servers/databases/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/readme.md
@@ -15,6 +15,8 @@ This module deploys an Azure SQL Server Database.
 | :-- | :-- |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Sql/servers/databases` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2021-11-01/servers/databases) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
 
@@ -35,6 +37,12 @@ This module deploys an Azure SQL Server Database.
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `autoPauseDelay` | int | `0` |  | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
+| `backupDifferentialInterval` | int | `24` |  | Differential backup interval in hours. |
+| `backupLogRetentionDays` | int | `7` |  | Poin-in-time backup retention in days. |
+| `backupMonthlyRetention` | string | `''` |  | Weekly retention in ISO 8601 duration format. |
+| `backupWeeklyRetention` | string | `''` |  | Monthly retention in ISO 8601 duration format. |
+| `backupYearlyRetention` | string | `''` |  | Yearly retention in ISO 8601 duration format. |
+| `backupYearlyRetentionWeek` | int | `1` |  | Backup week of year to keep for yearly retention. |
 | `collation` | string | `'SQL_Latin1_General_CP1_CI_AS'` |  | The collation of the database. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
 | `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |

--- a/modules/Microsoft.Sql/servers/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/deploy.bicep
@@ -180,6 +180,12 @@ module server_databases 'databases/deploy.bicep' = [for (database, index) in dat
     diagnosticSettingsName: contains(database, 'diagnosticSettingsName') ? database.diagnosticSettingsName : '${database.name}-diagnosticSettings'
     elasticPoolId: contains(database, 'elasticPoolId') ? database.elasticPoolId : ''
     enableDefaultTelemetry: enableReferencedModulesTelemetry
+    backupDifferentialInterval: contains(database, 'backupDifferentialInterval') ? database.backupDifferentialInterval : 24
+    backupLogRetentionDays: contains(database, 'backupLogRetentionDays') ? database.backupLogRetentionDays : 7
+    backupWeeklyRetention: contains(database, 'backupWeeklyRetention') ? database.backupWeeklyRetention : ''
+    backupMonthlyRetention: contains(database, 'backupMonthlyRetention') ? database.backupMonthlyRetention : ''
+    backupYearlyRetention: contains(database, 'backupYearlyRetention') ? database.backupYearlyRetention : ''
+    backupYearlyRetentionWeek: contains(database, 'backupYearlyRetentionWeek') ? database.backupYearlyRetentionWeek : 1
   }
   dependsOn: [
     server_elasticPools // Enables us to add databases to existing elastic pools

--- a/modules/Microsoft.Sql/servers/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/deploy.bicep
@@ -180,8 +180,8 @@ module server_databases 'databases/deploy.bicep' = [for (database, index) in dat
     diagnosticSettingsName: contains(database, 'diagnosticSettingsName') ? database.diagnosticSettingsName : '${database.name}-diagnosticSettings'
     elasticPoolId: contains(database, 'elasticPoolId') ? database.elasticPoolId : ''
     enableDefaultTelemetry: enableReferencedModulesTelemetry
-    backupShortTermRetentionPolicies: contains(database, 'backupShortTermRetentionPolicies') ? database.backupShortTermRetentionPolicies : {}
-    backupLongTermRetentionPolicies: contains(database, 'backupLongTermRetentionPolicies') ? database.backupLongTermRetentionPolicies : {}
+    backupShortTermRetentionPolicy: contains(database, 'backupShortTermRetentionPolicy') ? database.backupShortTermRetentionPolicy : {}
+    backupLongTermRetentionPolicy: contains(database, 'backupLongTermRetentionPolicy') ? database.backupLongTermRetentionPolicy : {}
   }
   dependsOn: [
     server_elasticPools // Enables us to add databases to existing elastic pools

--- a/modules/Microsoft.Sql/servers/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/deploy.bicep
@@ -180,12 +180,8 @@ module server_databases 'databases/deploy.bicep' = [for (database, index) in dat
     diagnosticSettingsName: contains(database, 'diagnosticSettingsName') ? database.diagnosticSettingsName : '${database.name}-diagnosticSettings'
     elasticPoolId: contains(database, 'elasticPoolId') ? database.elasticPoolId : ''
     enableDefaultTelemetry: enableReferencedModulesTelemetry
-    backupDifferentialInterval: contains(database, 'backupDifferentialInterval') ? database.backupDifferentialInterval : 24
-    backupLogRetentionDays: contains(database, 'backupLogRetentionDays') ? database.backupLogRetentionDays : 7
-    backupWeeklyRetention: contains(database, 'backupWeeklyRetention') ? database.backupWeeklyRetention : ''
-    backupMonthlyRetention: contains(database, 'backupMonthlyRetention') ? database.backupMonthlyRetention : ''
-    backupYearlyRetention: contains(database, 'backupYearlyRetention') ? database.backupYearlyRetention : ''
-    backupYearlyRetentionWeek: contains(database, 'backupYearlyRetentionWeek') ? database.backupYearlyRetentionWeek : 1
+    backupShortTermRetentionPolicies: contains(database, 'backupShortTermRetentionPolicies') ? database.backupShortTermRetentionPolicies : {}
+    backupLongTermRetentionPolicies: contains(database, 'backupLongTermRetentionPolicies') ? database.backupLongTermRetentionPolicies : {}
   }
   dependsOn: [
     server_elasticPools // Enables us to add databases to existing elastic pools

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -439,44 +439,102 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
 module servers './Microsoft.Sql/servers/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-sqlscom'
   params: {
-    // Required parameters
-    name: 'tfsbx-sqlscom'
-    // Non-required parameters
+    name: '<<namePrefix>>-sqlscom'
     administratorLogin: 'adminUserName'
     administratorLoginPassword: '<administratorLoginPassword>'
     databases: [
       {
         backupLogRetentionDays: 14
-        backupMonthlyRetention: 'P5M'
+        backupWeeklyRetention: 'P4W'
         capacity: 0
         collation: 'SQL_Latin1_General_CP1_CI_AS'
+        diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
+        diagnosticEventHubName: '<diagnosticEventHubName>'
+        diagnosticLogsRetentionInDays: 7
+        diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
+        diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
         elasticPoolId: '<elasticPoolId>'
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
-        name: 'tfsbx-sqlscomdb-001'
+        name: '<<namePrefix>>-sqlscomdb-001'
         skuName: 'ElasticPool'
         skuTier: 'GeneralPurpose'
-        tags: {
-          costallocation: 'test'
-        }
       }
     ]
     elasticPools: [
       {
         maintenanceConfigurationId: '<maintenanceConfigurationId>'
-        name: 'tfsbx-sqlscom-ep-001'
+        name: '<<namePrefix>>-sqlscom-ep-001'
         skuCapacity: 10
         skuName: 'GP_Gen5'
         skuTier: 'GeneralPurpose'
-        tags: {
-          costallocation: 'test'
-        }
       }
     ]
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    firewallRules: [
+      {
+        endIpAddress: '0.0.0.0'
+        name: 'AllowAllWindowsAzureIps'
+        startIpAddress: '0.0.0.0'
+      }
+    ]
+    keys: [
+      {
+        name: '<name>'
+        serverKeyType: 'AzureKeyVault'
+        uri: '<uri>'
+      }
+    ]
     location: '<location>'
-    tags: {
-      costallocation: 'test'
+    lock: 'CanNotDelete'
+    primaryUserAssignedIdentityId: '<primaryUserAssignedIdentityId>'
+    privateEndpoints: [
+      {
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            '<privateDNSResourceId>'
+          ]
+        }
+        service: 'sqlServer'
+        subnetResourceId: '<subnetResourceId>'
+      }
+    ]
+    roleAssignments: [
+      {
+        principalIds: [
+          '<managedIdentityPrincipalId>'
+        ]
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'Reader'
+      }
+    ]
+    securityAlertPolicies: [
+      {
+        emailAccountAdmins: true
+        name: 'Default'
+        state: 'Enabled'
+      }
+    ]
+    systemAssignedIdentity: true
+    userAssignedIdentities: {
+      '<managedIdentityResourceId>': {}
+    }
+    virtualNetworkRules: [
+      {
+        ignoreMissingVnetServiceEndpoint: true
+        name: 'newVnetRule1'
+        virtualNetworkSubnetId: '<virtualNetworkSubnetId>'
+      }
+    ]
+    vulnerabilityAssessmentsObj: {
+      emailSubscriptionAdmins: true
+      name: 'default'
+      recurringScansEmails: [
+        'test1@contoso.com'
+        'test2@contoso.com'
+      ]
+      recurringScansIsEnabled: true
+      vulnerabilityAssessmentsStorageAccountId: '<vulnerabilityAssessmentsStorageAccountId>'
     }
   }
 }
@@ -494,11 +552,9 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
-      "value": "tfsbx-sqlscom"
+      "value": "<<namePrefix>>-sqlscom"
     },
-    // Non-required parameters
     "administratorLogin": {
       "value": "adminUserName"
     },
@@ -509,18 +565,20 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "backupLogRetentionDays": 14,
-          "backupMonthlyRetention": "P5M",
+          "backupWeeklyRetention": "P4W",
           "capacity": 0,
           "collation": "SQL_Latin1_General_CP1_CI_AS",
+          "diagnosticEventHubAuthorizationRuleId": "<diagnosticEventHubAuthorizationRuleId>",
+          "diagnosticEventHubName": "<diagnosticEventHubName>",
+          "diagnosticLogsRetentionInDays": 7,
+          "diagnosticStorageAccountId": "<diagnosticStorageAccountId>",
+          "diagnosticWorkspaceId": "<diagnosticWorkspaceId>",
           "elasticPoolId": "<elasticPoolId>",
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
-          "name": "tfsbx-sqlscomdb-001",
+          "name": "<<namePrefix>>-sqlscomdb-001",
           "skuName": "ElasticPool",
-          "skuTier": "GeneralPurpose",
-          "tags": {
-            "costallocation": "test"
-          }
+          "skuTier": "GeneralPurpose"
         }
       ]
     },
@@ -528,25 +586,103 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "maintenanceConfigurationId": "<maintenanceConfigurationId>",
-          "name": "tfsbx-sqlscom-ep-001",
+          "name": "<<namePrefix>>-sqlscom-ep-001",
           "skuCapacity": 10,
           "skuName": "GP_Gen5",
-          "skuTier": "GeneralPurpose",
-          "tags": {
-            "costallocation": "test"
-          }
+          "skuTier": "GeneralPurpose"
         }
       ]
     },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },
+    "firewallRules": {
+      "value": [
+        {
+          "endIpAddress": "0.0.0.0",
+          "name": "AllowAllWindowsAzureIps",
+          "startIpAddress": "0.0.0.0"
+        }
+      ]
+    },
+    "keys": {
+      "value": [
+        {
+          "name": "<name>",
+          "serverKeyType": "AzureKeyVault",
+          "uri": "<uri>"
+        }
+      ]
+    },
     "location": {
       "value": "<location>"
     },
-    "tags": {
+    "lock": {
+      "value": "CanNotDelete"
+    },
+    "primaryUserAssignedIdentityId": {
+      "value": "<primaryUserAssignedIdentityId>"
+    },
+    "privateEndpoints": {
+      "value": [
+        {
+          "privateDnsZoneGroup": {
+            "privateDNSResourceIds": [
+              "<privateDNSResourceId>"
+            ]
+          },
+          "service": "sqlServer",
+          "subnetResourceId": "<subnetResourceId>"
+        }
+      ]
+    },
+    "roleAssignments": {
+      "value": [
+        {
+          "principalIds": [
+            "<managedIdentityPrincipalId>"
+          ],
+          "principalType": "ServicePrincipal",
+          "roleDefinitionIdOrName": "Reader"
+        }
+      ]
+    },
+    "securityAlertPolicies": {
+      "value": [
+        {
+          "emailAccountAdmins": true,
+          "name": "Default",
+          "state": "Enabled"
+        }
+      ]
+    },
+    "systemAssignedIdentity": {
+      "value": true
+    },
+    "userAssignedIdentities": {
       "value": {
-        "costallocation": "test"
+        "<managedIdentityResourceId>": {}
+      }
+    },
+    "virtualNetworkRules": {
+      "value": [
+        {
+          "ignoreMissingVnetServiceEndpoint": true,
+          "name": "newVnetRule1",
+          "virtualNetworkSubnetId": "<virtualNetworkSubnetId>"
+        }
+      ]
+    },
+    "vulnerabilityAssessmentsObj": {
+      "value": {
+        "emailSubscriptionAdmins": true,
+        "name": "default",
+        "recurringScansEmails": [
+          "test1@contoso.com",
+          "test2@contoso.com"
+        ],
+        "recurringScansIsEnabled": true,
+        "vulnerabilityAssessmentsStorageAccountId": "<vulnerabilityAssessmentsStorageAccountId>"
       }
     }
   }

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -568,7 +568,6 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     "databases": {
       "value": [
         {
-          "backupLogRetentionDays": 14,
           "backupLongTermRetentionPolicy": {
             "monthlyRetention": "P6M"
           },

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -17,10 +17,12 @@ This module deploys a SQL server.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/privateEndpoints` | [2022-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/privateEndpoints) |
-| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-05-01/privateEndpoints/privateDnsZoneGroups) |
+| `Microsoft.Network/privateEndpoints` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints) |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints/privateDnsZoneGroups) |
 | `Microsoft.Sql/servers` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers) |
 | `Microsoft.Sql/servers/databases` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2021-11-01/servers/databases) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
 | `Microsoft.Sql/servers/elasticPools` | [2022-02-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-02-01-preview/servers/elasticPools) |
 | `Microsoft.Sql/servers/firewallRules` | [2022-02-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-02-01-preview/servers/firewallRules) |
 | `Microsoft.Sql/servers/keys` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/keys) |
@@ -41,7 +43,7 @@ This module deploys a SQL server.
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `administratorLogin` | string | `''` | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
-| `administratorLoginPassword` | securestring | `''` | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
+| `administratorLoginPassword` | secureString | `''` | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
 | `administrators` | object | `{object}` | The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | `primaryUserAssignedIdentityId` | string | `''` | The resource ID of a user assigned identity to be used by default. Required if "userAssignedIdentities" is not empty. |
 
@@ -442,6 +444,8 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     administratorLoginPassword: '<administratorLoginPassword>'
     databases: [
       {
+        backupLogRetentionDays: 14
+        backupWeeklyRetention: 'P4W'
         capacity: 0
         collation: 'SQL_Latin1_General_CP1_CI_AS'
         diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
@@ -560,6 +564,8 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     "databases": {
       "value": [
         {
+          "backupLogRetentionDays": 14,
+          "backupWeeklyRetention": "P4W",
           "capacity": 0,
           "collation": "SQL_Latin1_General_CP1_CI_AS",
           "diagnosticEventHubAuthorizationRuleId": "<diagnosticEventHubAuthorizationRuleId>",

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -445,7 +445,12 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     databases: [
       {
         backupLogRetentionDays: 14
-        backupWeeklyRetention: 'P4W'
+        backupLongTermRetentionPolicies: {
+          monthlyRetention: 'P6M'
+        }
+        backupShortTermRetentionPolicies: {
+          retentionDays: 14
+        }
         capacity: 0
         collation: 'SQL_Latin1_General_CP1_CI_AS'
         diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
@@ -565,7 +570,12 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "backupLogRetentionDays": 14,
-          "backupWeeklyRetention": "P4W",
+          "backupLongTermRetentionPolicies": {
+            "monthlyRetention": "P6M"
+          },
+          "backupShortTermRetentionPolicies": {
+            "retentionDays": 14
+          },
           "capacity": 0,
           "collation": "SQL_Latin1_General_CP1_CI_AS",
           "diagnosticEventHubAuthorizationRuleId": "<diagnosticEventHubAuthorizationRuleId>",

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -43,7 +43,7 @@ This module deploys a SQL server.
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `administratorLogin` | string | `''` | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
-| `administratorLoginPassword` | secureString | `''` | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
+| `administratorLoginPassword` | securestring | `''` | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
 | `administrators` | object | `{object}` | The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | `primaryUserAssignedIdentityId` | string | `''` | The resource ID of a user assigned identity to be used by default. Required if "userAssignedIdentities" is not empty. |
 
@@ -439,102 +439,44 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
 module servers './Microsoft.Sql/servers/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-sqlscom'
   params: {
-    name: '<<namePrefix>>-sqlscom'
+    // Required parameters
+    name: 'tfsbx-sqlscom'
+    // Non-required parameters
     administratorLogin: 'adminUserName'
     administratorLoginPassword: '<administratorLoginPassword>'
     databases: [
       {
         backupLogRetentionDays: 14
-        backupWeeklyRetention: 'P4W'
+        backupMonthlyRetention: 'P5M'
         capacity: 0
         collation: 'SQL_Latin1_General_CP1_CI_AS'
-        diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
-        diagnosticEventHubName: '<diagnosticEventHubName>'
-        diagnosticLogsRetentionInDays: 7
-        diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
-        diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
         elasticPoolId: '<elasticPoolId>'
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
-        name: '<<namePrefix>>-sqlscomdb-001'
+        name: 'tfsbx-sqlscomdb-001'
         skuName: 'ElasticPool'
         skuTier: 'GeneralPurpose'
+        tags: {
+          costallocation: 'test'
+        }
       }
     ]
     elasticPools: [
       {
         maintenanceConfigurationId: '<maintenanceConfigurationId>'
-        name: '<<namePrefix>>-sqlscom-ep-001'
+        name: 'tfsbx-sqlscom-ep-001'
         skuCapacity: 10
         skuName: 'GP_Gen5'
         skuTier: 'GeneralPurpose'
+        tags: {
+          costallocation: 'test'
+        }
       }
     ]
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
-    firewallRules: [
-      {
-        endIpAddress: '0.0.0.0'
-        name: 'AllowAllWindowsAzureIps'
-        startIpAddress: '0.0.0.0'
-      }
-    ]
-    keys: [
-      {
-        name: '<name>'
-        serverKeyType: 'AzureKeyVault'
-        uri: '<uri>'
-      }
-    ]
     location: '<location>'
-    lock: 'CanNotDelete'
-    primaryUserAssignedIdentityId: '<primaryUserAssignedIdentityId>'
-    privateEndpoints: [
-      {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSResourceId>'
-          ]
-        }
-        service: 'sqlServer'
-        subnetResourceId: '<subnetResourceId>'
-      }
-    ]
-    roleAssignments: [
-      {
-        principalIds: [
-          '<managedIdentityPrincipalId>'
-        ]
-        principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'Reader'
-      }
-    ]
-    securityAlertPolicies: [
-      {
-        emailAccountAdmins: true
-        name: 'Default'
-        state: 'Enabled'
-      }
-    ]
-    systemAssignedIdentity: true
-    userAssignedIdentities: {
-      '<managedIdentityResourceId>': {}
-    }
-    virtualNetworkRules: [
-      {
-        ignoreMissingVnetServiceEndpoint: true
-        name: 'newVnetRule1'
-        virtualNetworkSubnetId: '<virtualNetworkSubnetId>'
-      }
-    ]
-    vulnerabilityAssessmentsObj: {
-      emailSubscriptionAdmins: true
-      name: 'default'
-      recurringScansEmails: [
-        'test1@contoso.com'
-        'test2@contoso.com'
-      ]
-      recurringScansIsEnabled: true
-      vulnerabilityAssessmentsStorageAccountId: '<vulnerabilityAssessmentsStorageAccountId>'
+    tags: {
+      costallocation: 'test'
     }
   }
 }
@@ -552,9 +494,11 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    // Required parameters
     "name": {
-      "value": "<<namePrefix>>-sqlscom"
+      "value": "tfsbx-sqlscom"
     },
+    // Non-required parameters
     "administratorLogin": {
       "value": "adminUserName"
     },
@@ -565,20 +509,18 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "backupLogRetentionDays": 14,
-          "backupWeeklyRetention": "P4W",
+          "backupMonthlyRetention": "P5M",
           "capacity": 0,
           "collation": "SQL_Latin1_General_CP1_CI_AS",
-          "diagnosticEventHubAuthorizationRuleId": "<diagnosticEventHubAuthorizationRuleId>",
-          "diagnosticEventHubName": "<diagnosticEventHubName>",
-          "diagnosticLogsRetentionInDays": 7,
-          "diagnosticStorageAccountId": "<diagnosticStorageAccountId>",
-          "diagnosticWorkspaceId": "<diagnosticWorkspaceId>",
           "elasticPoolId": "<elasticPoolId>",
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
-          "name": "<<namePrefix>>-sqlscomdb-001",
+          "name": "tfsbx-sqlscomdb-001",
           "skuName": "ElasticPool",
-          "skuTier": "GeneralPurpose"
+          "skuTier": "GeneralPurpose",
+          "tags": {
+            "costallocation": "test"
+          }
         }
       ]
     },
@@ -586,103 +528,25 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "maintenanceConfigurationId": "<maintenanceConfigurationId>",
-          "name": "<<namePrefix>>-sqlscom-ep-001",
+          "name": "tfsbx-sqlscom-ep-001",
           "skuCapacity": 10,
           "skuName": "GP_Gen5",
-          "skuTier": "GeneralPurpose"
+          "skuTier": "GeneralPurpose",
+          "tags": {
+            "costallocation": "test"
+          }
         }
       ]
     },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },
-    "firewallRules": {
-      "value": [
-        {
-          "endIpAddress": "0.0.0.0",
-          "name": "AllowAllWindowsAzureIps",
-          "startIpAddress": "0.0.0.0"
-        }
-      ]
-    },
-    "keys": {
-      "value": [
-        {
-          "name": "<name>",
-          "serverKeyType": "AzureKeyVault",
-          "uri": "<uri>"
-        }
-      ]
-    },
     "location": {
       "value": "<location>"
     },
-    "lock": {
-      "value": "CanNotDelete"
-    },
-    "primaryUserAssignedIdentityId": {
-      "value": "<primaryUserAssignedIdentityId>"
-    },
-    "privateEndpoints": {
-      "value": [
-        {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSResourceId>"
-            ]
-          },
-          "service": "sqlServer",
-          "subnetResourceId": "<subnetResourceId>"
-        }
-      ]
-    },
-    "roleAssignments": {
-      "value": [
-        {
-          "principalIds": [
-            "<managedIdentityPrincipalId>"
-          ],
-          "principalType": "ServicePrincipal",
-          "roleDefinitionIdOrName": "Reader"
-        }
-      ]
-    },
-    "securityAlertPolicies": {
-      "value": [
-        {
-          "emailAccountAdmins": true,
-          "name": "Default",
-          "state": "Enabled"
-        }
-      ]
-    },
-    "systemAssignedIdentity": {
-      "value": true
-    },
-    "userAssignedIdentities": {
+    "tags": {
       "value": {
-        "<managedIdentityResourceId>": {}
-      }
-    },
-    "virtualNetworkRules": {
-      "value": [
-        {
-          "ignoreMissingVnetServiceEndpoint": true,
-          "name": "newVnetRule1",
-          "virtualNetworkSubnetId": "<virtualNetworkSubnetId>"
-        }
-      ]
-    },
-    "vulnerabilityAssessmentsObj": {
-      "value": {
-        "emailSubscriptionAdmins": true,
-        "name": "default",
-        "recurringScansEmails": [
-          "test1@contoso.com",
-          "test2@contoso.com"
-        ],
-        "recurringScansIsEnabled": true,
-        "vulnerabilityAssessmentsStorageAccountId": "<vulnerabilityAssessmentsStorageAccountId>"
+        "costallocation": "test"
       }
     }
   }

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -445,10 +445,10 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     databases: [
       {
         backupLogRetentionDays: 14
-        backupLongTermRetentionPolicies: {
+        backupLongTermRetentionPolicy: {
           monthlyRetention: 'P6M'
         }
-        backupShortTermRetentionPolicies: {
+        backupShortTermRetentionPolicy: {
           retentionDays: 14
         }
         capacity: 0
@@ -570,10 +570,10 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
       "value": [
         {
           "backupLogRetentionDays": 14,
-          "backupLongTermRetentionPolicies": {
+          "backupLongTermRetentionPolicy": {
             "monthlyRetention": "P6M"
           },
-          "backupShortTermRetentionPolicies": {
+          "backupShortTermRetentionPolicy": {
             "retentionDays": 14
           },
           "capacity": 0,

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -444,7 +444,6 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     administratorLoginPassword: '<administratorLoginPassword>'
     databases: [
       {
-        backupLogRetentionDays: 14
         backupLongTermRetentionPolicy: {
           monthlyRetention: 'P6M'
         }


### PR DESCRIPTION
# Description

The change adds support for configuring short and long term backup retention policies for Azure SQL Databases.

Default values are fetched from a deployment through portal without defining any policy.
retentionDays: 7
diffBackupIntervalInHours: 24

## Pipeline references

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
