### PR TITLE
Add test cases for nested role assignmnents

### DIFF
--- a/modules/Microsoft.Network/dnsResolvers/.test/common/dependencies.bicep
+++ b/modules/Microsoft.Network/dnsResolvers/.test/common/dependencies.bicep
@@ -1,8 +1,16 @@
 @description('Required. The name of the Virtual Network to create.')
 param virtualNetworkName string
 
+@description('Required. The name of the Managed Identity to create.')
+param managedIdentityName string
+
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: managedIdentityName
+  location: location
+}
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
   name: virtualNetworkName
@@ -54,3 +62,6 @@ output subnetResourceId_dnsIn string = virtualNetwork.properties.subnets[0].id
 
 @description('The resource ID of the created outbound endpoint Virtual Network Subnet.')
 output subnetResourceId_dnsOut string = virtualNetwork.properties.subnets[1].id
+
+@description('The principal ID of the created Managed Identity.')
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/modules/Microsoft.Network/dnsResolvers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/dnsResolvers/.test/common/deploy.test.bicep
@@ -33,6 +33,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
     virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
+    managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
     location: location
   }
 }
@@ -64,12 +65,13 @@ module testDeployment '../../deploy.bicep' = {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'
     }
+    lock: 'CanNotDelete'
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
         description: 'Reader Role Assignment'
         principalIds: [
-          'c99b4f9a-4268-4ab0-bd02-85d160b29a36' // carml-contributor-group
+          nestedDependencies.outputs.managedIdentityPrincipalId
         ]
       }
     ]

--- a/modules/Microsoft.Network/dnsResolvers/.test/common/deploy.test.bicep
+++ b/modules/Microsoft.Network/dnsResolvers/.test/common/deploy.test.bicep
@@ -64,5 +64,14 @@ module testDeployment '../../deploy.bicep' = {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'
     }
+    roleAssignments: [
+      {
+        roleDefinitionIdOrName: 'Reader'
+        description: 'Reader Role Assignment'
+        principalIds: [
+          'c99b4f9a-4268-4ab0-bd02-85d160b29a36' // carml-contributor-group
+        ]
+      }
+    ]
   }
 }

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -834,503 +834,14 @@ Describe 'Test file tests' -Tag 'TestTemplate' {
             $hasExpectedResourceType | Should -Be $true
         }
     }
+}
 
