### PR TITLE
[Modules] Support for configuring backup retention policies for Azure SQL Database

### DIFF
--- a/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/common/deploy.test.bicep
@@ -116,6 +116,12 @@ module testDeployment '../../deploy.bicep' = {
         diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
         diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
         elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/<<namePrefix>>-${serviceShort}/elasticPools/<<namePrefix>>-${serviceShort}-ep-001'
+        backupShortTermRetentionPolicy: {
+          retentionDays: 14
+        }
+        backupLongTermRetentionPolicy: {
+          monthlyRetention: 'P6M'
+        }
       }
     ]
     firewallRules: [

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
@@ -16,6 +16,21 @@ param weekOfYear int = 1
 @description('Optional. Yearly retention in ISO 8601 duration format.')
 param yearlyRetention string = ''
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
 resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
   name: serverName
 }

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/deploy.bicep
@@ -1,0 +1,46 @@
+@description('Required. The name of the parent SQL Server.')
+param serverName string
+
+@description('Required. The name of the parent database.')
+param databaseName string
+
+@description('Optional. Monthly retention in ISO 8601 duration format.')
+param weeklyRetention string = ''
+
+@description('Optional. Weekly retention in ISO 8601 duration format.')
+param monthlyRetention string = ''
+
+@description('Optional. Week of year backup to keep for yearly retention.')
+param weekOfYear int = 1
+
+@description('Optional. Yearly retention in ISO 8601 duration format.')
+param yearlyRetention string = ''
+
+resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+  name: serverName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2022-05-01-preview' existing = {
+  name: databaseName
+  parent: server
+}
+
+resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2022-05-01-preview' = {
+  name: 'default'
+  parent: database
+  properties: {
+    monthlyRetention: monthlyRetention
+    weeklyRetention: weeklyRetention
+    weekOfYear: weekOfYear
+    yearlyRetention: yearlyRetention
+  }
+}
+
+@description('The resource group the long-term policy was deployed into.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The name of the long-term policy.')
+output name string = backupLongTermRetentionPolicy.name
+
+@description('The resource ID of the long-term policy.')
+output resourceId string = backupLongTermRetentionPolicy.id

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
@@ -28,6 +28,7 @@ This module deploys a long term retention policy for a Azure SQL Database.
 
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `monthlyRetention` | string | `''` | Weekly retention in ISO 8601 duration format. |
 | `weeklyRetention` | string | `''` | Monthly retention in ISO 8601 duration format. |
 | `weekOfYear` | int | `1` | Week of year backup to keep for yearly retention. |

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
@@ -1,0 +1,45 @@
+# SQL Server Database Long Term Backup Retention Policy `[Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies]`
+
+This module deploys a long term retention policy for a Azure SQL Database.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `databaseName` | string | The name of the parent database. |
+| `serverName` | string | The name of the parent SQL Server. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `monthlyRetention` | string | `''` | Weekly retention in ISO 8601 duration format. |
+| `weeklyRetention` | string | `''` | Monthly retention in ISO 8601 duration format. |
+| `weekOfYear` | int | `1` | Week of year backup to keep for yearly retention. |
+| `yearlyRetention` | string | `''` | Yearly retention in ISO 8601 duration format. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/readme.md
@@ -38,7 +38,9 @@ This module deploys a long term retention policy for a Azure SQL Database.
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+| `name` | string | The name of the long-term policy. |
+| `resourceGroupName` | string | The resource group the long-term policy was deployed into. |
+| `resourceId` | string | The resource ID of the long-term policy. |
 
 ## Cross-referenced modules
 

