### PR TITLE
[Modules] Synapse workspaces Added support for resourceId

### DIFF
--- a/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
@@ -86,7 +86,7 @@ output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 output privateDNSResourceId string = privateDNSZone.id
 
 @description('The resource ID of the created Storage Account.')
-output storageAccountId string = storageAccount.id
+output storageAccountResourceId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/dependencies.bicep
@@ -85,8 +85,8 @@ output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSResourceId string = privateDNSZone.id
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
@@ -61,7 +61,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     initialWorkspaceAdminObjectID: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/common/deploy.test.bicep
@@ -61,7 +61,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     initialWorkspaceAdminObjectID: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
@@ -60,7 +60,7 @@ output keyVaultResourceId string = keyVault.id
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
 @description('The resource ID of the created Storage Account.')
-output storageAccountId string = storageAccount.id
+output storageAccountResourceId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/dependencies.bicep
@@ -59,8 +59,8 @@ output keyVaultResourceId string = keyVault.id
 @description('The name of the Key Vault Encryption Key.')
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
@@ -50,7 +50,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwsai/deploy.test.bicep
@@ -50,7 +50,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
@@ -80,8 +80,8 @@ output keyVaultResourceId string = keyVault.id
 @description('The name of the Key Vault Encryption Key.')
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/dependencies.bicep
@@ -81,7 +81,7 @@ output keyVaultResourceId string = keyVault.id
 output keyVaultEncryptionKeyName string = keyVault::key.name
 
 @description('The resource ID of the created Storage Account.')
-output storageAccountId string = storageAccount.id
+output storageAccountResourceId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
@@ -51,7 +51,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/encrwuai/deploy.test.bicep
@@ -51,7 +51,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     encryption: true

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
@@ -24,8 +24,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     }
 }
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/dependencies.bicep
@@ -25,7 +25,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 }
 
 @description('The resource ID of the created Storage Account.')
-output storageAccountId string = storageAccount.id
+output storageAccountResourceId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     managedVirtualNetwork: true

--- a/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/managedvnet/deploy.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     managedVirtualNetwork: true

--- a/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
@@ -24,8 +24,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     }
 }
 
-@description('The name of the created Storage Account.')
-output storageAccountName string = storageAccount.name
+@description('The resource ID of the created Storage Account.')
+output storageAccountId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/dependencies.bicep
@@ -25,7 +25,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 }
 
 @description('The resource ID of the created Storage Account.')
-output storageAccountId string = storageAccount.id
+output storageAccountResourceId string = storageAccount.id
 
 @description('The name of the created container.')
 output storageContainerName string = storageAccount::blobService::container.name

--- a/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountName: nestedDependencies.outputs.storageAccountName
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     enableDefaultTelemetry: enableDefaultTelemetry

--- a/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
+++ b/modules/Microsoft.Synapse/workspaces/.test/min/deploy.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     name: '<<namePrefix>>${serviceShort}001'
-    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountId
+    defaultDataLakeStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
     defaultDataLakeStorageFilesystem: nestedDependencies.outputs.storageContainerName
     sqlAdministratorLogin: 'synwsadmin'
     enableDefaultTelemetry: enableDefaultTelemetry

--- a/modules/Microsoft.Synapse/workspaces/deploy.bicep
+++ b/modules/Microsoft.Synapse/workspaces/deploy.bicep
@@ -15,8 +15,8 @@ param azureADOnlyAuthentication bool = false
 @description('Optional. AAD object ID of initial workspace admin.')
 param initialWorkspaceAdminObjectID string = ''
 
-@description('Required. Name of the default ADLS Gen2 storage account.')
-param defaultDataLakeStorageAccountName string
+@description('Required. Resource ID of the default ADLS Gen2 storage account.')
+param defaultDataLakeStorageAccountResourceId string
 
 @description('Required. The default ADLS Gen2 file system.')
 param defaultDataLakeStorageFilesystem string
@@ -199,7 +199,8 @@ resource workspace 'Microsoft.Synapse/workspaces@2021-06-01' = {
       initialWorkspaceAdminObjectId: initialWorkspaceAdminObjectID
     } : null
     defaultDataLakeStorage: {
-      accountUrl: 'https://${defaultDataLakeStorageAccountName}.dfs.${environment().suffixes.storage}'
+      resourceId: defaultDataLakeStorageAccountResourceId
+      accountUrl: 'https://${last(split(defaultDataLakeStorageAccountResourceId, '/'))!}.dfs.${environment().suffixes.storage}'
       filesystem: defaultDataLakeStorageFilesystem
       createManagedPrivateEndpoint: managedVirtualNetwork ? defaultDataLakeStorageCreateManagedPrivateEndpoint : null
     }

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -29,7 +29,7 @@ This module deploys a Synapse Workspace.
 
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `defaultDataLakeStorageAccountId` | string | Resource ID of the default ADLS Gen2 storage account. |
+| `defaultDataLakeStorageAccountResourceId` | string | Resource ID of the default ADLS Gen2 storage account. |
 | `defaultDataLakeStorageFilesystem` | string | The default ADLS Gen2 file system. |
 | `name` | string | The name of the Synapse Workspace. |
 | `sqlAdministratorLogin` | string | Login for administrator access to the workspace's SQL pools. |