-    Describe 'Deployment template tests' -Tag 'Template' {
+Describe 'Deployment template tests' -Tag 'Template' {
 
-        Context 'General template' {
+    Context 'General template' {
 
-            $deploymentFolderTestCases = [System.Collections.ArrayList] @()
-            foreach ($moduleFolderPath in $moduleFolderPaths) {
-
-                # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
-                $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
-                if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
-                    if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
-                        $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
-                        $templateContent = bicep build $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
-
-                        if (-not $templateContent) {
-                            throw ($bicepTemplateCompilationFailedException -f $templateFilePath)
-                        }
-                    } elseIf (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
-                        $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
-                        $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
-
-                        if (-not $templateContent) {
-                            throw ($jsonTemplateLoadFailedException -f $templateFilePath)
-                        }
-                    } else {
-                        throw ($templateNotFoundException -f $moduleFolderPath)
-                    }
-                    $convertedTemplates[$moduleFolderPathKey] = @{
-                        templateFilePath = $templateFilePath
-                        templateContent  = $templateContent
-                    }
-                } else {
-                    $templateContent = $convertedTemplates[$moduleFolderPathKey].templateContent
-                    $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
-                }
-
-                # Parameter file test cases
-                $testFileTestCases = @()
-                $templateFile_Parameters = $templateContent.parameters
-                $TemplateFile_AllParameterNames = $templateFile_Parameters.Keys | Sort-Object
-                $TemplateFile_RequiredParametersNames = ($templateFile_Parameters.Keys | Where-Object { -not $templateFile_Parameters[$_].ContainsKey('defaultValue') }) | Sort-Object
-
-                if (Test-Path (Join-Path $moduleFolderPath '.test')) {
-
-                    # Can be removed after full migration to bicep test files
-                    $moduleTestFilePaths = Get-ModuleTestFileList -ModulePath $moduleFolderPath | ForEach-Object { Join-Path $moduleFolderPath $_ }
-
-                    foreach ($moduleTestFilePath in $moduleTestFilePaths) {
-                        if ((Split-Path $moduleTestFilePath -Extension) -eq '.json') {
-
-                            $rawContentHashtable = (Get-Content $moduleTestFilePath) | ConvertFrom-Json -AsHashtable
-
-                            # Skipping any file that is not actually a ARM-JSON parameter file
-                            $isParameterFile = $rawContentHashtable.'$schema' -like '*deploymentParameters*'
-                            if (-not $isParameterFile) {
-                                continue
-                            }
-
-                            $deploymentTestFile_AllParameterNames = $rawContentHashtable.parameters.Keys | Sort-Object
-                        } else {
-                            $deploymentFileContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
-                            $deploymentTestFile_AllParameterNames = $deploymentFileContent.resources[-1].properties.parameters.Keys | Sort-Object # The last resource should be the test
-                        }
-                        $testFileTestCases += @{
-                            testFile_Path                        = $moduleTestFilePath
-                            testFile_Name                        = Split-Path $moduleTestFilePath -Leaf
-                            testFile_AllParameterNames           = $deploymentTestFile_AllParameterNames
-                            templateFile_AllParameterNames       = $TemplateFile_AllParameterNames
-                            templateFile_RequiredParametersNames = $TemplateFile_RequiredParametersNames
-                            tokenConfiguration                   = $tokenConfiguration
-                        }
-                    }
-                }
-
-                # Test file setup
-                $deploymentFolderTestCases += @{
-                    moduleFolderName  = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
-                    templateContent   = $templateContent
-                    templateFilePath  = $templateFilePath
-                    testFileTestCases = $testFileTestCases
-                }
-            }
-
-            It '[<moduleFolderName>] The template file should not be empty.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $templateContent | Should -Not -Be $null
-            }
-
-            It '[<moduleFolderName>] Template schema version should be the latest.' -TestCases $deploymentFolderTestCases {
-                # the actual value changes depending on the scope of the template (RG, subscription, MG, tenant) !!
-                # https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-syntax
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                $Schemaverion = $templateContent.'$schema'
-                $SchemaArray = @()
-                if ($Schemaverion -eq $RGdeployment) {
-                    $SchemaOutput = $true
-                } elseIf ($Schemaverion -eq $Subscriptiondeployment) {
-                    $SchemaOutput = $true
-                } elseIf ($Schemaverion -eq $MGdeployment) {
-                    $SchemaOutput = $true
-                } elseIf ($Schemaverion -eq $Tenantdeployment) {
-                    $SchemaOutput = $true
-                } else {
-                    $SchemaOutput = $false
-                }
-                $SchemaArray += $SchemaOutput
-                $SchemaArray | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] Template schema should use HTTPS reference.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $Schemaverion = $templateContent.'$schema'
-            ($Schemaverion.Substring(0, 5) -eq 'https') | Should -Be $true
-            }
-
-            It '[<moduleFolderName>] All apiVersion properties should be set to a static, hard-coded value.' -TestCases $deploymentFolderTestCases {
-                #https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-best-practices
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $ApiVersion = $templateContent.resources.apiVersion
-                $ApiVersionArray = @()
-                foreach ($API in $ApiVersion) {
-                    if ($API.Substring(0, 2) -eq '20') {
-                        $ApiVersionOutput = $true
-                    } elseIf ($API.substring(1, 10) -eq 'parameters') {
-                        # An API version should not be referenced as a parameter
-                        $ApiVersionOutput = $false
-                    } elseIf ($API.substring(1, 10) -eq 'variables') {
-                        # An API version should not be referenced as a variable
-                        $ApiVersionOutput = $false
-                    } else {
-                        $ApiVersionOutput = $false
-                    }
-                    $ApiVersionArray += $ApiVersionOutput
-                }
-                $ApiVersionArray | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] The template file should contain required elements [schema], [contentVersion], [resources].' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $templateContent.Keys | Should -Contain '$schema'
-                $templateContent.Keys | Should -Contain 'contentVersion'
-                $templateContent.Keys | Should -Contain 'resources'
-            }
-
-            It '[<moduleFolderName>] If delete lock is implemented, the template should have a lock parameter with an empty default value.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                if ($lock = $templateContent.parameters.lock) {
-                    $lock.Keys | Should -Contain 'defaultValue'
-                    $lock.defaultValue | Should -Be ''
-                }
-            }
-
-            It '[<moduleFolderName>] Parameter names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                if (-not $templateContent.parameters) {
-                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                    return
-                }
-
-                $CamelCasingFlag = @()
-                $Parameter = $templateContent.parameters.Keys
-                foreach ($Param in $Parameter) {
-                    if ($Param.substring(0, 1) -cnotmatch '[a-z]' -or $Param -match '-' -or $Param -match '_') {
-                        $CamelCasingFlag += $false
-                    } else {
-                        $CamelCasingFlag += $true
-                    }
-                }
-                $CamelCasingFlag | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] Variable names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                if (-not $templateContent.variables) {
-                    Set-ItResult -Skipped -Because 'the module template has no variables.'
-                    return
-                }
-
-                $CamelCasingFlag = @()
-                $Variable = $templateContent.variables.Keys
-
-                foreach ($Variab in $Variable) {
-                    if ($Variab.substring(0, 1) -cnotmatch '[a-z]' -or $Variab -match '-') {
-                        $CamelCasingFlag += $false
-                    } else {
-                        $CamelCasingFlag += $true
-                    }
-                }
-                $CamelCasingFlag | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] Output names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $CamelCasingFlag = @()
-                $Outputs = $templateContent.outputs.Keys
-
-                foreach ($Output in $Outputs) {
-                    if ($Output.substring(0, 1) -cnotmatch '[a-z]' -or $Output -match '-' -or $Output -match '_') {
-                        $CamelCasingFlag += $false
-                    } else {
-                        $CamelCasingFlag += $true
-                    }
-                }
-                $CamelCasingFlag | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] CUA ID deployment should be present in the template.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $enableDefaultTelemetryFlag = @()
-                $Schemaverion = $templateContent.'$schema'
-                if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
-                    if (($templateContent.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.condition -like "*[parameters('enableDefaultTelemetry')]*") -or ($templateContent.resources.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.resources.condition -like "*[parameters('enableDefaultTelemetry')]*")) {
-                        $enableDefaultTelemetryFlag += $true
-                    } else {
-                        $enableDefaultTelemetryFlag += $false
-                    }
-                }
-                $enableDefaultTelemetryFlag | Should -Not -Contain $false
-            }
-
-            It '[<moduleFolderName>] The Location should be defined as a parameter, with the default value of [resourceGroup().Location] or global for ResourceGroup deployment scope.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-                $LocationFlag = $true
-                $Schemaverion = $templateContent.'$schema'
-                if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
-                    $Locationparamoutputvalue = $templateContent.parameters.location.defaultValue
-                    $Locationparamoutput = $templateContent.parameters.Keys
-                    if ($Locationparamoutput -contains 'Location') {
-                        if ($Locationparamoutputvalue -eq '[resourceGroup().Location]' -or $Locationparamoutputvalue -eq 'global') {
-                            $LocationFlag = $true
-                        } else {
-
-                            $LocationFlag = $false
-                        }
-                        $LocationFlag | Should -Contain $true
-                    }
-                }
-            }
-
-            It '[<moduleFolderName>] Location output should be returned for resources that use it.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent,
-                    [string] $templateFilePath
-                )
-
-                $outputs = $templateContent.outputs
-
-                $primaryResourceType = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/modules/')[1]
-                $primaryResourceTypeResource = $templateContent.resources | Where-Object { $_.type -eq $primaryResourceType }
-
-                if ($primaryResourceTypeResource.keys -contains 'location' -and $primaryResourceTypeResource.location -ne 'global') {
-                    # If the main resource has a location property, an output should be returned too
-                    $outputs.keys | Should -Contain 'location'
-
-                    # It should further reference the location property of the primary resource and not e.g. the location input parameter
-                    $outputs.location.value | Should -Match $primaryResourceType
-                }
-            }
-
-            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent,
-                    [string] $templateFilePath
-                )
-
-                $outputs = $templateContent.outputs.Keys
-                $deploymentScope = Get-ScopeOfTemplateFile -TemplateFilePath $templateFilePath
-
-                if ($deploymentScope -eq 'resourceGroup') {
-                    $outputs | Should -Contain 'resourceGroupName'
-                }
-            }
-
-            It '[<moduleFolderName>] Resource name output should exist.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent,
-                    $templateFilePath
-                )
-
-                # check if module contains a 'primary' resource we could draw a name from
-                $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
-                if ($templateContent.resources.type -notcontains $moduleResourceType) {
-                    Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a name from.'
-                    return
-                }
-
-                # Otherwise test for standard outputs
-                $outputs = $templateContent.outputs.Keys
-                $outputs | Should -Contain 'name'
-            }
-
-            It '[<moduleFolderName>] Resource ID output should exist.' -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent,
-                    $templateFilePath
-                )
-
-                # check if module contains a 'primary' resource we could draw a name from
-                $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
-                if ($templateContent.resources.type -notcontains $moduleResourceType) {
-                    Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a resource ID from.'
-                    return
-                }
-
-                # Otherwise test for standard outputs
-                $outputs = $templateContent.outputs.Keys
-                $outputs | Should -Contain 'resourceId'
-            }
-
-            It "[<moduleFolderName>] Each parameters' description should start with a one word category starting with a capital letter, followed by a dot, a space and the actual description text ending with a dot." -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                if (-not $templateContent.parameters) {
-                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                    return
-                }
-
-                $incorrectParameters = @()
-                $templateParameters = $templateContent.parameters.Keys
-                foreach ($parameter in $templateParameters) {
-                    $data = ($templateContent.parameters.$parameter.metadata).description
-                    if ($data -notmatch '(?s)^[A-Z][a-zA-Z]+\. .+\.$') {
-                        $incorrectParameters += $parameter
-                    }
-                }
-                $incorrectParameters | Should -BeNullOrEmpty
-            }
-
-            It "[<moduleFolderName>] Conditional parameters' description should contain 'Required if' followed by the condition making the parameter required." -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                if (-not $templateContent.parameters) {
-                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                    return
-                }
-
-                $incorrectParameters = @()
-                $templateParameters = $templateContent.parameters.Keys
-                foreach ($parameter in $templateParameters) {
-                    $data = ($templateContent.parameters.$parameter.metadata).description
-                    switch -regex ($data) {
-                        '^Conditional. .*' {
-                            if ($data -notmatch '.*\. Required if .*') {
-                                $incorrectParameters += $parameter
-                            }
-                        }
-                    }
-                }
-                $incorrectParameters | Should -BeNullOrEmpty
-            }
-
-            It "[<moduleFolderName>] outputs' description should start with a capital letter and contain text ending with a dot." -TestCases $deploymentFolderTestCases {
-
-                param(
-                    [string] $moduleFolderName,
-                    [hashtable] $templateContent
-                )
-
-                if (-not $templateContent.outputs) {
-                    Set-ItResult -Skipped -Because 'the module template has no outputs.'
-                    return
-                }
-
-                $incorrectOutputs = @()
-                $templateOutputs = $templateContent.outputs.Keys
-                foreach ($output in $templateOutputs) {
-                    $data = ($templateContent.outputs.$output.metadata).description
-                    if ($data -notmatch '(?s)^[A-Z].+\.$') {
-                        $incorrectOutputs += $output
-                    }
-                }
-                $incorrectOutputs | Should -BeNullOrEmpty
-            }
-
-            # PARAMETER Tests
-            It '[<moduleFolderName>] All parameters in parameters files exist in template file (`deploy.json`).' -TestCases $deploymentFolderTestCases {
-                param (
-                    [hashtable[]] $testFileTestCases
-                )
-
-                foreach ($parameterFileTestCase in $testFileTestCases) {
-                    $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
-                    $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
-
-                    $nonExistentParameters = $testFile_AllParameterNames | Where-Object { $templateFile_AllParameterNames -notcontains $_ }
-                    $nonExistentParameters.Count | Should -Be 0 -Because ('no parameter in the parameter file should not exist in the template file. Found excess items: [{0}].' -f ($nonExistentParameters -join ', '))
-                }
-            }
-
-            It '[<moduleFolderName>] All required parameters in template file (`deploy.json`) should exist in parameters files.' -TestCases $deploymentFolderTestCases {
-                param (
-                    [hashtable[]] $testFileTestCases
-                )
-
-                foreach ($parameterFileTestCase in $testFileTestCases) {
-                    $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
-                    $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
-
-                    $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
-                    $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}].' -f ($missingParameters -join ', '))
-                }
-            }
-
-            It '[<moduleFolderName>] All non-required parameters in template file should not have description that start with "Required.".' -TestCases $deploymentFolderTestCases {
-                param (
-                    [hashtable[]] $testFileTestCases,
-                    [hashtable] $templateContent
-                )
-
-                foreach ($parameterFileTestCase in $testFileTestCases) {
-                    $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
-                    $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
-                    $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $templateFile_RequiredParametersNames }
-
-                    $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
-                    $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}].' -f ($incorrectParameters -join ', '))
-                }
-            }
-        }
-    }
-
-    Describe 'API version tests' -Tag 'ApiCheck' {
-
-        $testCases = @()
-        $apiSpecsFilePath = Join-Path $repoRootPath 'utilities' 'src' 'apiSpecsList.json'
-
-        if (-not (Test-Path $apiSpecsFilePath)) {
-            Write-Verbose "Skipping API tests as no API version are available in path [$apiSpecsFilePath]"
-            return
-        }
-
-        $ApiVersions = Get-Content -Path $apiSpecsFilePath -Raw | ConvertFrom-Json
+        $deploymentFolderTestCases = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
-
-            $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
 
             # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
             $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
@@ -1361,131 +872,621 @@ Describe 'Test file tests' -Tag 'TestTemplate' {
                 $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
             }
 
-            $nestedResources = Get-NestedResourceList -TemplateFileContent $templateContent | Where-Object {
-                $_.type -notin @('Microsoft.Resources/deployments') -and $_
-            } | Select-Object 'Type', 'ApiVersion' -Unique | Sort-Object Type
+            # Parameter file test cases
+            $testFileTestCases = @()
+            $templateFile_Parameters = $templateContent.parameters
+            $TemplateFile_AllParameterNames = $templateFile_Parameters.Keys | Sort-Object
+            $TemplateFile_RequiredParametersNames = ($templateFile_Parameters.Keys | Where-Object { -not $templateFile_Parameters[$_].ContainsKey('defaultValue') }) | Sort-Object
 
-            foreach ($resource in $nestedResources) {
+            if (Test-Path (Join-Path $moduleFolderPath '.test')) {
 
-                switch ($resource.type) {
-                    { $PSItem -like '*diagnosticsettings*' } {
-                        $testCases += @{
-                            moduleName                     = $moduleFolderName
-                            resourceType                   = 'diagnosticsettings'
-                            ProviderNamespace              = 'Microsoft.insights'
-                            TargetApi                      = $resource.ApiVersion
-                            AvailableApiVersions           = $ApiVersions
-                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                # Can be removed after full migration to bicep test files
+                $moduleTestFilePaths = Get-ModuleTestFileList -ModulePath $moduleFolderPath | ForEach-Object { Join-Path $moduleFolderPath $_ }
+
+                foreach ($moduleTestFilePath in $moduleTestFilePaths) {
+                    if ((Split-Path $moduleTestFilePath -Extension) -eq '.json') {
+
+                        $rawContentHashtable = (Get-Content $moduleTestFilePath) | ConvertFrom-Json -AsHashtable
+
+                        # Skipping any file that is not actually a ARM-JSON parameter file
+                        $isParameterFile = $rawContentHashtable.'$schema' -like '*deploymentParameters*'
+                        if (-not $isParameterFile) {
+                            continue
                         }
-                        break
+
+                        $deploymentTestFile_AllParameterNames = $rawContentHashtable.parameters.Keys | Sort-Object
+                    } else {
+                        $deploymentFileContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
+                        $deploymentTestFile_AllParameterNames = $deploymentFileContent.resources[-1].properties.parameters.Keys | Sort-Object # The last resource should be the test
                     }
-                    { $PSItem -like '*locks' } {
-                        $testCases += @{
-                            moduleName                     = $moduleFolderName
-                            resourceType                   = 'locks'
-                            ProviderNamespace              = 'Microsoft.Authorization'
-                            TargetApi                      = $resource.ApiVersion
-                            AvailableApiVersions           = $ApiVersions
-                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                        }
-                        break
+                    $testFileTestCases += @{
+                        testFile_Path                        = $moduleTestFilePath
+                        testFile_Name                        = Split-Path $moduleTestFilePath -Leaf
+                        testFile_AllParameterNames           = $deploymentTestFile_AllParameterNames
+                        templateFile_AllParameterNames       = $TemplateFile_AllParameterNames
+                        templateFile_RequiredParametersNames = $TemplateFile_RequiredParametersNames
+                        tokenConfiguration                   = $tokenConfiguration
                     }
-                    { $PSItem -like '*roleAssignments' } {
-                        $testCases += @{
-                            moduleName                     = $moduleFolderName
-                            resourceType                   = 'roleassignments'
-                            ProviderNamespace              = 'Microsoft.Authorization'
-                            TargetApi                      = $resource.ApiVersion
-                            AvailableApiVersions           = $ApiVersions
-                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                        }
-                        break
+                }
+            }
+
+            # Test file setup
+            $deploymentFolderTestCases += @{
+                moduleFolderName  = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
+                templateContent   = $templateContent
+                templateFilePath  = $templateFilePath
+                testFileTestCases = $testFileTestCases
+            }
+        }
+
+        It '[<moduleFolderName>] The template file should not be empty.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $templateContent | Should -Not -Be $null
+        }
+
+        It '[<moduleFolderName>] Template schema version should be the latest.' -TestCases $deploymentFolderTestCases {
+            # the actual value changes depending on the scope of the template (RG, subscription, MG, tenant) !!
+            # https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-syntax
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            $Schemaverion = $templateContent.'$schema'
+            $SchemaArray = @()
+            if ($Schemaverion -eq $RGdeployment) {
+                $SchemaOutput = $true
+            } elseIf ($Schemaverion -eq $Subscriptiondeployment) {
+                $SchemaOutput = $true
+            } elseIf ($Schemaverion -eq $MGdeployment) {
+                $SchemaOutput = $true
+            } elseIf ($Schemaverion -eq $Tenantdeployment) {
+                $SchemaOutput = $true
+            } else {
+                $SchemaOutput = $false
+            }
+            $SchemaArray += $SchemaOutput
+            $SchemaArray | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] Template schema should use HTTPS reference.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $Schemaverion = $templateContent.'$schema'
+            ($Schemaverion.Substring(0, 5) -eq 'https') | Should -Be $true
+        }
+
+        It '[<moduleFolderName>] All apiVersion properties should be set to a static, hard-coded value.' -TestCases $deploymentFolderTestCases {
+            #https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-best-practices
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $ApiVersion = $templateContent.resources.apiVersion
+            $ApiVersionArray = @()
+            foreach ($API in $ApiVersion) {
+                if ($API.Substring(0, 2) -eq '20') {
+                    $ApiVersionOutput = $true
+                } elseIf ($API.substring(1, 10) -eq 'parameters') {
+                    # An API version should not be referenced as a parameter
+                    $ApiVersionOutput = $false
+                } elseIf ($API.substring(1, 10) -eq 'variables') {
+                    # An API version should not be referenced as a variable
+                    $ApiVersionOutput = $false
+                } else {
+                    $ApiVersionOutput = $false
+                }
+                $ApiVersionArray += $ApiVersionOutput
+            }
+            $ApiVersionArray | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] The template file should contain required elements [schema], [contentVersion], [resources].' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $templateContent.Keys | Should -Contain '$schema'
+            $templateContent.Keys | Should -Contain 'contentVersion'
+            $templateContent.Keys | Should -Contain 'resources'
+        }
+
+        It '[<moduleFolderName>] If delete lock is implemented, the template should have a lock parameter with an empty default value.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            if ($lock = $templateContent.parameters.lock) {
+                $lock.Keys | Should -Contain 'defaultValue'
+                $lock.defaultValue | Should -Be ''
+            }
+        }
+
+        It '[<moduleFolderName>] Parameter names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            if (-not $templateContent.parameters) {
+                Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                return
+            }
+
+            $CamelCasingFlag = @()
+            $Parameter = $templateContent.parameters.Keys
+            foreach ($Param in $Parameter) {
+                if ($Param.substring(0, 1) -cnotmatch '[a-z]' -or $Param -match '-' -or $Param -match '_') {
+                    $CamelCasingFlag += $false
+                } else {
+                    $CamelCasingFlag += $true
+                }
+            }
+            $CamelCasingFlag | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] Variable names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            if (-not $templateContent.variables) {
+                Set-ItResult -Skipped -Because 'the module template has no variables.'
+                return
+            }
+
+            $CamelCasingFlag = @()
+            $Variable = $templateContent.variables.Keys
+
+            foreach ($Variab in $Variable) {
+                if ($Variab.substring(0, 1) -cnotmatch '[a-z]' -or $Variab -match '-') {
+                    $CamelCasingFlag += $false
+                } else {
+                    $CamelCasingFlag += $true
+                }
+            }
+            $CamelCasingFlag | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] Output names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $CamelCasingFlag = @()
+            $Outputs = $templateContent.outputs.Keys
+
+            foreach ($Output in $Outputs) {
+                if ($Output.substring(0, 1) -cnotmatch '[a-z]' -or $Output -match '-' -or $Output -match '_') {
+                    $CamelCasingFlag += $false
+                } else {
+                    $CamelCasingFlag += $true
+                }
+            }
+            $CamelCasingFlag | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] CUA ID deployment should be present in the template.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $enableDefaultTelemetryFlag = @()
+            $Schemaverion = $templateContent.'$schema'
+            if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
+                if (($templateContent.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.condition -like "*[parameters('enableDefaultTelemetry')]*") -or ($templateContent.resources.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.resources.condition -like "*[parameters('enableDefaultTelemetry')]*")) {
+                    $enableDefaultTelemetryFlag += $true
+                } else {
+                    $enableDefaultTelemetryFlag += $false
+                }
+            }
+            $enableDefaultTelemetryFlag | Should -Not -Contain $false
+        }
+
+        It '[<moduleFolderName>] The Location should be defined as a parameter, with the default value of [resourceGroup().Location] or global for ResourceGroup deployment scope.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+            $LocationFlag = $true
+            $Schemaverion = $templateContent.'$schema'
+            if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
+                $Locationparamoutputvalue = $templateContent.parameters.location.defaultValue
+                $Locationparamoutput = $templateContent.parameters.Keys
+                if ($Locationparamoutput -contains 'Location') {
+                    if ($Locationparamoutputvalue -eq '[resourceGroup().Location]' -or $Locationparamoutputvalue -eq 'global') {
+                        $LocationFlag = $true
+                    } else {
+
+                        $LocationFlag = $false
                     }
-                    { $PSItem -like '*privateEndpoints' -and ($PSItem -notlike '*managedPrivateEndpoints') } {
-                        $testCases += @{
-                            moduleName                     = $moduleFolderName
-                            resourceType                   = 'privateEndpoints'
-                            ProviderNamespace              = 'Microsoft.Network'
-                            TargetApi                      = $resource.ApiVersion
-                            AvailableApiVersions           = $ApiVersions
-                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                        }
-                        break
-                    }
-                    Default {
-                        $ProviderNamespace, $rest = $resource.Type.Split('/')
-                        $testCases += @{
-                            moduleName                     = $moduleFolderName
-                            resourceType                   = $rest -join '/'
-                            ProviderNamespace              = $ProviderNamespace
-                            TargetApi                      = $resource.ApiVersion
-                            AvailableApiVersions           = $ApiVersions
-                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                        }
-                        break
-                    }
+                    $LocationFlag | Should -Contain $true
                 }
             }
         }
 
