### PR TITLE
[Fixes] Fix target-path reference for Universal Package Publish

### DIFF
--- a/modules/Microsoft.KeyVault/vaults/version.json
+++ b/modules/Microsoft.KeyVault/vaults/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.6"
+    "version": "0.5"
 }

--- a/modules/Microsoft.KeyVault/vaults/version.json
+++ b/modules/Microsoft.KeyVault/vaults/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.5"
+    "version": "0.6"
 }

--- a/utilities/pipelines/resourcePublish/Publish-ModuleToUniversalArtifactsFeed.ps1
+++ b/utilities/pipelines/resourcePublish/Publish-ModuleToUniversalArtifactsFeed.ps1
@@ -121,12 +121,12 @@ function Publish-ModuleToUniversalArtifactsFeed {
         if ($PSCmdlet.ShouldProcess("Universal Package Feed entry [$universalPackageModuleName] version [$ModuleVersion] to feed [$VstsOrganizationUri/$VstsFeedProject/$VstsFeedName]", 'Publish')) {
             $env:AZURE_DEVOPS_EXT_PAT = $BearerToken
             $inputObject = @(
-                '--organization', "$VstsOrganizationUri",
-                '--feed', "$VstsFeedName",
-                '--scope', "$feedScope",
-                '--name', "$universalPackageModuleName",
-                '--version', "$ModuleVersion",
-                '--path', "$TemplateFilePath",
+                '--organization', $VstsOrganizationUri,
+                '--feed', $VstsFeedName,
+                '--scope', $feedScope,
+                '--name', $universalPackageModuleName,
+                '--version', $ModuleVersion,
+                '--path', (Split-Path $TemplateFilePath -Parent),
                 '--description', "$universalPackageModuleName Module",
                 '--verbose'
             )


### PR DESCRIPTION
# Description

- Updated the reference to the module's deploy file to its parent folder

![image](https://user-images.githubusercontent.com/5365358/221501720-53364650-f409-4313-b5cd-f89df76cd545.png)

Downloaded artifact
![image](https://user-images.githubusercontent.com/5365358/221502737-c716e5be-d4c1-42f5-a76b-02f037a358cc.png)


## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Build Status](https://dev.azure.com/carml/CARML/_apis/build/status/Modules/KeyVault%20-%20Vaults?branchName=users%2Falsehr%2F2829_publish)](https://dev.azure.com/carml/CARML/_build/latest?definitionId=46&branchName=users%2Falsehr%2F2829_publish) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