@@ -347,7 +347,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swcom'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
+    defaultDataLakeStorageAccountResourceId: '<defaultDataLakeStorageAccountResourceId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swcom001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -410,8 +410,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountId": {
-      "value": "<defaultDataLakeStorageAccountId>"
+    "defaultDataLakeStorageAccountResourceId": {
+      "value": "<defaultDataLakeStorageAccountResourceId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -504,7 +504,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swensa'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
+    defaultDataLakeStorageAccountResourceId: '<defaultDataLakeStorageAccountResourceId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swensa001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -532,8 +532,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountId": {
-      "value": "<defaultDataLakeStorageAccountId>"
+    "defaultDataLakeStorageAccountResourceId": {
+      "value": "<defaultDataLakeStorageAccountResourceId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -581,7 +581,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swenua'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
+    defaultDataLakeStorageAccountResourceId: '<defaultDataLakeStorageAccountResourceId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swenua001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -612,8 +612,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountId": {
-      "value": "<defaultDataLakeStorageAccountId>"
+    "defaultDataLakeStorageAccountResourceId": {
+      "value": "<defaultDataLakeStorageAccountResourceId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -664,7 +664,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmanv'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
+    defaultDataLakeStorageAccountResourceId: '<defaultDataLakeStorageAccountResourceId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmanv001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -696,8 +696,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountId": {
-      "value": "<defaultDataLakeStorageAccountId>"
+    "defaultDataLakeStorageAccountResourceId": {
+      "value": "<defaultDataLakeStorageAccountResourceId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -747,7 +747,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmin'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
+    defaultDataLakeStorageAccountResourceId: '<defaultDataLakeStorageAccountResourceId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmin001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -770,8 +770,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountId": {
-      "value": "<defaultDataLakeStorageAccountId>"
+    "defaultDataLakeStorageAccountResourceId": {
+      "value": "<defaultDataLakeStorageAccountResourceId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"

--- a/modules/Microsoft.Synapse/workspaces/readme.md
+++ b/modules/Microsoft.Synapse/workspaces/readme.md
@@ -29,7 +29,7 @@ This module deploys a Synapse Workspace.
 
 | Parameter Name | Type | Description |
 | :-- | :-- | :-- |
-| `defaultDataLakeStorageAccountName` | string | Name of the default ADLS Gen2 storage account. |
+| `defaultDataLakeStorageAccountId` | string | Resource ID of the default ADLS Gen2 storage account. |
 | `defaultDataLakeStorageFilesystem` | string | The default ADLS Gen2 file system. |
 | `name` | string | The name of the Synapse Workspace. |
 | `sqlAdministratorLogin` | string | Login for administrator access to the workspace's SQL pools. |
@@ -347,7 +347,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swcom'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swcom001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -410,8 +410,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -504,7 +504,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swensa'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swensa001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -532,8 +532,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -581,7 +581,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swenua'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swenua001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -612,8 +612,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -664,7 +664,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmanv'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmanv001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -696,8 +696,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"
@@ -747,7 +747,7 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-swmin'
   params: {
     // Required parameters
-    defaultDataLakeStorageAccountName: '<defaultDataLakeStorageAccountName>'
+    defaultDataLakeStorageAccountId: '<defaultDataLakeStorageAccountId>'
     defaultDataLakeStorageFilesystem: '<defaultDataLakeStorageFilesystem>'
     name: '<<namePrefix>>swmin001'
     sqlAdministratorLogin: 'synwsadmin'
@@ -770,8 +770,8 @@ module workspaces './Microsoft.Synapse/workspaces/deploy.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "defaultDataLakeStorageAccountName": {
-      "value": "<defaultDataLakeStorageAccountName>"
+    "defaultDataLakeStorageAccountId": {
+      "value": "<defaultDataLakeStorageAccountId>"
     },
     "defaultDataLakeStorageFilesystem": {
       "value": "<defaultDataLakeStorageFilesystem>"


### PR DESCRIPTION
# Description

The field `resourceId` was added in the API which wasn't updated in the module. When the module is used, it is showing errors as it couldn't find the `resourceId` which is expected by the API.

Based on PR #2825 with addressed comments

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Synapse - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Falsehr%2F2825_merge)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
