### PR TITLE
[Modules] Correct max length of Application Gateway name

### DIFF
--- a/modules/Network/applicationGateways/main.bicep
+++ b/modules/Network/applicationGateways/main.bicep
@@ -1,5 +1,5 @@
 @description('Required. Name of the Application Gateway.')
-@maxLength(24)
+@maxLength(80)
 param name string
 
 @description('Optional. Location for all resources.')


### PR DESCRIPTION
# Description

Per https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork, it's 80 characters.

# Type of Change

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