-        It 'In [<moduleName>] used resource type [<ResourceType>] should use one of the recent API version(s). Currently using [<TargetApi>].' -TestCases $TestCases {
+        It '[<moduleFolderName>] Location output should be returned for resources that use it.' -TestCases $deploymentFolderTestCases {
 
             param(
-                [string] $moduleName,
-                [string] $ResourceType,
-                [string] $TargetApi,
-                [string] $ProviderNamespace,
-                [PSCustomObject] $AvailableApiVersions,
-                [bool] $AllowPreviewVersionsInAPITests
+                [string] $moduleFolderName,
+                [hashtable] $templateContent,
+                [string] $templateFilePath
             )
 
-            if (-not (($AvailableApiVersions | Get-Member -Type NoteProperty).Name -contains $ProviderNamespace)) {
-                Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing in your Azure API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
-                Set-ItResult -Skipped -Because "The Azure API version file is missing the Provider Namespace [$ProviderNamespace]."
+            $outputs = $templateContent.outputs
+
+            $primaryResourceType = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/modules/')[1]
+            $primaryResourceTypeResource = $templateContent.resources | Where-Object { $_.type -eq $primaryResourceType }
+
+            if ($primaryResourceTypeResource.keys -contains 'location' -and $primaryResourceTypeResource.location -ne 'global') {
+                # If the main resource has a location property, an output should be returned too
+                $outputs.keys | Should -Contain 'location'
+
+                # It should further reference the location property of the primary resource and not e.g. the location input parameter
+                $outputs.location.value | Should -Match $primaryResourceType
+            }
+        }
+
+        It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent,
+                [string] $templateFilePath
+            )
+
+            $outputs = $templateContent.outputs.Keys
+            $deploymentScope = Get-ScopeOfTemplateFile -TemplateFilePath $templateFilePath
+
+            if ($deploymentScope -eq 'resourceGroup') {
+                $outputs | Should -Contain 'resourceGroupName'
+            }
+        }
+
+        It '[<moduleFolderName>] Resource name output should exist.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent,
+                $templateFilePath
+            )
+
+            # check if module contains a 'primary' resource we could draw a name from
+            $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
+            if ($templateContent.resources.type -notcontains $moduleResourceType) {
+                Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a name from.'
                 return
             }
-            if (-not (($AvailableApiVersions.$ProviderNamespace | Get-Member -Type NoteProperty).Name -contains $ResourceType)) {
-                Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing the Resource Type [$ResourceType] in your API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
-                Set-ItResult -Skipped -Because "The Azure API version file is missing the Resource Type [$ResourceType] for Provider Namespace [$ProviderNamespace]."
+
+            # Otherwise test for standard outputs
+            $outputs = $templateContent.outputs.Keys
+            $outputs | Should -Contain 'name'
+        }
+
+        It '[<moduleFolderName>] Resource ID output should exist.' -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent,
+                $templateFilePath
+            )
+
+            # check if module contains a 'primary' resource we could draw a name from
+            $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
+            if ($templateContent.resources.type -notcontains $moduleResourceType) {
+                Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a resource ID from.'
                 return
             }
 
-            $resourceTypeApiVersions = $AvailableApiVersions.$ProviderNamespace.$ResourceType
+            # Otherwise test for standard outputs
+            $outputs = $templateContent.outputs.Keys
+            $outputs | Should -Contain 'resourceId'
+        }
 
