### PR TITLE
[Modules] Initial failovergroups commit

### DIFF
--- a/modules/Microsoft.Sql/servers/.test/fog/dependencies.bicep
+++ b/modules/Microsoft.Sql/servers/.test/fog/dependencies.bicep
@@ -1,0 +1,59 @@
+@description('Required. A short identifier for the kind of deployment.')
+param serviceShort string
+
+@description('Required. The location to deploy the primary resources to.')
+param primaryLocation string = resourceGroup().location
+
+@description('Required. The location to deploy the secondary resources to.')
+param secondaryLocation string = 'northeurope'
+
+@description('Optional. The name of the database.')
+param databaseName string = '<<namePrefix>>-${serviceShort}db-001'
+
+@description('Optional. The password to leverage for the login.')
+@secure()
+param password string = newGuid()
+
+module primaryServer '../../deploy.bicep' = {
+  name: '${uniqueString(deployment().name, primaryLocation)}-test-${serviceShort}'
+  params: {
+    name: '<<namePrefix>>-${serviceShort}'
+    location: primaryLocation
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: password
+    databases: [
+      {
+        name: databaseName
+        maxSizeBytes: 2147483648
+        skuName: 'Basic'
+        skuTier: 'Basic'
+        licenseType: 'LicenseIncluded'
+      }
+    ]
+  }
+}
+
+module failoverServer '../../deploy.bicep' = {
+  name: '${uniqueString(deployment().name, secondaryLocation)}-test-${serviceShort}'
+  params: {
+    name: '<<namePrefix>>-${serviceShort}-dr'
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: password
+    location: secondaryLocation
+  }
+}
+
+@description('The resource ID of the created virtual network subnet.')
+output primaryServerName string = primaryServer.outputs.name
+
+@description('The resource ID of the created virtual network subnet.')
+output primaryServerId string = primaryServer.outputs.resourceId
+
+@description('The resource ID of the created virtual network subnet.')
+output failoverServerName string = failoverServer.outputs.name
+
+@description('The resource ID of the created virtual network subnet.')
+output failoverServerId string = failoverServer.outputs.resourceId
+
+@description('The resource ID of the created virtual network subnet.')
+output databaseId string = resourceId('Microsoft.Sql/servers/databases', primaryServer.outputs.name, databaseName)

--- a/modules/Microsoft.Sql/servers/.test/fog/deploy.test.bicep
+++ b/modules/Microsoft.Sql/servers/.test/fog/deploy.test.bicep
@@ -1,0 +1,57 @@
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'ms.sql.servers-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param location string = deployment().location
+
+@description('Optional. The location to deploy failover resources to.')
+param secondaryLocation string = 'northeurope'
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'sqlfog'
+
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module nestedDependencies 'dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-nestedDependencies'
+  params: {
+    primaryLocation: location
+    secondaryLocation: secondaryLocation
+    serviceShort: serviceShort
+  }
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../failoverGroups/deploy.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  params: {
+    name: '${nestedDependencies.outputs.primaryServerName}-fog'
+    serverName: nestedDependencies.outputs.primaryServerName
+    partnerServerId: [{ id: nestedDependencies.outputs.failoverServerId }]
+    databases: [ nestedDependencies.outputs.databaseId ]
+    failoverPolicy: 'Manual'
+    failoverWithDataLossGracePeriodMinutes: 60
+  }
+}

