### PR TITLE
[Utilities] Enforce PS7.3 where required

### DIFF
--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -1,4 +1,4 @@
-﻿#requires -version 6.0
+﻿#requires -version 7.3
 
 <#
 .SYNOPSIS

--- a/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
+++ b/utilities/tools/helper/ConvertTo-OrderedHashtable.ps1
@@ -1,3 +1,5 @@
+#requires -version 7.3
+
 <#
 .SYNOPSIS
 Convert a given JSON string into an ordered HashTable.


### PR DESCRIPTION
# Description

- To avoid further issues of peers that want to use the script but have issues as they're using e.g. PowerShell version 7.2.7, this change enforces 7.3 (which contains the breaking change for the `ConvertFrom-Json -AsHashTable` invocation)
- Tested locally, no changes to the result

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
