### PR TITLE
[Modules] DocumentDB - Add enable free tier tag to cosmos db properties

### DIFF
--- a/modules/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/deploy.bicep
@@ -35,7 +35,7 @@ param defaultConsistencyLevel string = 'Session'
 @description('Optional. Enable automatic failover for regions.')
 param automaticFailover bool = true
 
-@description('Optional. Enable free tier.')
+@description('Optional. Flag to indicate whether Free Tier is enabled.')
 param enableFreeTier bool = false
 
 @minValue(10)

--- a/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
+++ b/modules/Microsoft.DocumentDB/databaseAccounts/readme.md
@@ -56,7 +56,7 @@ This module deploys a DocumentDB database account and its child resources.
 | `diagnosticStorageAccountId` | string | `''` |  | Resource ID of the diagnostic storage account. |
 | `diagnosticWorkspaceId` | string | `''` |  | Resource ID of the log analytics workspace. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
-| `enableFreeTier` | bool | `False` |  | Enable free tier. |
+| `enableFreeTier` | bool | `False` |  | Flag to indicate whether Free Tier is enabled. |
 | `gremlinDatabases` | _[gremlinDatabases](gremlinDatabases/readme.md)_ array | `[]` |  | Gremlin Databases configurations. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |


### PR DESCRIPTION
# Description

Added enablefreetier to properties of cosmos db to allow the deployment of cosmos db using free tier which will be useful for the development environment

Fixes: #3125 

> List any dependencies that are required for this change.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![DocumentDB - DatabaseAccounts](https://github.com/samuelya/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Fsamg%2FenableFreeTierForCosmosDb)](https://github.com/samuelya/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml)|

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
