### PR TITLE
[Modules] Updated  Microsoft.Compute/images: API versions, image sku

### DIFF
--- a/modules/Microsoft.Compute/images/.bicep/nested_roleAssignments.bicep
+++ b/modules/Microsoft.Compute/images/.bicep/nested_roleAssignments.bicep
@@ -68,7 +68,7 @@ var builtInRoleNames = {
   'Windows Admin Center Administrator Login': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a6333a3e-0164-44c3-b281-7a577aff287f')
 }
 
-resource image 'Microsoft.Compute/images@2021-04-01' existing = {
+resource image 'Microsoft.Compute/images@2022-11-01' existing = {
   name: last(split(resourceId, '/'))!
 }
 

--- a/modules/Microsoft.Compute/images/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Compute/images/.test/common/dependencies.bicep
@@ -30,7 +30,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
   location: location
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
@@ -40,9 +40,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   properties: {
     allowBlobPublicAccess: false
   }
-  resource blobServices 'blobServices@2021-09-01' = {
+  resource blobServices 'blobServices@2022-09-01' = {
     name: 'default'
-    resource container 'containers@2021-09-01' = {
+    resource container 'containers@2022-09-01' = {
       name: 'vhds'
       properties: {
         publicAccess: 'None'

--- a/modules/Microsoft.Compute/images/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Compute/images/.test/common/dependencies.bicep
@@ -80,8 +80,8 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
     source: {
       type: 'PlatformImage'
       publisher: 'MicrosoftWindowsDesktop'
-      offer: 'Windows-10'
-      sku: '19h2-evd'
+      offer: 'Windows-11'
+      sku: 'win11-21h2-avd'
       version: 'latest'
     }
     distribute: [

--- a/modules/Microsoft.Compute/images/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Compute/images/.test/common/deploy.test.bicep
@@ -26,7 +26,7 @@ param enableDefaultTelemetry bool = true
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: resourceGroupName
   location: location
 }

--- a/modules/Microsoft.Compute/images/deploy.bicep
+++ b/modules/Microsoft.Compute/images/deploy.bicep
@@ -59,7 +59,7 @@ param dataDisks array = []
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
-resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+resource defaultTelemetry 'Microsoft.Resources/deployments@2022-09-01' = if (enableDefaultTelemetry) {
   name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
   properties: {
     mode: 'Incremental'
@@ -71,7 +71,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource image 'Microsoft.Compute/images@2022-08-01' = {
+resource image 'Microsoft.Compute/images@2022-11-01' = {
   name: name
   location: location
   tags: tags

--- a/modules/Microsoft.Compute/images/readme.md
+++ b/modules/Microsoft.Compute/images/readme.md
@@ -15,7 +15,7 @@ This module deploys a compute image.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Compute/images` | [2022-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-08-01/images) |
+| `Microsoft.Compute/images` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-11-01/images) |
 
 ## Parameters
 


### PR DESCRIPTION
# Description

This PR resolves #2828  and introduces following improvements:

- replaced a non-existing source image sku for the "Common" test case (causing the workflow to fail): 
  - old: `Windows-10` - `19h2-evd`
  - new: `Windows-11` - `win11-21h2-avd`
- updated API versions in the test deployments
- updated API versions of the `image` resource

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Compute - Images](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.images.yml/badge.svg?branch=users%2Fkrbar%2F2828-compute-images-fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.images.yml) |

# Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
