### PR TITLE
[CI Environment] Do not delete tags that already exist on subscription level

### DIFF
--- a/modules/resources/tags/README.md
+++ b/modules/resources/tags/README.md
@@ -24,7 +24,7 @@ This module deploys Resources Tags on a subscription or resource group scope.
 | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `location` | string | `[deployment().location]` | Location deployment metadata. |
-| `onlyUpdate` | bool | `False` | Instead of overwriting the existing tags, combine them with the new tags. |
+| `onlyUpdate` | bool | `True` | Instead of overwriting the existing tags, combine them with the new tags. |
 | `resourceGroupName` | string | `''` | Name of the Resource Group to assign the tags to. If no Resource Group name is provided, and Subscription ID is provided, the module deploys at subscription level, therefore assigns the provided tags to the subscription. |
 | `subscriptionId` | string | `[subscription().id]` | Subscription ID of the subscription to assign the tags to. If no Resource Group name is provided, the module deploys at subscription level, therefore assigns the provided tags to the subscription. |
 | `tags` | object | `{object}` | Tags for the resource group. If not provided, removes existing tags. |

--- a/modules/resources/tags/main.bicep
+++ b/modules/resources/tags/main.bicep
@@ -4,7 +4,7 @@ targetScope = 'subscription'
 param tags object = {}
 
 @description('Optional. Instead of overwriting the existing tags, combine them with the new tags.')
-param onlyUpdate bool = false
+param onlyUpdate bool = true
 
 @description('Optional. Name of the Resource Group to assign the tags to. If no Resource Group name is provided, and Subscription ID is provided, the module deploys at subscription level, therefore assigns the provided tags to the subscription.')
 param resourceGroupName string = ''

--- a/utilities/pipelines/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
@@ -150,7 +150,31 @@ function Invoke-ResourceRemoval {
             }
             break
         }
+        'Microsoft.Resources/tags' {
+            # Get current tags on the subscription
+            $subscriptionId = $resourceId.Split('/')[2]
+            $currentTags = $(Get-AzTag -ResourceId /subscriptions/$subscriptionId).Properties
 
+            # Get the tags to remove
+            $tagsToRemove = @('Test', 'TestToo')
+            $tagsToKeep = @{}
+
+            #Loop over each key and add it to the new tags if it is not in the list of tags to remove
+            $currentTags.TagsProperty.Keys | ForEach-Object {
+                $key = $_
+                if ($tagsToRemove -notcontains $key) {
+                    $value = $currentTags.TagsProperty.$key
+                    $tagsToKeep.Add($key, $value)
+                }
+            }
+
+            $null = Remove-AzTag -ResourceId /subscriptions/$subscriptionId
+
+            if ($tagsToKeep.count -ne 0) {
+                $null = Update-AzTag -ResourceId /subscriptions/$subscriptionId -Tag $tagsToKeep -Operation Replace
+            }
+            break
+        }
         ### CODE LOCATION: Add custom removal action here
         Default {
             $null = Remove-AzResource -ResourceId $resourceId -Force -ErrorAction 'Stop'


### PR DESCRIPTION
# Description

Currently, whenever the `Microsoft.Resources/tags` module is tested by the CI environment, it will delete the entire tags object, which in most cases, is not desirable. 
This change gets all the previous tags from Azure and after deletion adds them back without the test tags.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