--- a/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/version.json
+++ b/modules/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1"
+}

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
@@ -1,0 +1,38 @@
+@description('Required. The name of the parent SQL Server.')
+param serverName string
+
+@description('Required. The name of the parent database.')
+param databaseName string
+
+@description('Optional. Differential backup interval in hours.')
+param diffBackupIntervalInHours int = 24
+
+@description('Optional. Poin-in-time retention in days.')
+param retentionDays int = 7
+
+resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+  name: serverName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2022-05-01-preview' existing = {
+  name: databaseName
+  parent: server
+}
+
+resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2022-05-01-preview' = {
+  name: 'default'
+  parent: database
+  properties: {
+    diffBackupIntervalInHours: diffBackupIntervalInHours
+    retentionDays: retentionDays
+  }
+}
+
+@description('The resource group the short-term policy was deployed into.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The name of the short-term policy.')
+output name string = backupShortTermRetentionPolicy.name
+
+@description('The resource ID of the short-term policy.')
+output resourceId string = backupShortTermRetentionPolicy.id

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/deploy.bicep
@@ -10,6 +10,21 @@ param diffBackupIntervalInHours int = 24
 @description('Optional. Poin-in-time retention in days.')
 param retentionDays int = 7
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
 resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
   name: serverName
 }

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
@@ -36,7 +36,9 @@ This module deploys a short term retention policy for a Azure SQL Database.
 
 | Output Name | Type | Description |
 | :-- | :-- | :-- |
-| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+| `name` | string | The name of the short-term policy. |
+| `resourceGroupName` | string | The resource group the short-term policy was deployed into. |
+| `resourceId` | string | The resource ID of the short-term policy. |
 
 ## Cross-referenced modules
 

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
@@ -1,0 +1,43 @@
+# SQL Server Database Short Term Backup Retention Policy `[Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies]`
+
+This module deploys a short term retention policy for a Azure SQL Database.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `databaseName` | string | The name of the parent database. |
+| `serverName` | string | The name of the parent SQL Server. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `diffBackupIntervalInHours` | int | `24` | Differential backup interval in hours. |
+| `retentionDays` | int | `7` | Poin-in-time retention in days. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The resource group of the deployed azure sql backup policy. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/readme.md
@@ -29,6 +29,7 @@ This module deploys a short term retention policy for a Azure SQL Database.
 | Parameter Name | Type | Default Value | Description |
 | :-- | :-- | :-- | :-- |
 | `diffBackupIntervalInHours` | int | `24` | Differential backup interval in hours. |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `retentionDays` | int | `7` | Poin-in-time retention in days. |
 
 

--- a/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/version.json
+++ b/modules/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1"
+}

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -158,6 +158,12 @@ param isLedgerOn bool = false
 @description('Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.')
 param maintenanceConfigurationId string = ''
 
+@description('Optional. The short term backup retention policy to create for the database.')
+param backupShortTermRetentionPolicy object = {}
+
+@description('Optional. The long term backup retention policy to create for the database.')
+param backupLongTermRetentionPolicy object = {}
+
 // The SKU object must be built in a variable
 // The alternative, 'null' as default values, leads to non-terminating deployments
 var skuVar = union({
@@ -221,6 +227,28 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
     logs: diagnosticsLogs
   }
   scope: database
+}
+
+module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies/deploy.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
+  params: {
+    serverName: serverName
+    databaseName: database.name
+    diffBackupIntervalInHours: contains(backupShortTermRetentionPolicy, 'diffBackupIntervalInHours') ? backupShortTermRetentionPolicy.diffBackupIntervalInHours : 24
+    retentionDays: contains(backupShortTermRetentionPolicy, 'retentionDays') ? backupShortTermRetentionPolicy.retentionDays : 7
+  }
+}
+
+module database_backupLongTermRetentionPolicy 'backupLongTermRetentionPolicies/deploy.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
+  params: {
+    serverName: serverName
+    databaseName: database.name
+    weeklyRetention: contains(backupLongTermRetentionPolicy, 'weeklyRetention') ? backupLongTermRetentionPolicy.weeklyRetention : ''
+    monthlyRetention: contains(backupLongTermRetentionPolicy, 'monthlyRetention') ? backupLongTermRetentionPolicy.monthlyRetention : ''
+    yearlyRetention: contains(backupLongTermRetentionPolicy, 'yearlyRetention') ? backupLongTermRetentionPolicy.yearlyRetention : ''
+    weekOfYear: contains(backupLongTermRetentionPolicy, 'weekOfYear') ? backupLongTermRetentionPolicy.weekOfYear : 1
+  }
 }
 
 @description('The name of the deployed database.')

