### PR TITLE
[Fixes] Storage Account Local User : Pass on correct parameter

### DIFF
--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -378,7 +378,7 @@ module storageAccount_localUsers 'localUsers/deploy.bicep' = [for (localUser, in
     storageAccountName: storageAccount.name
     name: localUser.name
     hasSharedKey: contains(localUser, 'hasSharedKey') ? localUser.hasSharedKey : false
-    hasSshKey: contains(localUser, 'hasSshPassword') ? localUser.hasSshPassword : true
+    hasSshKey: contains(localUser, 'hasSshKey') ? localUser.hasSshKey : false
     hasSshPassword: contains(localUser, 'hasSshPassword') ? localUser.hasSshPassword : false
     homeDirectory: contains(localUser, 'homeDirectory') ? localUser.homeDirectory : ''
     permissionScopes: contains(localUser, 'permissionScopes') ? localUser.permissionScopes : []

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -377,11 +377,11 @@ module storageAccount_localUsers 'localUsers/deploy.bicep' = [for (localUser, in
   params: {
     storageAccountName: storageAccount.name
     name: localUser.name
+    hasSshKey: localUser.hasSshKey
+    hasSshPassword: localUser.hasSshPassword
+    permissionScopes: localUser.permissionScopes
     hasSharedKey: contains(localUser, 'hasSharedKey') ? localUser.hasSharedKey : false
-    hasSshKey: contains(localUser, 'hasSshKey') ? localUser.hasSshKey : false
-    hasSshPassword: contains(localUser, 'hasSshPassword') ? localUser.hasSshPassword : false
     homeDirectory: contains(localUser, 'homeDirectory') ? localUser.homeDirectory : ''
-    permissionScopes: contains(localUser, 'permissionScopes') ? localUser.permissionScopes : []
     sshAuthorizedKeys: contains(localUser, 'sshAuthorizedKeys') ? localUser.sshAuthorizedKeys : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }


### PR DESCRIPTION
# Description

The parameter is not passed on as expected, but seems to be a copy/paste error.
In effect I cannot enable the authorizedKeys for the local user.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.
need to come back after it has run

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
