### PR TITLE
[Modules] Updated SKU for the Managed Environment Test

### DIFF
--- a/modules/Microsoft.App/managedEnvironments/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.App/managedEnvironments/.test/common/deploy.test.bicep
@@ -48,7 +48,7 @@ module testDeployment '../../deploy.bicep' = {
     name: '<<namePrefix>>${serviceShort}001'
     logAnalyticsWorkspaceResourceId: nestedDependencies.outputs.logAnalyticsWorkspaceResourceId
     location: location
-    skuName: 'Premium'
+    skuName: 'Consumption'
     internal: true
     dockerBridgeCidr: '172.16.0.1/28'
     platformReservedCidr: '172.17.17.0/24'

--- a/modules/Microsoft.App/managedEnvironments/readme.md
+++ b/modules/Microsoft.App/managedEnvironments/readme.md
@@ -199,7 +199,7 @@ module managedEnvironments './Microsoft.App/managedEnvironments/deploy.bicep' = 
     lock: 'CanNotDelete'
     platformReservedCidr: '172.17.17.0/24'
     platformReservedDnsIP: '172.17.17.17'
-    skuName: 'Premium'
+    skuName: 'Consumption'
     tags: {
       Env: 'test'
     }
@@ -252,7 +252,7 @@ module managedEnvironments './Microsoft.App/managedEnvironments/deploy.bicep' = 
       "value": "172.17.17.17"
     },
     "skuName": {
-      "value": "Premium"
+      "value": "Consumption"
     },
     "tags": {
       "value": {


### PR DESCRIPTION
Closes #3018 

# Description

Changed our test case to use the 'Consumption SKU' instead of the 'Premium' as the premium seems to have some support issues. Although the premium SKU is still mentioned in the Template Doc: https://learn.microsoft.com/en-us/azure/templates/microsoft.app/2022-10-01/managedenvironments?pivots=deployment-language-bicep#environmentskuproperties

| Pipeline |
| - |
| [![App - Managed Environments](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.managedenvironments.yml/badge.svg?branch=users%2Fahmad%2F3018_capp)](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.managedenvironments.yml)|

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