--- a/modules/Microsoft.Sql/servers/databases/readme.md
+++ b/modules/Microsoft.Sql/servers/databases/readme.md
@@ -15,6 +15,8 @@ This module deploys an Azure SQL Server Database.
 | :-- | :-- |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Sql/servers/databases` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2021-11-01/servers/databases) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
 
@@ -35,6 +37,8 @@ This module deploys an Azure SQL Server Database.
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
 | `autoPauseDelay` | int | `0` |  | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
+| `backupLongTermRetentionPolicy` | object | `{object}` |  | The long term backup retention policy to create for the database. |
+| `backupShortTermRetentionPolicy` | object | `{object}` |  | The short term backup retention policy to create for the database. |
 | `collation` | string | `'SQL_Latin1_General_CP1_CI_AS'` |  | The collation of the database. |
 | `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
 | `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |

--- a/modules/Microsoft.Sql/servers/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/deploy.bicep
@@ -180,6 +180,8 @@ module server_databases 'databases/deploy.bicep' = [for (database, index) in dat
     diagnosticSettingsName: contains(database, 'diagnosticSettingsName') ? database.diagnosticSettingsName : '${database.name}-diagnosticSettings'
     elasticPoolId: contains(database, 'elasticPoolId') ? database.elasticPoolId : ''
     enableDefaultTelemetry: enableReferencedModulesTelemetry
+    backupShortTermRetentionPolicy: contains(database, 'backupShortTermRetentionPolicy') ? database.backupShortTermRetentionPolicy : {}
+    backupLongTermRetentionPolicy: contains(database, 'backupLongTermRetentionPolicy') ? database.backupLongTermRetentionPolicy : {}
   }
   dependsOn: [
     server_elasticPools // Enables us to add databases to existing elastic pools

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -21,6 +21,8 @@ This module deploys a SQL server.
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints/privateDnsZoneGroups) |
 | `Microsoft.Sql/servers` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers) |
 | `Microsoft.Sql/servers/databases` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2021-11-01/servers/databases) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/databases/backupShortTermRetentionPolicies) |
 | `Microsoft.Sql/servers/elasticPools` | [2022-02-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-02-01-preview/servers/elasticPools) |
 | `Microsoft.Sql/servers/firewallRules` | [2022-02-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-02-01-preview/servers/firewallRules) |
 | `Microsoft.Sql/servers/keys` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/keys) |
@@ -442,6 +444,12 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     administratorLoginPassword: '<administratorLoginPassword>'
     databases: [
       {
+        backupLongTermRetentionPolicy: {
+          monthlyRetention: 'P6M'
+        }
+        backupShortTermRetentionPolicy: {
+          retentionDays: 14
+        }
         capacity: 0
         collation: 'SQL_Latin1_General_CP1_CI_AS'
         diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
@@ -560,6 +568,12 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
     "databases": {
       "value": [
         {
+          "backupLongTermRetentionPolicy": {
+            "monthlyRetention": "P6M"
+          },
+          "backupShortTermRetentionPolicy": {
+            "retentionDays": 14
+          },
           "capacity": 0,
           "collation": "SQL_Latin1_General_CP1_CI_AS",
           "diagnosticEventHubAuthorizationRuleId": "<diagnosticEventHubAuthorizationRuleId>",


### PR DESCRIPTION
Testing of #2802

Original PR description:


---------
# Description

The change adds support for configuring short and long term backup retention policies for Azure SQL Databases.

Default values are fetched from a deployment through portal without defining any policy.
retentionDays: 7
diffBackupIntervalInHours: 24

## Pipeline references

| Pipeline |
| - |
| [![Sql - Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=ex_users%2Fthofle%2FazsqlBackupPolicies)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
