### PR TITLE
[Modules] Synapse workspaces Added support for `resourceId` #2613

### DIFF
--- a/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
@@ -85,6 +85,9 @@ output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSResourceId string = privateDNSZone.id
 
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
+
 @description('The name of the created Storage Account.')
 output storageAccountName string = storageAccount.name
 

--- a/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
@@ -88,8 +88,5 @@ output privateDNSResourceId string = privateDNSZone.id
 @description('The resource ID of the created Storage Account.')
 output storageAccountId string = storageAccount.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
-
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
@@ -58,6 +58,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'

--- a/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
@@ -59,7 +59,6 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     name: '<<namePrefix>>${serviceShort}001'
     defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     initialWorkspaceAdminObjectID: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
@@ -62,8 +62,5 @@ output keyVaultEncryptionKeyName string = keyVault::key.name
 @description('The resource ID of the created Storage Account.')
 output storageAccountId string = storageAccount.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
-
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
@@ -59,6 +59,9 @@ output keyVaultResourceId string = keyVault.id
 @description('The name of the Key Vault Encryption Key.')
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
+
 @description('The name of the created Storage Account.')
 output storageAccountName string = storageAccount.name
 

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
@@ -48,7 +48,6 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     name: '<<namePrefix>>${serviceShort}001'
     defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
@@ -47,6 +47,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
@@ -80,6 +80,9 @@ output keyVaultResourceId string = keyVault.id
 @description('The name of the Key Vault Encryption Key.')
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
+
 @description('The name of the created Storage Account.')
 output storageAccountName string = storageAccount.name
 

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
@@ -83,8 +83,5 @@ output keyVaultEncryptionKeyName string = keyVault::key.name
 @description('The resource ID of the created Storage Account.')
 output storageAccountId string = storageAccount.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
-
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
@@ -49,7 +49,6 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     name: '<<namePrefix>>${serviceShort}001'
     defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
@@ -48,6 +48,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
@@ -24,6 +24,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     }
 }
 
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
+
 @description('The name of the created Storage Account.')
 output storageAccountName string = storageAccount.name
 

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
@@ -27,8 +27,5 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 @description('The resource ID of the created Storage Account.')
 output storageAccountId string = storageAccount.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
-
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
@@ -42,6 +42,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
@@ -43,7 +43,6 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     name: '<<namePrefix>>${serviceShort}001'
     defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     managedVirtualNetwork: true

--- a/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
@@ -24,6 +24,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     }
 }
 
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
+
 @description('The name of the created Storage Account.')
 output storageAccountName string = storageAccount.name
 

--- a/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
@@ -27,8 +27,5 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 @description('The resource ID of the created Storage Account.')
 output storageAccountId string = storageAccount.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
-
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
@@ -42,6 +42,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'

--- a/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
@@ -43,7 +43,6 @@ module testDeployment '../../deploy.bicep' = {
   params: {
     name: '<<namePrefix>>${serviceShort}001'
     defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
   }

--- a/modules/Microsoft.Synapse/workspaces/deploy.bicep
+++ b/modules/Microsoft.Synapse/workspaces/deploy.bicep
@@ -197,7 +197,7 @@ resource workspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
     } : null
     defaultDataLakeStorage: {
       resourceId: defaultDataLakeStorageAccountResourceId
-      accountUrl: 'https://${split(defaultDataLakeStorageAccountResourceId, '/')[-1]}.dfs.${environment().suffixes.storage}'
+      accountUrl: 'https://${last(split(defaultDataLakeStorageAccountResourceId, '/'))!}.dfs.${environment().suffixes.storage}'
       filesystem: defaultDataLakeStorageFilesystem
       createManagedPrivateEndpoint: managedVirtualNetwork ? defaultDataLakeStorageCreateManagedPrivateEndpoint : null
     }

--- a/modules/Microsoft.Synapse/workspaces/deploy.bicep
+++ b/modules/Microsoft.Synapse/workspaces/deploy.bicep
@@ -18,9 +18,6 @@ param initialWorkspaceAdminObjectID string = ''
 @description('Required. Resource ID of the default ADLS Gen2 storage account.')
 param defaultDataLakeStorageAccountResourceId string
 
-@description('Required. Name of the default ADLS Gen2 storage account.')
-param defaultDataLakeStorageAccountName string
-
 @description('Required. The default ADLS Gen2 file system.')
 param defaultDataLakeStorageFilesystem string
 
@@ -200,7 +197,7 @@ resource workspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
     } : null
     defaultDataLakeStorage: {
       resourceId: defaultDataLakeStorageAccountResourceId
-      accountUrl: 'https://${defaultDataLakeStorageAccountName}.dfs.${environment().suffixes.storage}'
+      accountUrl: 'https://${split(defaultDataLakeStorageAccountResourceId, '/')[-1]}.dfs.${environment().suffixes.storage}'
       filesystem: defaultDataLakeStorageFilesystem
       createManagedPrivateEndpoint: managedVirtualNetwork ? defaultDataLakeStorageCreateManagedPrivateEndpoint : null
     }