-            if (-not $resourceTypeApiVersions) {
-                Write-Warning ('[API Test] We are currently unable to determine the available API versions for resource type [{0}/{1}].' -f $ProviderNamespace, $resourceType)
-                continue
+        It "[<moduleFolderName>] Each parameters' description should start with a one word category starting with a capital letter, followed by a dot, a space and the actual description text ending with a dot." -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            if (-not $templateContent.parameters) {
+                Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                return
             }
 
-            $approvedApiVersions = @()
-            if ($AllowPreviewVersionsInAPITests) {
-                # We allow the latest 5 including previews (in case somebody wants to use preview), or the latest 3 non-preview
-                $approvedApiVersions += $resourceTypeApiVersions | Select-Object -Last 5
-                $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
+            $incorrectParameters = @()
+            $templateParameters = $templateContent.parameters.Keys
+            foreach ($parameter in $templateParameters) {
+                $data = ($templateContent.parameters.$parameter.metadata).description
+                if ($data -notmatch '(?s)^[A-Z][a-zA-Z]+\. .+\.$') {
+                    $incorrectParameters += $parameter
+                }
+            }
+            $incorrectParameters | Should -BeNullOrEmpty
+        }
+
+        It "[<moduleFolderName>] Conditional parameters' description should contain 'Required if' followed by the condition making the parameter required." -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            if (-not $templateContent.parameters) {
+                Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                return
+            }
+
+            $incorrectParameters = @()
+            $templateParameters = $templateContent.parameters.Keys
+            foreach ($parameter in $templateParameters) {
+                $data = ($templateContent.parameters.$parameter.metadata).description
+                switch -regex ($data) {
+                    '^Conditional. .*' {
+                        if ($data -notmatch '.*\. Required if .*') {
+                            $incorrectParameters += $parameter
+                        }
+                    }
+                }
+            }
+            $incorrectParameters | Should -BeNullOrEmpty
+        }
+
+        It "[<moduleFolderName>] outputs' description should start with a capital letter and contain text ending with a dot." -TestCases $deploymentFolderTestCases {
+
+            param(
+                [string] $moduleFolderName,
+                [hashtable] $templateContent
+            )
+
+            if (-not $templateContent.outputs) {
+                Set-ItResult -Skipped -Because 'the module template has no outputs.'
+                return
+            }
+
+            $incorrectOutputs = @()
+            $templateOutputs = $templateContent.outputs.Keys
+            foreach ($output in $templateOutputs) {
+                $data = ($templateContent.outputs.$output.metadata).description
+                if ($data -notmatch '(?s)^[A-Z].+\.$') {
+                    $incorrectOutputs += $output
+                }
+            }
+            $incorrectOutputs | Should -BeNullOrEmpty
+        }
+
+        # PARAMETER Tests
+        It '[<moduleFolderName>] All parameters in parameters files exist in template file (`deploy.json`).' -TestCases $deploymentFolderTestCases {
+            param (
+                [hashtable[]] $testFileTestCases
+            )
+
+            foreach ($parameterFileTestCase in $testFileTestCases) {
+                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
+                $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+
+                $nonExistentParameters = $testFile_AllParameterNames | Where-Object { $templateFile_AllParameterNames -notcontains $_ }
+                $nonExistentParameters.Count | Should -Be 0 -Because ('no parameter in the parameter file should not exist in the template file. Found excess items: [{0}].' -f ($nonExistentParameters -join ', '))
+            }
+        }
+
+        It '[<moduleFolderName>] All required parameters in template file (`deploy.json`) should exist in parameters files.' -TestCases $deploymentFolderTestCases {
+            param (
+                [hashtable[]] $testFileTestCases
+            )
+
+            foreach ($parameterFileTestCase in $testFileTestCases) {
+                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
+                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
+
+                $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
+                $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}].' -f ($missingParameters -join ', '))
+            }
+        }
+
+        It '[<moduleFolderName>] All non-required parameters in template file should not have description that start with "Required.".' -TestCases $deploymentFolderTestCases {
+            param (
+                [hashtable[]] $testFileTestCases,
+                [hashtable] $templateContent
+            )
+
+            foreach ($parameterFileTestCase in $testFileTestCases) {
+                $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
+                $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+                $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $templateFile_RequiredParametersNames }
+
+                $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
+                $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}].' -f ($incorrectParameters -join ', '))
+            }
+        }
+    }
+}
+
+Describe 'API version tests' -Tag 'ApiCheck' {
+
+    $testCases = @()
+    $apiSpecsFilePath = Join-Path $repoRootPath 'utilities' 'src' 'apiSpecsList.json'
+
+    if (-not (Test-Path $apiSpecsFilePath)) {
+        Write-Verbose "Skipping API tests as no API version are available in path [$apiSpecsFilePath]"
+        return
+    }
+
+    $ApiVersions = Get-Content -Path $apiSpecsFilePath -Raw | ConvertFrom-Json
+    foreach ($moduleFolderPath in $moduleFolderPaths) {
+
+        $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
+
+        # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
+        $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
+        if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
+            if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
+                $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
+                $templateContent = bicep build $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
+
+                if (-not $templateContent) {
+                    throw ($bicepTemplateCompilationFailedException -f $templateFilePath)
+                }
+            } elseIf (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
+                $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
+                $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+
+                if (-not $templateContent) {
+                    throw ($jsonTemplateLoadFailedException -f $templateFilePath)
+                }
             } else {
-                # We allow the latest 3 non-preview preview
-                $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
+                throw ($templateNotFoundException -f $moduleFolderPath)
             }
+            $convertedTemplates[$moduleFolderPathKey] = @{
+                templateFilePath = $templateFilePath
+                templateContent  = $templateContent
+            }
+        } else {
+            $templateContent = $convertedTemplates[$moduleFolderPathKey].templateContent
+            $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
+        }
 
-            $approvedApiVersions = $approvedApiVersions | Sort-Object -Unique -Descending
-            $approvedApiVersions | Should -Contain $TargetApi
+        $nestedResources = Get-NestedResourceList -TemplateFileContent $templateContent | Where-Object {
+            $_.type -notin @('Microsoft.Resources/deployments') -and $_
+        } | Select-Object 'Type', 'ApiVersion' -Unique | Sort-Object Type
 
-            # Provide a warning if an API version is second to next to expire.
-            if ($approvedApiVersions -contains $TargetApi) {
-                $indexOfVersion = $approvedApiVersions.IndexOf($TargetApi)
+        foreach ($resource in $nestedResources) {
 
-                # Example
-                # Available versions:
-                #
-                # 2017-08-01-beta
-                # 2017-08-01        < $TargetApi (Index = 1)
-                # 2017-07-14
-                # 2016-05-16
-
-                if ($indexOfVersion -gt ($approvedApiVersions.Count - 2)) {
-                    $newerAPIVersions = $approvedApiVersions[0..($indexOfVersion - 1)]
-                    Write-Warning ("The used API version [$TargetApi] for Resource Type [$ProviderNamespace/$ResourceType] will soon expire. Please consider updating it. Consider using one of the newer API versions [{0}]" -f ($newerAPIVersions -join ', '))
+            switch ($resource.type) {
+                { $PSItem -like '*diagnosticsettings*' } {
+                    $testCases += @{
+                        moduleName                     = $moduleFolderName
+                        resourceType                   = 'diagnosticsettings'
+                        ProviderNamespace              = 'Microsoft.insights'
+                        TargetApi                      = $resource.ApiVersion
+                        AvailableApiVersions           = $ApiVersions
+                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                    }
+                    break
+                }
+                { $PSItem -like '*locks' } {
+                    $testCases += @{
+                        moduleName                     = $moduleFolderName
+                        resourceType                   = 'locks'
+                        ProviderNamespace              = 'Microsoft.Authorization'
+                        TargetApi                      = $resource.ApiVersion
+                        AvailableApiVersions           = $ApiVersions
+                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                    }
+                    break
+                }
+                { $PSItem -like '*roleAssignments' } {
+                    $testCases += @{
+                        moduleName                     = $moduleFolderName
+                        resourceType                   = 'roleassignments'
+                        ProviderNamespace              = 'Microsoft.Authorization'
+                        TargetApi                      = $resource.ApiVersion
+                        AvailableApiVersions           = $ApiVersions
+                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                    }
+                    break
+                }
+                { $PSItem -like '*privateEndpoints' -and ($PSItem -notlike '*managedPrivateEndpoints') } {
+                    $testCases += @{
+                        moduleName                     = $moduleFolderName
+                        resourceType                   = 'privateEndpoints'
+                        ProviderNamespace              = 'Microsoft.Network'
+                        TargetApi                      = $resource.ApiVersion
+                        AvailableApiVersions           = $ApiVersions
+                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                    }
+                    break
+                }
+                Default {
+                    $ProviderNamespace, $rest = $resource.Type.Split('/')
+                    $testCases += @{
+                        moduleName                     = $moduleFolderName
+                        resourceType                   = $rest -join '/'
+                        ProviderNamespace              = $ProviderNamespace
+                        TargetApi                      = $resource.ApiVersion
+                        AvailableApiVersions           = $ApiVersions
+                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                    }
+                    break
                 }
             }
         }
     }
+
+    It 'In [<moduleName>] used resource type [<ResourceType>] should use one of the recent API version(s). Currently using [<TargetApi>].' -TestCases $TestCases {
+
+        param(
+            [string] $moduleName,
+            [string] $ResourceType,
+            [string] $TargetApi,
+            [string] $ProviderNamespace,
+            [PSCustomObject] $AvailableApiVersions,
+            [bool] $AllowPreviewVersionsInAPITests
+        )
+
+        if (-not (($AvailableApiVersions | Get-Member -Type NoteProperty).Name -contains $ProviderNamespace)) {
+            Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing in your Azure API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
+            Set-ItResult -Skipped -Because "The Azure API version file is missing the Provider Namespace [$ProviderNamespace]."
+            return
+        }
+        if (-not (($AvailableApiVersions.$ProviderNamespace | Get-Member -Type NoteProperty).Name -contains $ResourceType)) {
+            Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing the Resource Type [$ResourceType] in your API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
+            Set-ItResult -Skipped -Because "The Azure API version file is missing the Resource Type [$ResourceType] for Provider Namespace [$ProviderNamespace]."
+            return
+        }
+
+        $resourceTypeApiVersions = $AvailableApiVersions.$ProviderNamespace.$ResourceType
+
+        if (-not $resourceTypeApiVersions) {
+            Write-Warning ('[API Test] We are currently unable to determine the available API versions for resource type [{0}/{1}].' -f $ProviderNamespace, $resourceType)
+            continue
+        }
+
+        $approvedApiVersions = @()
+        if ($AllowPreviewVersionsInAPITests) {
+            # We allow the latest 5 including previews (in case somebody wants to use preview), or the latest 3 non-preview
+            $approvedApiVersions += $resourceTypeApiVersions | Select-Object -Last 5
+            $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
+        } else {
+            # We allow the latest 3 non-preview preview
+            $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
+        }
+
+        $approvedApiVersions = $approvedApiVersions | Sort-Object -Unique -Descending
+        $approvedApiVersions | Should -Contain $TargetApi
+
+        # Provide a warning if an API version is second to next to expire.
+        if ($approvedApiVersions -contains $TargetApi) {
+            $indexOfVersion = $approvedApiVersions.IndexOf($TargetApi)
+
+            # Example
+            # Available versions:
+            #
+            # 2017-08-01-beta
+            # 2017-08-01        < $TargetApi (Index = 1)
+            # 2017-07-14
+            # 2016-05-16
+
+            if ($indexOfVersion -gt ($approvedApiVersions.Count - 2)) {
+                $newerAPIVersions = $approvedApiVersions[0..($indexOfVersion - 1)]
+                Write-Warning ("The used API version [$TargetApi] for Resource Type [$ProviderNamespace/$ResourceType] will soon expire. Please consider updating it. Consider using one of the newer API versions [{0}]" -f ($newerAPIVersions -join ', '))
+            }
+        }
+    }
+}

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -802,14 +802,535 @@ Describe 'Test file tests' -Tag 'TestTemplate' {
             }
         }
     }
