### PR TITLE
[Modules] Simplify roleAssignment implementation for Resource Group

### DIFF
--- a/modules/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
+++ b/modules/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
@@ -5,7 +5,7 @@ param principalIds array
 param roleDefinitionIdOrName string
 
 @sys.description('Required. The resource ID of the resource to apply the role assignment to.')
-param resourceId string
+param resourceId string = resourceGroup().id
 
 @sys.description('Optional. The principal type of the assigned principal ID.')
 @allowed([

--- a/modules/Microsoft.Resources/resourceGroups/deploy.bicep
+++ b/modules/Microsoft.Resources/resourceGroups/deploy.bicep
@@ -65,7 +65,6 @@ module resourceGroup_roleAssignments '.bicep/nested_roleAssignments.bicep' = [fo
     roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
     condition: contains(roleAssignment, 'condition') ? roleAssignment.condition : ''
     delegatedManagedIdentityResourceId: contains(roleAssignment, 'delegatedManagedIdentityResourceId') ? roleAssignment.delegatedManagedIdentityResourceId : ''
-    resourceId: resourceGroup.id
   }
   scope: resourceGroup
 }]


### PR DESCRIPTION
# Description

Simplify the inputs required for RG RBAC. As the resource ID is already provided in the scope of the deployment, the default is to get the current resourceGroup id.

## Pipeline references

| Pipeline |
| - |
| [![Resources - ResourceGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml/badge.svg?branch=mast%2Ffeat%2Frg_rbac_cleanup)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
