### PR TITLE
[Module] Microsoft.Storage/StorageAccounts policy exemption

### DIFF
--- a/modules/Microsoft.Storage/storageAccounts/.bicep/nested_policyExemptions.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.bicep/nested_policyExemptions.bicep
@@ -1,0 +1,63 @@
+@sys.description('Required. The resource ID of the resource to apply the policy exemption to.')
+param resourceId string
+
+@sys.description('Required. Specifies the name of the policy exemption. Maximum length is 64 characters.')
+@maxLength(64)
+param name string
+
+@sys.description('Optional. The display name of the policy exemption. Maximum length is 128 characters.')
+@maxLength(128)
+param displayName string = ''
+
+@sys.description('Optional. The description of the policy exemption.')
+param description string = ''
+
+@sys.description('Optional. The policy exemption metadata. Metadata is an open ended object and is typically a collection of key-value pairs.')
+param metadata object = {}
+
+@sys.description('Optional. The policy exemption category. Possible values are Waiver and Mitigated. Default is Mitigated.')
+@allowed([
+  'Mitigated'
+  'Waiver'
+])
+param exemptionCategory string = 'Mitigated'
+
+@sys.description('Required. The resource ID of the policy assignment that is being exempted.')
+param policyAssignmentId string
+
+@sys.description('Optional. The policy definition reference ID list when the associated policy assignment is an assignment of a policy set definition.')
+param policyDefinitionReferenceIds array = []
+
+@sys.description('Optional. The expiration date and time (in UTC ISO 8601 format yyyy-MM-ddTHH:mm:ssZ) of the policy exemption. e.g. 2021-10-02T03:57:00.000Z.')
+param expiresOn string = ''
+
+@sys.description('Optional. The option whether validate the exemption is at or under the assignment scope.')
+@allowed([
+  ''
+  'Default'
+  'DoNotValidate'
+])
+param assignmentScopeValidation string = ''
+
+@sys.description('Optional. The resource selector list to filter policies by resource properties.')
+param resourceSelectors array = []
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' existing = {
+  name: last(split(resourceId, '/'))!
+}
+
+resource policyExemption 'Microsoft.Authorization/policyExemptions@2022-07-01-preview' = {
+  name: name
+  properties: {
+    assignmentScopeValidation: !empty(assignmentScopeValidation) ? assignmentScopeValidation : null
+    displayName: !empty(displayName) ? displayName : null
+    description: !empty(description) ? description : null
+    exemptionCategory: exemptionCategory
+    expiresOn: !empty(expiresOn) ? expiresOn : null
+    metadata: !empty(metadata) ? metadata : null
+    policyAssignmentId: policyAssignmentId
+    policyDefinitionReferenceIds: !empty(policyDefinitionReferenceIds) ? policyDefinitionReferenceIds : null
+    resourceSelectors: resourceSelectors
+  }
+  scope: storageAccount
+}

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -64,8 +64,15 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
 resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
     name: policyAssignmentName
     scope: resourceGroup()
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            '${managedIdentity.id}': {}
+        }
+    }
     properties: {
         policyDefinitionId: policyDefinitionId
+        enforcementMode: 'Default'
     }
 }
 

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -8,7 +8,7 @@ param virtualNetworkName string
 param managedIdentityName string
 
 @description('Optional. The name of the policy assignment.')
-param policyAssignmentName string = '${resourceGroup().name}-Configure storage accounts to disable public network access'
+param policyAssignmentName string = '${resourceGroup().name}-DisableStoragePublicNetworkAccess'
 
 @description('Optional. The policy definition Id to be assigned.')
 param policyDefinitionId string = '/providers/Microsoft.Authorization/policyDefinitions/a06d0189-92e8-4dba-b0c4-08d7669fce7d'

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -8,7 +8,7 @@ param virtualNetworkName string
 param managedIdentityName string
 
 @description('Optional. The name of the policy assignment.')
-param policyAssignmentName string = '${resourceGroup().name}-DisableStoragePublicNetworkAccess'
+param policyAssignmentName string = 'DisableStoragePublicNetworkAccess'
 
 @description('Optional. The policy definition Id to be assigned.')
 param policyDefinitionId string = '/providers/Microsoft.Authorization/policyDefinitions/a06d0189-92e8-4dba-b0c4-08d7669fce7d'

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -64,6 +64,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
 resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
     name: policyAssignmentName
     scope: resourceGroup()
+    location: location
     identity: {
         type: 'UserAssigned'
         userAssignedIdentities: {

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -7,6 +7,12 @@ param virtualNetworkName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+@description('Optional. The name of the policy assignment.')
+param policyAssignmentName string = 'Configure your Storage account public access to be disallowed'
+
+@description('Optional. The policy definition Id to be assigned.')
+param policyDefinitionId string = '/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab'
+
 var addressPrefix = '10.0.0.0/16'
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
@@ -55,6 +61,14 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
     location: location
 }
 
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+    name: policyAssignmentName
+    scope: resourceGroup()
+    properties: {
+        policyDefinitionId: policyDefinitionId
+    }
+}
+
 @description('The resource ID of the created Virtual Network Subnet.')
 output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 
@@ -66,3 +80,6 @@ output managedIdentityResourceId string = managedIdentity.id
 
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSZoneResourceId string = privateDNSZone.id
+
+@description('The resource ID of the Policy Assignment.')
+output policyAssignmentId string = policyAssignment.id

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/dependencies.bicep
@@ -8,10 +8,10 @@ param virtualNetworkName string
 param managedIdentityName string
 
 @description('Optional. The name of the policy assignment.')