--- a/modules/Microsoft.Sql/servers/failoverGroups/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/failoverGroups/deploy.bicep
@@ -1,0 +1,47 @@
+@description('Required. The name of the Failover group.')
+param name string
+
+@description('Required. The name of the parent SQL Server.')
+param serverName string
+
+@description('Required. An array containing a PartnerInfo object. [{id: resourceID}]')
+param partnerServerId array
+
+@description('Optional. The name of the databases to include in the failover group.')
+param databases array = []
+
+@description('Optional. The failover policy.')
+@allowed([
+  'Manual'
+  'Automatic'
+])
+param failoverPolicy string = 'Manual'
+
+@description('Optional. The failover data loss grace period.')
+param failoverWithDataLossGracePeriodMinutes int = 60
+
+resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+  name: serverName
+}
+
+resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2022-05-01-preview' = {
+  name: name
+  parent: server
+  properties: {
+    databases: databases
+    partnerServers: partnerServerId
+    readWriteEndpoint: {
+      failoverPolicy: failoverPolicy
+      failoverWithDataLossGracePeriodMinutes: failoverPolicy != 'Manual' ? failoverWithDataLossGracePeriodMinutes : null
+    }
+  }
+}
+
+@description('The resource ID of the deployed azure sql failover group.')
+output resourceId string = failoverGroup.id
+
+@description('The name of the deployed azure sql failover group.')
+output name string = failoverGroup.name
+
+@description('The resource group of the deployed azure sql failover group.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/Microsoft.Sql/servers/failoverGroups/readme.md
+++ b/modules/Microsoft.Sql/servers/failoverGroups/readme.md
@@ -1,0 +1,47 @@
+# `[Microsoft.Sql/servers/failoverGroups]`
+
+This module deploys a failover group for Azure SQL Database
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Sql/servers/failoverGroups` | [2022-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2022-05-01-preview/servers/failoverGroups) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the Failover group. |
+| `partnerServerId` | array | An array containing a PartnerInfo object. [{id: resourceID}] |
+| `serverName` | string | The name of the parent SQL Server. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `databases` | array | `[]` |  | The name of the databases to include in the failover group. |
+| `failoverPolicy` | string | `'Manual'` | `[Automatic, Manual]` | The failover policy. |
+| `failoverWithDataLossGracePeriodMinutes` | int | `60` |  | The failover data loss grace period. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the deployed azure sql failover group. |
+| `resourceGroupName` | string | The resource group of the deployed azure sql failover group. |
+| `resourceId` | string | The resource ID of the deployed azure sql failover group. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/Microsoft.Sql/servers/failoverGroups/version.json
+++ b/modules/Microsoft.Sql/servers/failoverGroups/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.1"
+}

--- a/modules/Microsoft.Sql/servers/readme.md
+++ b/modules/Microsoft.Sql/servers/readme.md
@@ -705,7 +705,68 @@ module servers './Microsoft.Sql/servers/deploy.bicep' = {
 </details>
 <p>
 
-<h3>Example 3: Pe</h3>
+<h3>Example 3: Fog</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module servers './Microsoft.Sql/servers/deploy.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-test-sqlfog'
+  params: {
+    // Required parameters
+    name: '<name>'
+    // Non-required parameters
+    databases: '<databases>'
+    failoverPolicy: 'Manual'
+    failoverWithDataLossGracePeriodMinutes: 60
+    partnerServerId: '<partnerServerId>'
+    serverName: '<serverName>'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "<name>"
+    },
+    // Non-required parameters
+    "databases": {
+      "value": "<databases>"
+    },
+    "failoverPolicy": {
+      "value": "Manual"
+    },
+    "failoverWithDataLossGracePeriodMinutes": {
+      "value": 60
+    },
+    "partnerServerId": {
+      "value": "<partnerServerId>"
+    },
+    "serverName": {
+      "value": "<serverName>"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<h3>Example 4: Pe</h3>
 
 <details>
 


### PR DESCRIPTION
# Description

Initial commit of Microsoft.Sql/servers/failoverGroups

Creating this PR to trigger a discussion. It currently fails the pester test because the parameters are not included in the servers deploy.bicep.

I am not sure if it makes sense to have failoverGroups as a part of servers/deploy.bicep.

* The failover groups API require two (and only two) logical servers in two different regions as input.
* The included databases can only exist on the "primary" server when being added to the Failover Group.
* PartnerServers is a required parameter by the API, it cannot be empty so it cannot be "declaratively" removed.
* When a failover group is removed/deleted the secondary server is not affected, neither is the synchronization of any joined databases.

Very interested in suggestions on how this could fit into the repository.

# Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
