### PR TITLE
[Modules] Microsoft.Synapse/workspaces - adding 'systemAssignedPrincipalId' as output

### DIFF
--- a/modules/Microsoft.Synapse/workspaces/deploy.bicep
+++ b/modules/Microsoft.Synapse/workspaces/deploy.bicep
@@ -323,5 +323,8 @@ output resourceGroupName string = resourceGroup().name
 @description('The workspace connectivity endpoints.')
 output connectivityEndpoints object = workspace.properties.connectivityEndpoints
 
+@description('The principal ID of the system assigned identity.')
+output systemAssignedPrincipalId string = contains(workspace.identity, 'principalId') ? workspace.identity.principalId : ''
+
 @description('The location the resource was deployed into.')
 output location string = workspace.location

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -318,6 +318,7 @@ userAssignedIdentities: {
 | `name` | string | The name of the deployed Synapse Workspace. |
 | `resourceGroupName` | string | The resource group of the deployed Synapse Workspace. |
 | `resourceID` | string | The resource ID of the deployed Synapse Workspace. |
+| `systemAssignedPrincipalId` | string | The principal ID of the system assigned identity. |
 
 ## Cross-referenced modules
 


### PR DESCRIPTION
# Description

This PR resolves #3004 and adds the PrincipalId of the system-assigned identity as a new output `systemAssignedPrincipalId`.

## Pipeline references

| Pipeline |
| - |
| [![Synapse - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Fkrbar%2F3004-synapse-output)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) |

# Type of Change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
