### PR TITLE
[Modules] Reduced permissions of ML encr test

### DIFF
--- a/modules/Microsoft.MachineLearningServices/workspaces/.test/encr/dependencies.bicep
+++ b/modules/Microsoft.MachineLearningServices/workspaces/.test/encr/dependencies.bicep
@@ -82,10 +82,10 @@ resource keyVaultServicePermissions 'Microsoft.Authorization/roleAssignments@202
 }
 resource keyVaultDataPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
     name: guid('msi-${keyVault.id}-${location}-${managedIdentity.id}-KeyVault-Data-Admin-RoleAssignment')
-    scope: keyVault
+    scope: keyVault::key
     properties: {
         principalId: managedIdentity.properties.principalId
-        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483') // Key Vault Administrator
+        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424') // Key Vault Crypto User
         principalType: 'ServicePrincipal'
     }
 }

--- a/modules/Microsoft.MachineLearningServices/workspaces/deploy.bicep
+++ b/modules/Microsoft.MachineLearningServices/workspaces/deploy.bicep
@@ -239,7 +239,7 @@ resource workspace 'Microsoft.MachineLearningServices/workspaces@2022-10-01' = {
     primaryUserAssignedIdentity: primaryUserAssignedIdentity
     publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) ? 'Disabled' : 'Enabled')
     serviceManagedResourcesSettings: serviceManagedResourcesSettings
-    // sharedPrivateLinkResources: []
+    sharedPrivateLinkResources: sharedPrivateLinkResources // Note: This property is not idempotent. Neither with [] or `null`
   }
 }
 

--- a/modules/Microsoft.MachineLearningServices/workspaces/deploy.bicep
+++ b/modules/Microsoft.MachineLearningServices/workspaces/deploy.bicep
@@ -239,7 +239,7 @@ resource workspace 'Microsoft.MachineLearningServices/workspaces@2022-10-01' = {
     primaryUserAssignedIdentity: primaryUserAssignedIdentity
     publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) ? 'Disabled' : 'Enabled')
     serviceManagedResourcesSettings: serviceManagedResourcesSettings
-    sharedPrivateLinkResources: sharedPrivateLinkResources
+    // sharedPrivateLinkResources: []
   }
 }
 


### PR DESCRIPTION
# Description

- Reduced the permissions of the Encryption Test of the ML workspace from the original `Key Vault Administrator` to `Key Vault Crypto User` with scope `key` as it does not require any more permissions. This is also closer aligned to similar tests for other modules.
- Added a comment to one of the properties that turned out to be NOT idempotent (and pretty weird too)

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![MachineLearningServices - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.machinelearningservices.workspaces.yml/badge.svg?branch=users%2Falsehr%2FmlSharedPeTest)](https://github.com/Azure/ResourceModules/actions/workflows/ms.machinelearningservices.workspaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