-param policyAssignmentName string = 'Configure your Storage account public access to be disallowed'
+param policyAssignmentName string = '${resourceGroup().name}-Configure storage accounts to disable public network access'
 
 @description('Optional. The policy definition Id to be assigned.')
-param policyDefinitionId string = '/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab'
+param policyDefinitionId string = '/providers/Microsoft.Authorization/policyDefinitions/a06d0189-92e8-4dba-b0c4-08d7669fce7d'
 
 var addressPrefix = '10.0.0.0/16'
 

--- a/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/.test/common/deploy.test.bicep
@@ -69,6 +69,16 @@ module testDeployment '../../deploy.bicep' = {
     enableHierarchicalNamespace: true
     enableSftp: true
     enableNfsV3: true
+    policyExemptions: [
+      {
+        name: '<<namePrefix>>${serviceShort}001-PolicyExemption001'
+        displayName: '<<namePrefix>>${serviceShort}001 Policy Exception'
+        description: 'Test Policy Exemption 1'
+        assignmentScopeValidation: 'DoNotValidate'
+        policyAssignmentId: nestedDependencies.outputs.policyAssignmentId
+        exemptionCategory: 'Waiver'
+      }
+    ]
     privateEndpoints: [
       {
         service: 'blob'

--- a/modules/Microsoft.Storage/storageAccounts/deploy.bicep
+++ b/modules/Microsoft.Storage/storageAccounts/deploy.bicep
@@ -347,7 +347,7 @@ resource storageAccount_policyExemptions 'Microsoft.Authorization/policyExemptio
     assignmentScopeValidation: contains(policyExemption, 'assignmentScopeValidation') ? policyExemption.assignmentScopeValidation : ''
     displayName: contains(policyExemption, 'displayName') ? policyExemption.description : ''
     description: contains(policyExemption, 'description') ? policyExemption.description : ''
-    metadata: contains(policyExemption, 'metadata') ? policyExemption.metadata : ''
+    metadata: contains(policyExemption, 'metadata') ? policyExemption.metadata : {}
     policyAssignmentId: policyExemption.policyAssignmentId
     policyDefinitionReferenceIds: contains(policyExemption, 'policyDefinitionReferenceIds') ? policyExemption.policyDefinitionReferenceIds : null
     exemptionCategory: contains(policyExemption, 'exemptionCategory') ? policyExemption.exemptionCategory : null

--- a/modules/Microsoft.Storage/storageAccounts/readme.md
+++ b/modules/Microsoft.Storage/storageAccounts/readme.md
@@ -16,6 +16,7 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
+| `Microsoft.Authorization/policyExemptions` | [2022-07-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-07-01-preview/policyExemptions) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Network/privateEndpoints` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints) |
@@ -85,6 +86,7 @@ This module is used to deploy a storage account, with the ability to deploy 1 or
 | `managementPolicyRules` | array | `[]` |  | The Storage Account ManagementPolicies Rules. |
 | `minimumTlsVersion` | string | `'TLS1_2'` | `[TLS1_0, TLS1_1, TLS1_2]` | Set the minimum TLS version on request to storage. |
 | `networkAcls` | object | `{object}` |  | Networks ACLs, this value contains IPs to whitelist and/or Subnet information. For security reasons, it is recommended to set the DefaultAction Deny. |
+| `policyExemptions` | array | `[]` |  | Array of policy exemption objects that contain the 'name' and 'policyAssignmentId' to policy exemptions on this resource. |
 | `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | `publicNetworkAccess` | string | `''` | `['', Disabled, Enabled]` | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set. |
 | `queueServices` | _[queueServices](queueServices/readme.md)_ object | `{object}` |  | Queue service and queues to create. |
@@ -531,6 +533,16 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
         }
       ]
     }
+    policyExemptions: [
+      {
+        assignmentScopeValidation: 'DoNotValidate'
+        description: 'Test Policy Exemption 1'
+        displayName: '<<namePrefix>>ssacom001 Policy Exception'
+        exemptionCategory: 'Waiver'
+        name: '<<namePrefix>>ssacom001-PolicyExemption001'
+        policyAssignmentId: '<policyAssignmentId>'
+      }
+    ]
     privateEndpoints: [
       {
         privateDnsZoneGroup: {
@@ -757,6 +769,18 @@ module storageAccounts './Microsoft.Storage/storageAccounts/deploy.bicep' = {
           }
         ]
       }
+    },
+    "policyExemptions": {
+      "value": [
+        {
+          "assignmentScopeValidation": "DoNotValidate",
+          "description": "Test Policy Exemption 1",
+          "displayName": "<<namePrefix>>ssacom001 Policy Exception",
+          "exemptionCategory": "Waiver",
+          "name": "<<namePrefix>>ssacom001-PolicyExemption001",
+          "policyAssignmentId": "<policyAssignmentId>"
+        }
+      ]
     },
     "privateEndpoints": {
       "value": [


### PR DESCRIPTION
# Description

This update adds the deployment of policy exemptions at the Storage Account level which is a useful deployment orchestration when we must deploy storage accounts with public access allowed and we have policy deployed at a higher scope that blocks that resource creation.

## Pipeline references

[![Storage - StorageAccounts](https://github.com/shawntmeyer/CARML/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=StorageAccount-PolicyExemption)](https://github.com/shawntmeyer/CARML/actions/workflows/ms.storage.storageaccounts.yml)

# Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
