### PR TITLE
[Modules] API Management allowed values update

### DIFF
--- a/modules/api-management/service/apis/README.md
+++ b/modules/api-management/service/apis/README.md
@@ -39,7 +39,7 @@ This module deploys an API Management Service API.
 | `apiDescription` | string | `''` |  | Description of the API. May include HTML formatting tags. |
 | `apiRevision` | string | `''` |  | Describes the Revision of the API. If no value is provided, default revision 1 is created. |
 | `apiRevisionDescription` | string | `''` |  | Description of the API Revision. |
-| `apiType` | string | `'http'` | `[http, soap]` | Type of API to create. * http creates a SOAP to REST API * soap creates a SOAP pass-through API. |
+| `apiType` | string | `'http'` | `[graphql, http, soap, websocket]` | Type of API to create. * http creates a SOAP to REST API * soap creates a SOAP pass-through API. |
 | `apiVersion` | string | `''` |  | Indicates the Version identifier of the API if the API is versioned. |
 | `apiVersionDescription` | string | `''` |  | Description of the API Version. |
 | `apiVersionSetId` | string | `''` |  | Indicates the Version identifier of the API version set. |
@@ -53,7 +53,7 @@ This module deploys an API Management Service API.
 | `sourceApiId` | string | `''` |  | API identifier of the source API. |
 | `subscriptionKeyParameterNames` | object | `{object}` |  | Protocols over which API is made available. |
 | `subscriptionRequired` | bool | `False` |  | Specifies whether an API or Product subscription is required for accessing the API. |
-| `type` | string | `'http'` | `[http, soap]` | Type of API. |
+| `type` | string | `'http'` | `[graphql, http, soap, websocket]` | Type of API. |
 | `value` | string | `''` |  | Content value when Importing an API. |
 | `wsdlSelector` | object | `{object}` |  | Criteria to limit import of WSDL to a subset of the document. |
 

--- a/modules/api-management/service/apis/main.bicep
+++ b/modules/api-management/service/apis/main.bicep
@@ -15,8 +15,10 @@ param apiRevisionDescription string = ''
 
 @description('Optional. Type of API to create. * http creates a SOAP to REST API * soap creates a SOAP pass-through API.')
 @allowed([
+  'graphql'
   'http'
   'soap'
+  'websocket'
 ])
 param apiType string = 'http'
 
@@ -83,8 +85,10 @@ param subscriptionRequired bool = false
 
 @description('Optional. Type of API.')
 @allowed([
+  'graphql'
   'http'
   'soap'
+  'websocket'
 ])
 param type string = 'http'
 

--- a/modules/api-management/service/apis/main.bicep
+++ b/modules/api-management/service/apis/main.bicep
@@ -13,7 +13,7 @@ param apiRevision string = ''
 @description('Optional. Description of the API Revision.')
 param apiRevisionDescription string = ''
 
-@description('Optional. Type of API to create. * http creates a SOAP to REST API * soap creates a SOAP pass-through API.')
+@description('Optional. Type of API to create. * http creates a REST API * soap creates a SOAP pass-through API * websocket creates websocket API * graphql creates GraphQL API.')
 @allowed([
   'graphql'
   'http'


### PR DESCRIPTION
# Description

- Update apim api type allowed values to include graphql and websocket.
 
## Pipeline references

[![ApiManagement - Service](https://github.com/clarked-msft/ResourceModules/actions/workflows/ms.apimanagement.service.yml/badge.svg)](https://github.com/clarked-msft/ResourceModules/actions/workflows/ms.apimanagement.service.yml)

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
