### PR TITLE
[CI Environment] CODEOWNERS - Fix codeowners based on team rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-*   @Azure/modules-maintainers
+*   @Azure/module-maintainers


### PR DESCRIPTION
# Description

As the names of the teams have been renamed, the auto assignment on reviewers in PRs is not working. This attempts to fix that so that reviewers are again auto assigned.

## Pipeline references

| Pipeline |
| - |
| N/A |

# Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code