-}
+    Context 'Role Assignmnet test' {
 
-Describe 'Deployment template tests' -Tag 'Template' {
+        $roleAssignmentTestCases = @()
 
-    Context 'General template' {
-
-        $deploymentFolderTestCases = [System.Collections.ArrayList] @()
         foreach ($moduleFolderPath in $moduleFolderPaths) {
+            if (Test-Path (Join-Path $moduleFolderPath '.bicep/nested_roleAssignments.bicep')) {
+                $nestedFilePath = Join-Path $moduleFolderPath '.bicep/nested_roleAssignments.bicep'
+                $nestedFileContent = Get-Content $nestedFilePath
+
+                #$resourceTypeIdentifier = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
+                $resourceTypeIdentifier = (Get-Content (Join-Path $moduleFolderPath 'readme.md')).split('`')[1].substring(1).Replace(']', '')
+
+            }
+
+            $roleAssignmentTestCases += @{
+                resourceTypeIdentifier = $resourceTypeIdentifier
+                nestedFileContent      = $nestedFileContent
+                nestedFilePath         = $nestedFilePath
+            }
+        }
+
+        It '[<moduleFolderName>] nested role assignment deployment should contain the module resource Type as existing Resource.' -TestCases ($roleAssignmentTestCases | Where-Object { (Split-Path $_.nestedFilePath -Extension) -eq '.bicep' }) {
+
+            param(
+                [object[]] $nestedFileContent,
+                [string] $resourceTypeIdentifier
+            )
+
+            $hasExpectedResourceType = ($nestedFileContent | Out-String) -match $resourceTypeIdentifier
+            $hasExpectedResourceType | Should -Be $true
+        }
+    }
+
+    Describe 'Deployment template tests' -Tag 'Template' {
+
+        Context 'General template' {
+
+            $deploymentFolderTestCases = [System.Collections.ArrayList] @()
+            foreach ($moduleFolderPath in $moduleFolderPaths) {
+
+                # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
+                $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
+                if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
+                    if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
+                        $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
+                        $templateContent = bicep build $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
+
+                        if (-not $templateContent) {
+                            throw ($bicepTemplateCompilationFailedException -f $templateFilePath)
+                        }
+                    } elseIf (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
+                        $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
+                        $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
+
+                        if (-not $templateContent) {
+                            throw ($jsonTemplateLoadFailedException -f $templateFilePath)
+                        }
+                    } else {
+                        throw ($templateNotFoundException -f $moduleFolderPath)
+                    }
+                    $convertedTemplates[$moduleFolderPathKey] = @{
+                        templateFilePath = $templateFilePath
+                        templateContent  = $templateContent
+                    }
+                } else {
+                    $templateContent = $convertedTemplates[$moduleFolderPathKey].templateContent
+                    $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
+                }
+
+                # Parameter file test cases
+                $testFileTestCases = @()
+                $templateFile_Parameters = $templateContent.parameters
+                $TemplateFile_AllParameterNames = $templateFile_Parameters.Keys | Sort-Object
+                $TemplateFile_RequiredParametersNames = ($templateFile_Parameters.Keys | Where-Object { -not $templateFile_Parameters[$_].ContainsKey('defaultValue') }) | Sort-Object
+
+                if (Test-Path (Join-Path $moduleFolderPath '.test')) {
+
+                    # Can be removed after full migration to bicep test files
+                    $moduleTestFilePaths = Get-ModuleTestFileList -ModulePath $moduleFolderPath | ForEach-Object { Join-Path $moduleFolderPath $_ }
+
+                    foreach ($moduleTestFilePath in $moduleTestFilePaths) {
+                        if ((Split-Path $moduleTestFilePath -Extension) -eq '.json') {
+
+                            $rawContentHashtable = (Get-Content $moduleTestFilePath) | ConvertFrom-Json -AsHashtable
+
+                            # Skipping any file that is not actually a ARM-JSON parameter file
+                            $isParameterFile = $rawContentHashtable.'$schema' -like '*deploymentParameters*'
+                            if (-not $isParameterFile) {
+                                continue
+                            }
+
+                            $deploymentTestFile_AllParameterNames = $rawContentHashtable.parameters.Keys | Sort-Object
+                        } else {
+                            $deploymentFileContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
+                            $deploymentTestFile_AllParameterNames = $deploymentFileContent.resources[-1].properties.parameters.Keys | Sort-Object # The last resource should be the test
+                        }
+                        $testFileTestCases += @{
+                            testFile_Path                        = $moduleTestFilePath
+                            testFile_Name                        = Split-Path $moduleTestFilePath -Leaf
+                            testFile_AllParameterNames           = $deploymentTestFile_AllParameterNames
+                            templateFile_AllParameterNames       = $TemplateFile_AllParameterNames
+                            templateFile_RequiredParametersNames = $TemplateFile_RequiredParametersNames
+                            tokenConfiguration                   = $tokenConfiguration
+                        }
+                    }
+                }
+
+                # Test file setup
+                $deploymentFolderTestCases += @{
+                    moduleFolderName  = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
+                    templateContent   = $templateContent
+                    templateFilePath  = $templateFilePath
+                    testFileTestCases = $testFileTestCases
+                }
+            }
+
+            It '[<moduleFolderName>] The template file should not be empty.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $templateContent | Should -Not -Be $null
+            }
+
+            It '[<moduleFolderName>] Template schema version should be the latest.' -TestCases $deploymentFolderTestCases {
+                # the actual value changes depending on the scope of the template (RG, subscription, MG, tenant) !!
+                # https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-syntax
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                $Schemaverion = $templateContent.'$schema'
+                $SchemaArray = @()
+                if ($Schemaverion -eq $RGdeployment) {
+                    $SchemaOutput = $true
+                } elseIf ($Schemaverion -eq $Subscriptiondeployment) {
+                    $SchemaOutput = $true
+                } elseIf ($Schemaverion -eq $MGdeployment) {
+                    $SchemaOutput = $true
+                } elseIf ($Schemaverion -eq $Tenantdeployment) {
+                    $SchemaOutput = $true
+                } else {
+                    $SchemaOutput = $false
+                }
+                $SchemaArray += $SchemaOutput
+                $SchemaArray | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] Template schema should use HTTPS reference.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $Schemaverion = $templateContent.'$schema'
+            ($Schemaverion.Substring(0, 5) -eq 'https') | Should -Be $true
+            }
+
+            It '[<moduleFolderName>] All apiVersion properties should be set to a static, hard-coded value.' -TestCases $deploymentFolderTestCases {
+                #https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-best-practices
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $ApiVersion = $templateContent.resources.apiVersion
+                $ApiVersionArray = @()
+                foreach ($API in $ApiVersion) {
+                    if ($API.Substring(0, 2) -eq '20') {
+                        $ApiVersionOutput = $true
+                    } elseIf ($API.substring(1, 10) -eq 'parameters') {
+                        # An API version should not be referenced as a parameter
+                        $ApiVersionOutput = $false
+                    } elseIf ($API.substring(1, 10) -eq 'variables') {
+                        # An API version should not be referenced as a variable
+                        $ApiVersionOutput = $false
+                    } else {
+                        $ApiVersionOutput = $false
+                    }
+                    $ApiVersionArray += $ApiVersionOutput
+                }
+                $ApiVersionArray | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] The template file should contain required elements [schema], [contentVersion], [resources].' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $templateContent.Keys | Should -Contain '$schema'
+                $templateContent.Keys | Should -Contain 'contentVersion'
+                $templateContent.Keys | Should -Contain 'resources'
+            }
+
+            It '[<moduleFolderName>] If delete lock is implemented, the template should have a lock parameter with an empty default value.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                if ($lock = $templateContent.parameters.lock) {
+                    $lock.Keys | Should -Contain 'defaultValue'
+                    $lock.defaultValue | Should -Be ''
+                }
+            }
+
+            It '[<moduleFolderName>] Parameter names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                if (-not $templateContent.parameters) {
+                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                    return
+                }
+
+                $CamelCasingFlag = @()
+                $Parameter = $templateContent.parameters.Keys
+                foreach ($Param in $Parameter) {
+                    if ($Param.substring(0, 1) -cnotmatch '[a-z]' -or $Param -match '-' -or $Param -match '_') {
+                        $CamelCasingFlag += $false
+                    } else {
+                        $CamelCasingFlag += $true
+                    }
+                }
+                $CamelCasingFlag | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] Variable names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                if (-not $templateContent.variables) {
+                    Set-ItResult -Skipped -Because 'the module template has no variables.'
+                    return
+                }
+
+                $CamelCasingFlag = @()
+                $Variable = $templateContent.variables.Keys
+
+                foreach ($Variab in $Variable) {
+                    if ($Variab.substring(0, 1) -cnotmatch '[a-z]' -or $Variab -match '-') {
+                        $CamelCasingFlag += $false
+                    } else {
+                        $CamelCasingFlag += $true
+                    }
+                }
+                $CamelCasingFlag | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] Output names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $CamelCasingFlag = @()
+                $Outputs = $templateContent.outputs.Keys
+
+                foreach ($Output in $Outputs) {
+                    if ($Output.substring(0, 1) -cnotmatch '[a-z]' -or $Output -match '-' -or $Output -match '_') {
+                        $CamelCasingFlag += $false
+                    } else {
+                        $CamelCasingFlag += $true
+                    }
+                }
+                $CamelCasingFlag | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] CUA ID deployment should be present in the template.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $enableDefaultTelemetryFlag = @()
+                $Schemaverion = $templateContent.'$schema'
+                if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
+                    if (($templateContent.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.condition -like "*[parameters('enableDefaultTelemetry')]*") -or ($templateContent.resources.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.resources.condition -like "*[parameters('enableDefaultTelemetry')]*")) {
+                        $enableDefaultTelemetryFlag += $true
+                    } else {
+                        $enableDefaultTelemetryFlag += $false
+                    }
+                }
+                $enableDefaultTelemetryFlag | Should -Not -Contain $false
+            }
+
+            It '[<moduleFolderName>] The Location should be defined as a parameter, with the default value of [resourceGroup().Location] or global for ResourceGroup deployment scope.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+                $LocationFlag = $true
+                $Schemaverion = $templateContent.'$schema'
+                if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
+                    $Locationparamoutputvalue = $templateContent.parameters.location.defaultValue
+                    $Locationparamoutput = $templateContent.parameters.Keys
+                    if ($Locationparamoutput -contains 'Location') {
+                        if ($Locationparamoutputvalue -eq '[resourceGroup().Location]' -or $Locationparamoutputvalue -eq 'global') {
+                            $LocationFlag = $true
+                        } else {
+
+                            $LocationFlag = $false
+                        }
+                        $LocationFlag | Should -Contain $true
+                    }
+                }
+            }
+
+            It '[<moduleFolderName>] Location output should be returned for resources that use it.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent,
+                    [string] $templateFilePath
+                )
+
+                $outputs = $templateContent.outputs
+
+                $primaryResourceType = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/modules/')[1]
+                $primaryResourceTypeResource = $templateContent.resources | Where-Object { $_.type -eq $primaryResourceType }
+
+                if ($primaryResourceTypeResource.keys -contains 'location' -and $primaryResourceTypeResource.location -ne 'global') {
+                    # If the main resource has a location property, an output should be returned too
+                    $outputs.keys | Should -Contain 'location'
+
+                    # It should further reference the location property of the primary resource and not e.g. the location input parameter
+                    $outputs.location.value | Should -Match $primaryResourceType
+                }
+            }
+
+            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent,
+                    [string] $templateFilePath
+                )
+
+                $outputs = $templateContent.outputs.Keys
+                $deploymentScope = Get-ScopeOfTemplateFile -TemplateFilePath $templateFilePath
+
+                if ($deploymentScope -eq 'resourceGroup') {
+                    $outputs | Should -Contain 'resourceGroupName'
+                }
+            }
+
+            It '[<moduleFolderName>] Resource name output should exist.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent,
+                    $templateFilePath
+                )
+
+                # check if module contains a 'primary' resource we could draw a name from
+                $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
+                if ($templateContent.resources.type -notcontains $moduleResourceType) {
+                    Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a name from.'
+                    return
+                }
+
+                # Otherwise test for standard outputs
+                $outputs = $templateContent.outputs.Keys
+                $outputs | Should -Contain 'name'
+            }
+
+            It '[<moduleFolderName>] Resource ID output should exist.' -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent,
+                    $templateFilePath
+                )
+
+                # check if module contains a 'primary' resource we could draw a name from
+                $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
+                if ($templateContent.resources.type -notcontains $moduleResourceType) {
+                    Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a resource ID from.'
+                    return
+                }
+
+                # Otherwise test for standard outputs
+                $outputs = $templateContent.outputs.Keys
+                $outputs | Should -Contain 'resourceId'
+            }
+
+            It "[<moduleFolderName>] Each parameters' description should start with a one word category starting with a capital letter, followed by a dot, a space and the actual description text ending with a dot." -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                if (-not $templateContent.parameters) {
+                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                    return
+                }
+
+                $incorrectParameters = @()
+                $templateParameters = $templateContent.parameters.Keys
+                foreach ($parameter in $templateParameters) {
+                    $data = ($templateContent.parameters.$parameter.metadata).description
+                    if ($data -notmatch '(?s)^[A-Z][a-zA-Z]+\. .+\.$') {
+                        $incorrectParameters += $parameter
+                    }
+                }
+                $incorrectParameters | Should -BeNullOrEmpty
+            }
+
+            It "[<moduleFolderName>] Conditional parameters' description should contain 'Required if' followed by the condition making the parameter required." -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                if (-not $templateContent.parameters) {
+                    Set-ItResult -Skipped -Because 'the module template has no parameters.'
+                    return
+                }
+
+                $incorrectParameters = @()
+                $templateParameters = $templateContent.parameters.Keys
+                foreach ($parameter in $templateParameters) {
+                    $data = ($templateContent.parameters.$parameter.metadata).description
+                    switch -regex ($data) {
+                        '^Conditional. .*' {
+                            if ($data -notmatch '.*\. Required if .*') {
+                                $incorrectParameters += $parameter
+                            }
+                        }
+                    }
+                }
+                $incorrectParameters | Should -BeNullOrEmpty
+            }
+
+            It "[<moduleFolderName>] outputs' description should start with a capital letter and contain text ending with a dot." -TestCases $deploymentFolderTestCases {
+
+                param(
+                    [string] $moduleFolderName,
+                    [hashtable] $templateContent
+                )
+
+                if (-not $templateContent.outputs) {
+                    Set-ItResult -Skipped -Because 'the module template has no outputs.'
+                    return
+                }
+
+                $incorrectOutputs = @()
+                $templateOutputs = $templateContent.outputs.Keys
+                foreach ($output in $templateOutputs) {
+                    $data = ($templateContent.outputs.$output.metadata).description
+                    if ($data -notmatch '(?s)^[A-Z].+\.$') {
+                        $incorrectOutputs += $output
+                    }
+                }
+                $incorrectOutputs | Should -BeNullOrEmpty
+            }
+
+            # PARAMETER Tests
+            It '[<moduleFolderName>] All parameters in parameters files exist in template file (`deploy.json`).' -TestCases $deploymentFolderTestCases {
+                param (
+                    [hashtable[]] $testFileTestCases
+                )
+
+                foreach ($parameterFileTestCase in $testFileTestCases) {
+                    $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
+                    $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+
+                    $nonExistentParameters = $testFile_AllParameterNames | Where-Object { $templateFile_AllParameterNames -notcontains $_ }
+                    $nonExistentParameters.Count | Should -Be 0 -Because ('no parameter in the parameter file should not exist in the template file. Found excess items: [{0}].' -f ($nonExistentParameters -join ', '))
+                }
+            }
+
+            It '[<moduleFolderName>] All required parameters in template file (`deploy.json`) should exist in parameters files.' -TestCases $deploymentFolderTestCases {
+                param (
+                    [hashtable[]] $testFileTestCases
+                )
+
+                foreach ($parameterFileTestCase in $testFileTestCases) {
+                    $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
+                    $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
+
+                    $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
+                    $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}].' -f ($missingParameters -join ', '))
+                }
+            }
+
+            It '[<moduleFolderName>] All non-required parameters in template file should not have description that start with "Required.".' -TestCases $deploymentFolderTestCases {
+                param (
+                    [hashtable[]] $testFileTestCases,
+                    [hashtable] $templateContent
+                )
+
+                foreach ($parameterFileTestCase in $testFileTestCases) {
+                    $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
+                    $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
+                    $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $templateFile_RequiredParametersNames }
+
+                    $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
+                    $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}].' -f ($incorrectParameters -join ', '))
+                }
+            }
+        }
+    }
+
+    Describe 'API version tests' -Tag 'ApiCheck' {
+
+        $testCases = @()
+        $apiSpecsFilePath = Join-Path $repoRootPath 'utilities' 'src' 'apiSpecsList.json'
+
+        if (-not (Test-Path $apiSpecsFilePath)) {
+            Write-Verbose "Skipping API tests as no API version are available in path [$apiSpecsFilePath]"
+            return
+        }
+
+        $ApiVersions = Get-Content -Path $apiSpecsFilePath -Raw | ConvertFrom-Json
+        foreach ($moduleFolderPath in $moduleFolderPaths) {
+
+            $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
 
             # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
             $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
@@ -840,621 +1361,131 @@ Describe 'Deployment template tests' -Tag 'Template' {
                 $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
             }
 
-            # Parameter file test cases
-            $testFileTestCases = @()
-            $templateFile_Parameters = $templateContent.parameters
-            $TemplateFile_AllParameterNames = $templateFile_Parameters.Keys | Sort-Object
-            $TemplateFile_RequiredParametersNames = ($templateFile_Parameters.Keys | Where-Object { -not $templateFile_Parameters[$_].ContainsKey('defaultValue') }) | Sort-Object
+            $nestedResources = Get-NestedResourceList -TemplateFileContent $templateContent | Where-Object {
+                $_.type -notin @('Microsoft.Resources/deployments') -and $_
+            } | Select-Object 'Type', 'ApiVersion' -Unique | Sort-Object Type
 
-            if (Test-Path (Join-Path $moduleFolderPath '.test')) {
+            foreach ($resource in $nestedResources) {
 
-                # Can be removed after full migration to bicep test files
-                $moduleTestFilePaths = Get-ModuleTestFileList -ModulePath $moduleFolderPath | ForEach-Object { Join-Path $moduleFolderPath $_ }
-
-                foreach ($moduleTestFilePath in $moduleTestFilePaths) {
-                    if ((Split-Path $moduleTestFilePath -Extension) -eq '.json') {
-
-                        $rawContentHashtable = (Get-Content $moduleTestFilePath) | ConvertFrom-Json -AsHashtable
-
-                        # Skipping any file that is not actually a ARM-JSON parameter file
-                        $isParameterFile = $rawContentHashtable.'$schema' -like '*deploymentParameters*'
-                        if (-not $isParameterFile) {
-                            continue
+                switch ($resource.type) {
+                    { $PSItem -like '*diagnosticsettings*' } {
+                        $testCases += @{
+                            moduleName                     = $moduleFolderName
+                            resourceType                   = 'diagnosticsettings'
+                            ProviderNamespace              = 'Microsoft.insights'
+                            TargetApi                      = $resource.ApiVersion
+                            AvailableApiVersions           = $ApiVersions
+                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
                         }
-
-                        $deploymentTestFile_AllParameterNames = $rawContentHashtable.parameters.Keys | Sort-Object
-                    } else {
-                        $deploymentFileContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
-                        $deploymentTestFile_AllParameterNames = $deploymentFileContent.resources[-1].properties.parameters.Keys | Sort-Object # The last resource should be the test
+                        break
                     }
-                    $testFileTestCases += @{
-                        testFile_Path                        = $moduleTestFilePath
-                        testFile_Name                        = Split-Path $moduleTestFilePath -Leaf
-                        testFile_AllParameterNames           = $deploymentTestFile_AllParameterNames
-                        templateFile_AllParameterNames       = $TemplateFile_AllParameterNames
-                        templateFile_RequiredParametersNames = $TemplateFile_RequiredParametersNames
-                        tokenConfiguration                   = $tokenConfiguration
-                    }
-                }
-            }
-
-            # Test file setup
-            $deploymentFolderTestCases += @{
-                moduleFolderName  = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
-                templateContent   = $templateContent
-                templateFilePath  = $templateFilePath
-                testFileTestCases = $testFileTestCases
-            }
-        }
-
-        It '[<moduleFolderName>] The template file should not be empty.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $templateContent | Should -Not -Be $null
-        }
-
-        It '[<moduleFolderName>] Template schema version should be the latest.' -TestCases $deploymentFolderTestCases {
-            # the actual value changes depending on the scope of the template (RG, subscription, MG, tenant) !!
-            # https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-syntax
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-
-            $Schemaverion = $templateContent.'$schema'
-            $SchemaArray = @()
-            if ($Schemaverion -eq $RGdeployment) {
-                $SchemaOutput = $true
-            } elseIf ($Schemaverion -eq $Subscriptiondeployment) {
-                $SchemaOutput = $true
-            } elseIf ($Schemaverion -eq $MGdeployment) {
-                $SchemaOutput = $true
-            } elseIf ($Schemaverion -eq $Tenantdeployment) {
-                $SchemaOutput = $true
-            } else {
-                $SchemaOutput = $false
-            }
-            $SchemaArray += $SchemaOutput
-            $SchemaArray | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] Template schema should use HTTPS reference.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $Schemaverion = $templateContent.'$schema'
-            ($Schemaverion.Substring(0, 5) -eq 'https') | Should -Be $true
-        }
-
-        It '[<moduleFolderName>] All apiVersion properties should be set to a static, hard-coded value.' -TestCases $deploymentFolderTestCases {
-            #https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-best-practices
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $ApiVersion = $templateContent.resources.apiVersion
-            $ApiVersionArray = @()
-            foreach ($API in $ApiVersion) {
-                if ($API.Substring(0, 2) -eq '20') {
-                    $ApiVersionOutput = $true
-                } elseIf ($API.substring(1, 10) -eq 'parameters') {
-                    # An API version should not be referenced as a parameter
-                    $ApiVersionOutput = $false
-                } elseIf ($API.substring(1, 10) -eq 'variables') {
-                    # An API version should not be referenced as a variable
-                    $ApiVersionOutput = $false
-                } else {
-                    $ApiVersionOutput = $false
-                }
-                $ApiVersionArray += $ApiVersionOutput
-            }
-            $ApiVersionArray | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] The template file should contain required elements [schema], [contentVersion], [resources].' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $templateContent.Keys | Should -Contain '$schema'
-            $templateContent.Keys | Should -Contain 'contentVersion'
-            $templateContent.Keys | Should -Contain 'resources'
-        }
-
-        It '[<moduleFolderName>] If delete lock is implemented, the template should have a lock parameter with an empty default value.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            if ($lock = $templateContent.parameters.lock) {
-                $lock.Keys | Should -Contain 'defaultValue'
-                $lock.defaultValue | Should -Be ''
-            }
-        }
-
-        It '[<moduleFolderName>] Parameter names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-
-            if (-not $templateContent.parameters) {
-                Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                return
-            }
-
-            $CamelCasingFlag = @()
-            $Parameter = $templateContent.parameters.Keys
-            foreach ($Param in $Parameter) {
-                if ($Param.substring(0, 1) -cnotmatch '[a-z]' -or $Param -match '-' -or $Param -match '_') {
-                    $CamelCasingFlag += $false
-                } else {
-                    $CamelCasingFlag += $true
-                }
-            }
-            $CamelCasingFlag | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] Variable names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-
-            if (-not $templateContent.variables) {
-                Set-ItResult -Skipped -Because 'the module template has no variables.'
-                return
-            }
-
-            $CamelCasingFlag = @()
-            $Variable = $templateContent.variables.Keys
-
-            foreach ($Variab in $Variable) {
-                if ($Variab.substring(0, 1) -cnotmatch '[a-z]' -or $Variab -match '-') {
-                    $CamelCasingFlag += $false
-                } else {
-                    $CamelCasingFlag += $true
-                }
-            }
-            $CamelCasingFlag | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] Output names should be camel-cased (no dashes or underscores and must start with lower-case letter).' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $CamelCasingFlag = @()
-            $Outputs = $templateContent.outputs.Keys
-
-            foreach ($Output in $Outputs) {
-                if ($Output.substring(0, 1) -cnotmatch '[a-z]' -or $Output -match '-' -or $Output -match '_') {
-                    $CamelCasingFlag += $false
-                } else {
-                    $CamelCasingFlag += $true
-                }
-            }
-            $CamelCasingFlag | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] CUA ID deployment should be present in the template.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $enableDefaultTelemetryFlag = @()
-            $Schemaverion = $templateContent.'$schema'
-            if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
-                if (($templateContent.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.condition -like "*[parameters('enableDefaultTelemetry')]*") -or ($templateContent.resources.resources.type -ccontains 'Microsoft.Resources/deployments' -and $templateContent.resources.resources.condition -like "*[parameters('enableDefaultTelemetry')]*")) {
-                    $enableDefaultTelemetryFlag += $true
-                } else {
-                    $enableDefaultTelemetryFlag += $false
-                }
-            }
-            $enableDefaultTelemetryFlag | Should -Not -Contain $false
-        }
-
-        It '[<moduleFolderName>] The Location should be defined as a parameter, with the default value of [resourceGroup().Location] or global for ResourceGroup deployment scope.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-            $LocationFlag = $true
-            $Schemaverion = $templateContent.'$schema'
-            if ((($Schemaverion.Split('/')[5]).Split('.')[0]) -eq (($RGdeployment.Split('/')[5]).Split('.')[0])) {
-                $Locationparamoutputvalue = $templateContent.parameters.location.defaultValue
-                $Locationparamoutput = $templateContent.parameters.Keys
-                if ($Locationparamoutput -contains 'Location') {
-                    if ($Locationparamoutputvalue -eq '[resourceGroup().Location]' -or $Locationparamoutputvalue -eq 'global') {
-                        $LocationFlag = $true
-                    } else {
-
-                        $LocationFlag = $false
-                    }
-                    $LocationFlag | Should -Contain $true
-                }
-            }
-        }
-
-        It '[<moduleFolderName>] Location output should be returned for resources that use it.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent,
-                [string] $templateFilePath
-            )
-
-            $outputs = $templateContent.outputs
-
-            $primaryResourceType = (Split-Path $TemplateFilePath -Parent).Replace('\', '/').split('/modules/')[1]
-            $primaryResourceTypeResource = $templateContent.resources | Where-Object { $_.type -eq $primaryResourceType }
-
-            if ($primaryResourceTypeResource.keys -contains 'location' -and $primaryResourceTypeResource.location -ne 'global') {
-                # If the main resource has a location property, an output should be returned too
-                $outputs.keys | Should -Contain 'location'
-
-                # It should further reference the location property of the primary resource and not e.g. the location input parameter
-                $outputs.location.value | Should -Match $primaryResourceType
-            }
-        }
-
-        It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent,
-                [string] $templateFilePath
-            )
-
-            $outputs = $templateContent.outputs.Keys
-            $deploymentScope = Get-ScopeOfTemplateFile -TemplateFilePath $templateFilePath
-
-            if ($deploymentScope -eq 'resourceGroup') {
-                $outputs | Should -Contain 'resourceGroupName'
-            }
-        }
-
-        It '[<moduleFolderName>] Resource name output should exist.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent,
-                $templateFilePath
-            )
-
-            # check if module contains a 'primary' resource we could draw a name from
-            $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
-            if ($templateContent.resources.type -notcontains $moduleResourceType) {
-                Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a name from.'
-                return
-            }
-
-            # Otherwise test for standard outputs
-            $outputs = $templateContent.outputs.Keys
-            $outputs | Should -Contain 'name'
-        }
-
-        It '[<moduleFolderName>] Resource ID output should exist.' -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent,
-                $templateFilePath
-            )
-
-            # check if module contains a 'primary' resource we could draw a name from
-            $moduleResourceType = (Split-Path (($templateFilePath -replace '\\', '/') -split '/modules/')[1] -Parent) -replace '\\', '/'
-            if ($templateContent.resources.type -notcontains $moduleResourceType) {
-                Set-ItResult -Skipped -Because 'the module template has no primary resource to fetch a resource ID from.'
-                return
-            }
-
-            # Otherwise test for standard outputs
-            $outputs = $templateContent.outputs.Keys
-            $outputs | Should -Contain 'resourceId'
-        }
-
-        It "[<moduleFolderName>] Each parameters' description should start with a one word category starting with a capital letter, followed by a dot, a space and the actual description text ending with a dot." -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-
-            if (-not $templateContent.parameters) {
-                Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                return
-            }
-
-            $incorrectParameters = @()
-            $templateParameters = $templateContent.parameters.Keys
-            foreach ($parameter in $templateParameters) {
-                $data = ($templateContent.parameters.$parameter.metadata).description
-                if ($data -notmatch '(?s)^[A-Z][a-zA-Z]+\. .+\.$') {
-                    $incorrectParameters += $parameter
-                }
-            }
-            $incorrectParameters | Should -BeNullOrEmpty
-        }
-
-        It "[<moduleFolderName>] Conditional parameters' description should contain 'Required if' followed by the condition making the parameter required." -TestCases $deploymentFolderTestCases {
-
-            param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
-            )
-
-            if (-not $templateContent.parameters) {
-                Set-ItResult -Skipped -Because 'the module template has no parameters.'
-                return
-            }
-
-            $incorrectParameters = @()
-            $templateParameters = $templateContent.parameters.Keys
-            foreach ($parameter in $templateParameters) {
-                $data = ($templateContent.parameters.$parameter.metadata).description
-                switch -regex ($data) {
-                    '^Conditional. .*' {
-                        if ($data -notmatch '.*\. Required if .*') {
-                            $incorrectParameters += $parameter
+                    { $PSItem -like '*locks' } {
+                        $testCases += @{
+                            moduleName                     = $moduleFolderName
+                            resourceType                   = 'locks'
+                            ProviderNamespace              = 'Microsoft.Authorization'
+                            TargetApi                      = $resource.ApiVersion
+                            AvailableApiVersions           = $ApiVersions
+                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
                         }
+                        break
+                    }
+                    { $PSItem -like '*roleAssignments' } {
+                        $testCases += @{
+                            moduleName                     = $moduleFolderName
+                            resourceType                   = 'roleassignments'
+                            ProviderNamespace              = 'Microsoft.Authorization'
+                            TargetApi                      = $resource.ApiVersion
+                            AvailableApiVersions           = $ApiVersions
+                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                        }
+                        break
+                    }
+                    { $PSItem -like '*privateEndpoints' -and ($PSItem -notlike '*managedPrivateEndpoints') } {
+                        $testCases += @{
+                            moduleName                     = $moduleFolderName
+                            resourceType                   = 'privateEndpoints'
+                            ProviderNamespace              = 'Microsoft.Network'
+                            TargetApi                      = $resource.ApiVersion
+                            AvailableApiVersions           = $ApiVersions
+                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                        }
+                        break
+                    }
+                    Default {
+                        $ProviderNamespace, $rest = $resource.Type.Split('/')
+                        $testCases += @{
+                            moduleName                     = $moduleFolderName
+                            resourceType                   = $rest -join '/'
+                            ProviderNamespace              = $ProviderNamespace
+                            TargetApi                      = $resource.ApiVersion
+                            AvailableApiVersions           = $ApiVersions
+                            AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
+                        }
+                        break
                     }
                 }
             }
-            $incorrectParameters | Should -BeNullOrEmpty
         }
 
-        It "[<moduleFolderName>] outputs' description should start with a capital letter and contain text ending with a dot." -TestCases $deploymentFolderTestCases {
+        It 'In [<moduleName>] used resource type [<ResourceType>] should use one of the recent API version(s). Currently using [<TargetApi>].' -TestCases $TestCases {
 
             param(
-                [string] $moduleFolderName,
-                [hashtable] $templateContent
+                [string] $moduleName,
+                [string] $ResourceType,
+                [string] $TargetApi,
+                [string] $ProviderNamespace,
+                [PSCustomObject] $AvailableApiVersions,
+                [bool] $AllowPreviewVersionsInAPITests
             )
 
-            if (-not $templateContent.outputs) {
-                Set-ItResult -Skipped -Because 'the module template has no outputs.'
+            if (-not (($AvailableApiVersions | Get-Member -Type NoteProperty).Name -contains $ProviderNamespace)) {
+                Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing in your Azure API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
+                Set-ItResult -Skipped -Because "The Azure API version file is missing the Provider Namespace [$ProviderNamespace]."
+                return
+            }
+            if (-not (($AvailableApiVersions.$ProviderNamespace | Get-Member -Type NoteProperty).Name -contains $ResourceType)) {
+                Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing the Resource Type [$ResourceType] in your API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
+                Set-ItResult -Skipped -Because "The Azure API version file is missing the Resource Type [$ResourceType] for Provider Namespace [$ProviderNamespace]."
                 return
             }
 
-            $incorrectOutputs = @()
-            $templateOutputs = $templateContent.outputs.Keys
-            foreach ($output in $templateOutputs) {
-                $data = ($templateContent.outputs.$output.metadata).description
-                if ($data -notmatch '(?s)^[A-Z].+\.$') {
-                    $incorrectOutputs += $output
-                }
+            $resourceTypeApiVersions = $AvailableApiVersions.$ProviderNamespace.$ResourceType
+
+            if (-not $resourceTypeApiVersions) {
+                Write-Warning ('[API Test] We are currently unable to determine the available API versions for resource type [{0}/{1}].' -f $ProviderNamespace, $resourceType)
+                continue
             }
-            $incorrectOutputs | Should -BeNullOrEmpty
-        }
 
-        # PARAMETER Tests
-        It '[<moduleFolderName>] All parameters in parameters files exist in template file (`deploy.json`).' -TestCases $deploymentFolderTestCases {
-            param (
-                [hashtable[]] $testFileTestCases
-            )
-
-            foreach ($parameterFileTestCase in $testFileTestCases) {
-                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
-                $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
-
-                $nonExistentParameters = $testFile_AllParameterNames | Where-Object { $templateFile_AllParameterNames -notcontains $_ }
-                $nonExistentParameters.Count | Should -Be 0 -Because ('no parameter in the parameter file should not exist in the template file. Found excess items: [{0}].' -f ($nonExistentParameters -join ', '))
-            }
-        }
-
-        It '[<moduleFolderName>] All required parameters in template file (`deploy.json`) should exist in parameters files.' -TestCases $deploymentFolderTestCases {
-            param (
-                [hashtable[]] $testFileTestCases
-            )
-
-            foreach ($parameterFileTestCase in $testFileTestCases) {
-                $TemplateFile_RequiredParametersNames = $parameterFileTestCase.TemplateFile_RequiredParametersNames
-                $testFile_AllParameterNames = $parameterFileTestCase.testFile_AllParameterNames
-
-                $missingParameters = $templateFile_RequiredParametersNames | Where-Object { $testFile_AllParameterNames -notcontains $_ }
-                $missingParameters.Count | Should -Be 0 -Because ('no required parameters in the template file should be missing in the parameter file. Found missing items: [{0}].' -f ($missingParameters -join ', '))
-            }
-        }
-
-        It '[<moduleFolderName>] All non-required parameters in template file should not have description that start with "Required.".' -TestCases $deploymentFolderTestCases {
-            param (
-                [hashtable[]] $testFileTestCases,
-                [hashtable] $templateContent
-            )
-
-            foreach ($parameterFileTestCase in $testFileTestCases) {
-                $templateFile_RequiredParametersNames = $parameterFileTestCase.templateFile_RequiredParametersNames
-                $templateFile_AllParameterNames = $parameterFileTestCase.templateFile_AllParameterNames
-                $nonRequiredParameterNames = $templateFile_AllParameterNames | Where-Object { $_ -notin $templateFile_RequiredParametersNames }
-
-                $incorrectParameters = $nonRequiredParameterNames | Where-Object { ($templateContent.parameters[$_].defaultValue) -and ($templateContent.parameters[$_].metadata.description -like 'Required. *') }
-                $incorrectParameters.Count | Should -Be 0 -Because ('all non-required parameters in the template file should not have a description that starts with "Required.". Found incorrect items: [{0}].' -f ($incorrectParameters -join ', '))
-            }
-        }
-    }
-}
-
-Describe 'API version tests' -Tag 'ApiCheck' {
-
-    $testCases = @()
-    $apiSpecsFilePath = Join-Path $repoRootPath 'utilities' 'src' 'apiSpecsList.json'
-
-    if (-not (Test-Path $apiSpecsFilePath)) {
-        Write-Verbose "Skipping API tests as no API version are available in path [$apiSpecsFilePath]"
-        return
-    }
-
-    $ApiVersions = Get-Content -Path $apiSpecsFilePath -Raw | ConvertFrom-Json
-    foreach ($moduleFolderPath in $moduleFolderPaths) {
-
-        $moduleFolderName = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1]
-
-        # For runtime purposes, we cache the compiled template in a hashtable that uses a formatted relative module path as a key
-        $moduleFolderPathKey = $moduleFolderPath.Replace('\', '/').Split('/modules/')[1].Trim('/').Replace('/', '-')
-        if (-not ($convertedTemplates.Keys -contains $moduleFolderPathKey)) {
-            if (Test-Path (Join-Path $moduleFolderPath 'deploy.bicep')) {
-                $templateFilePath = Join-Path $moduleFolderPath 'deploy.bicep'
-                $templateContent = bicep build $templateFilePath --stdout | ConvertFrom-Json -AsHashtable
-
-                if (-not $templateContent) {
-                    throw ($bicepTemplateCompilationFailedException -f $templateFilePath)
-                }
-            } elseIf (Test-Path (Join-Path $moduleFolderPath 'deploy.json')) {
-                $templateFilePath = Join-Path $moduleFolderPath 'deploy.json'
-                $templateContent = Get-Content $templateFilePath -Raw | ConvertFrom-Json -AsHashtable
-
-                if (-not $templateContent) {
-                    throw ($jsonTemplateLoadFailedException -f $templateFilePath)
-                }
+            $approvedApiVersions = @()
+            if ($AllowPreviewVersionsInAPITests) {
+                # We allow the latest 5 including previews (in case somebody wants to use preview), or the latest 3 non-preview
+                $approvedApiVersions += $resourceTypeApiVersions | Select-Object -Last 5
+                $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
             } else {
-                throw ($templateNotFoundException -f $moduleFolderPath)
+                # We allow the latest 3 non-preview preview
+                $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
             }
-            $convertedTemplates[$moduleFolderPathKey] = @{
-                templateFilePath = $templateFilePath
-                templateContent  = $templateContent
-            }
-        } else {
-            $templateContent = $convertedTemplates[$moduleFolderPathKey].templateContent
-            $templateFilePath = $convertedTemplates[$moduleFolderPathKey].templateFilePath
-        }
 
-        $nestedResources = Get-NestedResourceList -TemplateFileContent $templateContent | Where-Object {
-            $_.type -notin @('Microsoft.Resources/deployments') -and $_
-        } | Select-Object 'Type', 'ApiVersion' -Unique | Sort-Object Type
+            $approvedApiVersions = $approvedApiVersions | Sort-Object -Unique -Descending
+            $approvedApiVersions | Should -Contain $TargetApi
 
-        foreach ($resource in $nestedResources) {
+            # Provide a warning if an API version is second to next to expire.
+            if ($approvedApiVersions -contains $TargetApi) {
+                $indexOfVersion = $approvedApiVersions.IndexOf($TargetApi)
 
-            switch ($resource.type) {
-                { $PSItem -like '*diagnosticsettings*' } {
-                    $testCases += @{
-                        moduleName                     = $moduleFolderName
-                        resourceType                   = 'diagnosticsettings'
-                        ProviderNamespace              = 'Microsoft.insights'
-                        TargetApi                      = $resource.ApiVersion
-                        AvailableApiVersions           = $ApiVersions
-                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                    }
-                    break
-                }
-                { $PSItem -like '*locks' } {
-                    $testCases += @{
-                        moduleName                     = $moduleFolderName
-                        resourceType                   = 'locks'
-                        ProviderNamespace              = 'Microsoft.Authorization'
-                        TargetApi                      = $resource.ApiVersion
-                        AvailableApiVersions           = $ApiVersions
-                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                    }
-                    break
-                }
-                { $PSItem -like '*roleAssignments' } {
-                    $testCases += @{
-                        moduleName                     = $moduleFolderName
-                        resourceType                   = 'roleassignments'
-                        ProviderNamespace              = 'Microsoft.Authorization'
-                        TargetApi                      = $resource.ApiVersion
-                        AvailableApiVersions           = $ApiVersions
-                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                    }
-                    break
-                }
-                { $PSItem -like '*privateEndpoints' -and ($PSItem -notlike '*managedPrivateEndpoints') } {
-                    $testCases += @{
-                        moduleName                     = $moduleFolderName
-                        resourceType                   = 'privateEndpoints'
-                        ProviderNamespace              = 'Microsoft.Network'
-                        TargetApi                      = $resource.ApiVersion
-                        AvailableApiVersions           = $ApiVersions
-                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                    }
-                    break
-                }
-                Default {
-                    $ProviderNamespace, $rest = $resource.Type.Split('/')
-                    $testCases += @{
-                        moduleName                     = $moduleFolderName
-                        resourceType                   = $rest -join '/'
-                        ProviderNamespace              = $ProviderNamespace
-                        TargetApi                      = $resource.ApiVersion
-                        AvailableApiVersions           = $ApiVersions
-                        AllowPreviewVersionsInAPITests = $AllowPreviewVersionsInAPITests
-                    }
-                    break
+                # Example
+                # Available versions:
+                #
+                # 2017-08-01-beta
+                # 2017-08-01        < $TargetApi (Index = 1)
+                # 2017-07-14
+                # 2016-05-16
+
+                if ($indexOfVersion -gt ($approvedApiVersions.Count - 2)) {
+                    $newerAPIVersions = $approvedApiVersions[0..($indexOfVersion - 1)]
+                    Write-Warning ("The used API version [$TargetApi] for Resource Type [$ProviderNamespace/$ResourceType] will soon expire. Please consider updating it. Consider using one of the newer API versions [{0}]" -f ($newerAPIVersions -join ', '))
                 }
             }
         }
     }
-
-    It 'In [<moduleName>] used resource type [<ResourceType>] should use one of the recent API version(s). Currently using [<TargetApi>].' -TestCases $TestCases {
-
-        param(
-            [string] $moduleName,
-            [string] $ResourceType,
-            [string] $TargetApi,
-            [string] $ProviderNamespace,
-            [PSCustomObject] $AvailableApiVersions,
-            [bool] $AllowPreviewVersionsInAPITests
-        )
-
-        if (-not (($AvailableApiVersions | Get-Member -Type NoteProperty).Name -contains $ProviderNamespace)) {
-            Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing in your Azure API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
-            Set-ItResult -Skipped -Because "The Azure API version file is missing the Provider Namespace [$ProviderNamespace]."
-            return
-        }
-        if (-not (($AvailableApiVersions.$ProviderNamespace | Get-Member -Type NoteProperty).Name -contains $ResourceType)) {
-            Write-Warning "[API Test] The Provider Namespace [$ProviderNamespace] is missing the Resource Type [$ResourceType] in your API versions file. Please consider updating it and if it is still missing to open an issue in the 'AzureAPICrawler' PowerShell module's GitHub repository."
-            Set-ItResult -Skipped -Because "The Azure API version file is missing the Resource Type [$ResourceType] for Provider Namespace [$ProviderNamespace]."
-            return
-        }
-
-        $resourceTypeApiVersions = $AvailableApiVersions.$ProviderNamespace.$ResourceType
-
-        if (-not $resourceTypeApiVersions) {
-            Write-Warning ('[API Test] We are currently unable to determine the available API versions for resource type [{0}/{1}].' -f $ProviderNamespace, $resourceType)
-            continue
-        }
-
-        $approvedApiVersions = @()
-        if ($AllowPreviewVersionsInAPITests) {
-            # We allow the latest 5 including previews (in case somebody wants to use preview), or the latest 3 non-preview
-            $approvedApiVersions += $resourceTypeApiVersions | Select-Object -Last 5
-            $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
-        } else {
-            # We allow the latest 3 non-preview preview
-            $approvedApiVersions += $resourceTypeApiVersions | Where-Object { $_ -notlike '*-preview' } | Select-Object -Last 3
-        }
-
-        $approvedApiVersions = $approvedApiVersions | Sort-Object -Unique -Descending
-        $approvedApiVersions | Should -Contain $TargetApi
-
-        # Provide a warning if an API version is second to next to expire.
-        if ($approvedApiVersions -contains $TargetApi) {
-            $indexOfVersion = $approvedApiVersions.IndexOf($TargetApi)
-
-            # Example
-            # Available versions:
-            #
-            # 2017-08-01-beta
-            # 2017-08-01        < $TargetApi (Index = 1)
-            # 2017-07-14
-            # 2016-05-16
-
-            if ($indexOfVersion -gt ($approvedApiVersions.Count - 2)) {
-                $newerAPIVersions = $approvedApiVersions[0..($indexOfVersion - 1)]
-                Write-Warning ("The used API version [$TargetApi] for Resource Type [$ProviderNamespace/$ResourceType] will soon expire. Please consider updating it. Consider using one of the newer API versions [{0}]" -f ($newerAPIVersions -join ', '))
-            }
-        }
-    }
-}


### PR DESCRIPTION
# Description

Added a Pester test to check if the resource type in the nested roleAssignment bicep is the same as the module.

ToDo: add role assignments to all common test deployments

Issue Referenc: #3162


## Pipeline references


| Pipeline | Description |
| - | - |
| [![Network - DNS Resolvers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsresolvers.yml/badge.svg?branch=users%2Fjpeasier%2FtestCaseForNested%2FRoleAssignments)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsresolvers.yml) | failed pester test - wrong resource type |
| [![KeyVault - Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Fjpeasier%2FtestCaseForNested%2FRoleAssignments)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml) | succeded pester test - correct resource type |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