--- a/modules/Microsoft.Synapse/workspaces/deploy.bicep
+++ b/modules/Microsoft.Synapse/workspaces/deploy.bicep
@@ -15,6 +15,9 @@ param azureADOnlyAuthentication bool = false
 @description('Optional. AAD object ID of initial workspace admin.')
 param initialWorkspaceAdminObjectID string = ''
 
+@description('Required. Resource ID of the default ADLS Gen2 storage account.')
+param defaultDataLakeStorageAccountResourceId string
+
 @description('Required. Name of the default ADLS Gen2 storage account.')
 param defaultDataLakeStorageAccountName string
 
@@ -196,6 +199,7 @@ resource workspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
       initialWorkspaceAdminObjectId: initialWorkspaceAdminObjectID
     } : null
     defaultDataLakeStorage: {
+      resourceId: defaultDataLakeStorageAccountResourceId
       accountUrl: 'https://${defaultDataLakeStorageAccountName}.dfs.${environment().suffixes.storage}'
       filesystem: defaultDataLakeStorageFilesystem
       createManagedPrivateEndpoint: managedVirtualNetwork ? defaultDataLakeStorageCreateManagedPrivateEndpoint : null

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -30,7 +30,6 @@ This module deploys a Synapse Workspace.
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
 | `defaultDataLakeStorageAccountId` | string | Resource ID of the default ADLS Gen2 storage account. |
-| `defaultDataLakeStorageAccountName` | string | Name of the default ADLS Gen2 storage account. |
 | `defaultDataLakeStorageFilesystem` | string | The default ADLS Gen2 file system. |
 | `name` | string | The name of the Synapse Workspace. |
 | `sqlAdministratorLogin` | string | Login for administrator access to the workspace's SQL pools. |
@@ -347,7 +346,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   params: {
     // Required parameters
     defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swcom001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -407,9 +405,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     // Required parameters
     "defaultDataLakeStorageAccountId": {
       "value": "<defaultDataLakeStorageAccountId>"
-    },
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -496,7 +491,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   params: {
     // Required parameters
     defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swensa001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -525,9 +519,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     // Required parameters
     "defaultDataLakeStorageAccountId": {
       "value": "<defaultDataLakeStorageAccountId>"
-    },
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -573,7 +564,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   params: {
     // Required parameters
     defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swenua001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -601,9 +591,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     // Required parameters
     "defaultDataLakeStorageAccountId": {
       "value": "<defaultDataLakeStorageAccountId>"
-    },
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -646,7 +633,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   params: {
     // Required parameters
     defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmanv001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -675,9 +661,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     // Required parameters
     "defaultDataLakeStorageAccountId": {
       "value": "<defaultDataLakeStorageAccountId>"
-    },
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -719,7 +702,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   params: {
     // Required parameters
     defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmin001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -742,9 +724,6 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     // Required parameters
     "defaultDataLakeStorageAccountId": {
       "value": "<defaultDataLakeStorageAccountId>"
-    },
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -29,6 +29,7 @@ This module deploys a Synapse Workspace.
 
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
+| `defaultDataLakeStorageAccountId` | string | Resource ID of the default ADLS Gen2 storage account. |
 | `defaultDataLakeStorageAccountName` | string | Name of the default ADLS Gen2 storage account. |
 | `defaultDataLakeStorageFilesystem` | string | The default ADLS Gen2 file system. |
 | `name` | string | The name of the Synapse Workspace. |
@@ -345,6 +346,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swcom'
   params: {
     // Required parameters
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swcom001'
@@ -403,6 +405,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
+    },
     "defaultDataLakeStorageAccountName": {
       "value": "<defaultDataLakeStorageAccountName>"
     },
@@ -490,6 +495,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swensa'
   params: {
     // Required parameters
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swensa001'
@@ -517,6 +523,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
+    },
     "defaultDataLakeStorageAccountName": {
       "value": "<defaultDataLakeStorageAccountName>"
     },
@@ -563,6 +572,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swenua'
   params: {
     // Required parameters
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swenua001'
@@ -589,6 +599,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
+    },
     "defaultDataLakeStorageAccountName": {
       "value": "<defaultDataLakeStorageAccountName>"
     },
@@ -632,6 +645,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmanv'
   params: {
     // Required parameters
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmanv001'
@@ -659,6 +673,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
+    },
     "defaultDataLakeStorageAccountName": {
       "value": "<defaultDataLakeStorageAccountName>"
     },
@@ -701,6 +718,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmin'
   params: {
     // Required parameters
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmin001'
@@ -722,6 +740,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
+    },
     "defaultDataLakeStorageAccountName": {
       "value": "<defaultDataLakeStorageAccountName>"
     },


### PR DESCRIPTION
# Description

>Thank you for your contribution !

> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.
- The field `resourceId` was added in the API which wasn't updated in the module. When the module is used, it is showing errors as it couldn't find the `resourceId` which is expected by the API.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
