### PR TITLE
[Modules] managedCluster - Add support for enabling Open Service Mesh

### DIFF
--- a/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/.test/azure/deploy.test.bicep
@@ -147,6 +147,7 @@ module testDeployment '../../deploy.bicep' = {
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
     diskEncryptionSetID: nestedDependencies.outputs.diskEncryptionSetResourceId
+    openServiceMeshEnabled: true
     lock: 'CanNotDelete'
     roleAssignments: [
       {

--- a/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
+++ b/modules/Microsoft.ContainerService/managedClusters/deploy.bicep
@@ -144,6 +144,9 @@ param aciConnectorLinuxEnabled bool = false
 @description('Optional. Specifies whether the azurepolicy add-on is enabled or not. For security reasons, this setting should be enabled.')
 param azurePolicyEnabled bool = true
 
+@description('Optional. Specifies whether the openServiceMesh add-on is enabled or not.')
+param openServiceMeshEnabled bool = false
+
 @description('Optional. Specifies the azure policy version to use.')
 param azurePolicyVersion string = 'v2'
 
@@ -438,6 +441,10 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' 
         config: azurePolicyEnabled ? {
           version: azurePolicyVersion
         } : null
+      }
+      openServiceMesh: {
+        enabled: openServiceMeshEnabled
+        config: openServiceMeshEnabled ? {} : null
       }
       kubeDashboard: {
         enabled: kubeDashboardEnabled

--- a/modules/Microsoft.ContainerService/managedClusters/readme.md
+++ b/modules/Microsoft.ContainerService/managedClusters/readme.md
@@ -115,6 +115,7 @@ This module deploys Azure Kubernetes Cluster (AKS).
 | `monitoringWorkspaceId` | string | `''` |  | Resource ID of the monitoring log analytics workspace. |
 | `nodeResourceGroup` | string | `[format('{0}_aks_{1}_nodes', resourceGroup().name, parameters('name'))]` |  | Name of the resource group containing agent pool nodes. |
 | `omsAgentEnabled` | bool | `True` |  | Specifies whether the OMS agent is enabled. |
+| `openServiceMeshEnabled` | bool | `False` |  | Specifies whether the openServiceMesh add-on is enabled or not. |
 | `podIdentityProfileAllowNetworkPluginKubenet` | bool | `False` |  | Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. |
 | `podIdentityProfileEnable` | bool | `False` |  | Whether the pod identity addon is enabled. |
 | `podIdentityProfileUserAssignedIdentities` | array | `[]` |  | The pod identities to use in the cluster. |
@@ -534,6 +535,7 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
       }
     }
     lock: 'CanNotDelete'
+    openServiceMeshEnabled: true
     roleAssignments: [
       {
         principalIds: [
@@ -726,6 +728,9 @@ module managedClusters './Microsoft.ContainerService/managedClusters/deploy.bice
     },
     "lock": {
       "value": "CanNotDelete"
+    },
+    "openServiceMeshEnabled": {
+      "value": true
     },
     "roleAssignments": {
       "value": [


### PR DESCRIPTION
# Description

- Add support for enabling Open Service Mesh
- Updated the Azure test to include enabling the open service mesh addon.

## Pipeline references

| Pipeline |
| - |
| [![ContainerService - ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Fmast%2FAKSosm)](https://github.com/Azure/ResourceModules/actions/runs/4372001076) |

# Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
