### PR TITLE
Reduced length of deployment name

### DIFF
--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -260,7 +260,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
 }
 
 module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies/deploy.bicep' = {
-  name: '${uniqueString(deployment().name, location)}-${name}-shortBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-${name}-shBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name
@@ -270,7 +270,7 @@ module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies
 }
 
 module database_backupLongTermRetentionPolicy 'backupLongTermRetentionPolicies/deploy.bicep' = {
-  name: '${uniqueString(deployment().name, location)}-${name}-longBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-${name}-lgBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name

--- a/modules/Microsoft.Sql/servers/databases/deploy.bicep
+++ b/modules/Microsoft.Sql/servers/databases/deploy.bicep
@@ -260,7 +260,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
 }
 
 module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies/deploy.bicep' = {
-  name: '${uniqueString(deployment().name, location)}-${name}-shortTermBackupRetention'
+  name: '${uniqueString(deployment().name, location)}-${name}-shortBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name
@@ -270,7 +270,7 @@ module database_backupShortTermRetentionPolicy 'backupShortTermRetentionPolicies
 }
 
 module database_backupLongTermRetentionPolicy 'backupLongTermRetentionPolicies/deploy.bicep' = {
-  name: '${uniqueString(deployment().name, location)}-${name}-longTermBackupRetention'
+  name: '${uniqueString(deployment().name, location)}-${name}-longBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name


### PR DESCRIPTION
# Description
Deployment names are limited to 64 characters. These names are very long and leaving only a small portion of the name the name of the database. The default name is already 39 characters, leaving only 25 characters for the name of the database. This change simply reduces it to 26 characters, leaving 38 characters for the database name. and therfor granting more flexibility.

````
The provided deployment name 'dfrl2mpjuwzn4-{dbname}-shortTermBackupRetention' has a length of '65' which exceeds the maximum length of '64'. 
````

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My code follows the style guidelines of this project
- [x] I did format my code
