### PR TITLE
[Modules] Added missing 'enableDefaultTelemetry' param in test files

### DIFF
--- a/modules/Microsoft.Resources/tags/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Resources/tags/.test/min/deploy.test.bicep
@@ -7,6 +7,9 @@ targetScope = 'subscription'
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'rtmin'
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============== //
 // Test Execution //
 // ============== //
@@ -14,5 +17,6 @@ param serviceShort string = 'rtmin'
 module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-test-${serviceShort}'
   params: {
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Resources/tags/.test/sub/deploy.test.bicep
+++ b/modules/Microsoft.Resources/tags/.test/sub/deploy.test.bicep
@@ -7,6 +7,9 @@ targetScope = 'subscription'
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'rtsub'
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============== //
 // Test Execution //
 // ============== //
@@ -19,5 +22,6 @@ module testDeployment '../../deploy.bicep' = {
       Test: 'Yes'
       TestToo: 'No'
     }
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Resources/tags/readme.md
+++ b/modules/Microsoft.Resources/tags/readme.md
@@ -100,6 +100,7 @@ The following module usage examples are retrieved from the content of the files 
 module tags './Microsoft.Resources/tags/deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-test-rtmin'
   params: {
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
   }
 }
 ```
@@ -115,7 +116,11 @@ module tags './Microsoft.Resources/tags/deploy.bicep' = {
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {}
+  "parameters": {
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    }
+  }
 }
 ```
 
@@ -187,6 +192,7 @@ module tags './Microsoft.Resources/tags/deploy.bicep' = {
 module tags './Microsoft.Resources/tags/deploy.bicep' = {
   name: '${uniqueString(deployment().name)}-test-rtsub'
   params: {
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
     onlyUpdate: true
     tags: {
       Test: 'Yes'
@@ -208,6 +214,9 @@ module tags './Microsoft.Resources/tags/deploy.bicep' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
     "onlyUpdate": {
       "value": true
     },

--- a/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
@@ -14,6 +14,9 @@ param location string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'swcom'
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -98,5 +101,6 @@ module testDeployment '../../deploy.bicep' = {
       'IntegrationActivityRuns'
       'IntegrationTriggerRuns'
     ]
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
@@ -17,6 +17,9 @@ param serviceShort string = 'swensa'
 @description('Generated. Used as a basis for unique resource names.')
 param baseTime string = utcNow('u')
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -55,5 +58,6 @@ module testDeployment '../../deploy.bicep' = {
     cMKKeyName: nestedDependencies.outputs.keyVaultEncryptionKeyName
     cMKUseSystemAssignedIdentity: true
     encryptionActivateWorkspace: true
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
@@ -17,6 +17,9 @@ param serviceShort string = 'swenua'
 @description('Generated. Used as a basis for unique resource names.')
 param baseTime string = utcNow('u')
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -55,5 +58,6 @@ module testDeployment '../../deploy.bicep' = {
     cMKKeyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
     cMKKeyName: nestedDependencies.outputs.keyVaultEncryptionKeyName
     cMKUserAssignedIdentityResourceId: nestedDependencies.outputs.managedIdentityResourceId
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
@@ -14,6 +14,9 @@ param location string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'swmanv'
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -50,5 +53,6 @@ module testDeployment '../../deploy.bicep' = {
     allowedAadTenantIdsForLinking: [
       tenant().tenantId
     ]
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
@@ -14,6 +14,9 @@ param location string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'swmin'
 
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -45,5 +48,6 @@ module testDeployment '../../deploy.bicep' = {
     defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
+    enableDefaultTelemetry: enableDefaultTelemetry
   }
 }

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -363,6 +363,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     diagnosticLogsRetentionInDays: 7
     diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
     initialWorkspaceAdminObjectID: '<initialWorkspaceAdminObjectID>'
     privateEndpoints: [
       {
@@ -441,6 +442,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     "diagnosticWorkspaceId": {
       "value": "<diagnosticWorkspaceId>"
     },
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
     "initialWorkspaceAdminObjectID": {
       "value": "<initialWorkspaceAdminObjectID>"
     },
@@ -498,6 +502,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     cMKKeyName: '<cMKKeyName>'
     cMKKeyVaultResourceId: '<cMKKeyVaultResourceId>'
     cMKUseSystemAssignedIdentity: true
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
     encryption: true
     encryptionActivateWorkspace: true
   }
@@ -539,6 +544,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     "cMKUseSystemAssignedIdentity": {
       "value": true
     },
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
     "encryption": {
       "value": true
     },
@@ -571,6 +579,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     cMKKeyName: '<cMKKeyName>'
     cMKKeyVaultResourceId: '<cMKKeyVaultResourceId>'
     cMKUserAssignedIdentityResourceId: '<cMKUserAssignedIdentityResourceId>'
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
     encryption: true
   }
 }
@@ -611,6 +620,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     "cMKUserAssignedIdentityResourceId": {
       "value": "<cMKUserAssignedIdentityResourceId>"
     },
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
     "encryption": {
       "value": true
     }
@@ -640,6 +652,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     allowedAadTenantIdsForLinking: [
       '<tenantId>'
     ]
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
     managedVirtualNetwork: true
     preventDataExfiltration: true
   }
@@ -677,6 +690,9 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
         "<tenantId>"
       ]
     },
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
     "managedVirtualNetwork": {
       "value": true
     },
@@ -705,6 +721,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmin001'
     sqlAdministratorLogin: 'synwsadmin'
+    // Non-required parameters
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
   }
 }
 ```
@@ -733,6 +751,10 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
     },
     "sqlAdministratorLogin": {
       "value": "synwsadmin"
+    },
+    // Non-required parameters
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR resolves #2810 and adds the parameter `enableDefaultTelemetry` wherever it's missing in the test files. Two modules and 7 test files are affected:
- Microsoft.Resources/tags
- Microsoft.Synapse/workspaces

## Pipeline references

| Pipeline |
| - |
| [![Resources - Tags](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml/badge.svg?branch=users%2Fkrbar%2Ftelemetry-fixes)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml) |
| [![Synapse - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Fkrbar%2Ftelemetry-fixes)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
