### PR TITLE
[Modules] managedClusters - Fix a bug for addonprofiles

### DIFF
--- a/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -419,34 +419,34 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' 
       }
       ingressApplicationGateway: {
         enabled: ingressApplicationGatewayEnabled && !empty(appGatewayResourceId)
-        config: {
+        config: ingressApplicationGatewayEnabled && !empty(appGatewayResourceId) ?{
           applicationGatewayId: !empty(appGatewayResourceId) ? any(appGatewayResourceId) : null
           effectiveApplicationGatewayId: !empty(appGatewayResourceId) ? any(appGatewayResourceId) : null
-        }
+        } : null
       }
       omsagent: {
         enabled: omsAgentEnabled && !empty(monitoringWorkspaceId)
-        config: {
+        config: omsAgentEnabled && !empty(monitoringWorkspaceId) ? {
           logAnalyticsWorkspaceResourceID: !empty(monitoringWorkspaceId) ? any(monitoringWorkspaceId) : null
-        }
+        } : null
       }
       aciConnectorLinux: {
         enabled: aciConnectorLinuxEnabled
       }
       azurepolicy: {
         enabled: azurePolicyEnabled
-        config: {
+        config: azurePolicyEnabled ? {
           version: azurePolicyVersion
-        }
+        } : null
       }
       kubeDashboard: {
         enabled: kubeDashboardEnabled
       }
       azureKeyvaultSecretsProvider: {
         enabled: enableKeyvaultSecretsProvider
-        config: {
+        config: enableKeyvaultSecretsProvider ? {
           enableSecretRotation: enableSecretRotation
-        }
+        } : null
       }
     }
     oidcIssuerProfile: enableOidcIssuerProfile ? {

--- a/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -419,7 +419,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' 
       }
       ingressApplicationGateway: {
         enabled: ingressApplicationGatewayEnabled && !empty(appGatewayResourceId)
-        config: ingressApplicationGatewayEnabled && !empty(appGatewayResourceId) ?{
+        config: ingressApplicationGatewayEnabled && !empty(appGatewayResourceId) ? {
           applicationGatewayId: !empty(appGatewayResourceId) ? any(appGatewayResourceId) : null
           effectiveApplicationGatewayId: !empty(appGatewayResourceId) ? any(appGatewayResourceId) : null
         } : null


### PR DESCRIPTION
# Description

When deploying the current version of managedCluster and you enable some of the addons, and later remove them using the module, you get an error for reconfiguring addonProfiles as the format is incorrectly formatted. This PR fixes this where its sets the expected value of `null` on config for the profiles which are disabled.

## Pipeline references

| Pipeline |
| - |
| [![ContainerService - ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Fmast%2FmanagedClusterFixAddonProfiles)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
