### PR TITLE
Adjusting sslPolicy based on policy type

### DIFF
--- a/modules/Microsoft.Network/applicationGateways/deploy.bicep
+++ b/modules/Microsoft.Network/applicationGateways/deploy.bicep
@@ -329,9 +329,12 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2022-07-01' =
         capacity: autoscaleMaxCapacity > 0 && autoscaleMinCapacity >= 0 ? null : capacity
       }
       sslCertificates: sslCertificates
-      sslPolicy: {
+      sslPolicy: sslPolicyType != 'Predefined' ? {
         cipherSuites: sslPolicyCipherSuites
         minProtocolVersion: sslPolicyMinProtocolVersion
+        policyName: empty(sslPolicyName) ? null : sslPolicyName
+        policyType: sslPolicyType
+      } : {
         policyName: empty(sslPolicyName) ? null : sslPolicyName
         policyType: sslPolicyType
       }


### PR DESCRIPTION
# Description

- Adjusting `sslPolicy` property content to be based on policy type. When using `predefined` the sslPolicy property do only need name and type.

## Pipeline references

| Pipeline |
| - |
| Coming soon! |

# Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
