### PR TITLE
Add Relay Namespace Support

### DIFF
--- a/.azuredevops/modulePipelines/ms.relay.namespaces.yml
+++ b/.azuredevops/modulePipelines/ms.relay.namespaces.yml
@@ -1,0 +1,51 @@
+name: 'Relay - Namespaces'
+
+parameters:
+  - name: staticValidation
+    displayName: Execute static validation
+    type: boolean
+    default: true
+  - name: deploymentValidation
+    displayName: Execute deployment validation
+    type: boolean
+    default: true
+  - name: removeDeployment
+    displayName: Remove deployed module
+    type: boolean
+    default: true
+  - name: prerelease
+    displayName: Publish prerelease module
+    type: boolean
+    default: false
+
+pr: none
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - '/modules/relay/namespaces/*'
+      - '/modules/network/private-endpoints/*'
+      - '/.azuredevops/modulePipelines/ms.relay.namespaces.yml'
+      - '/.azuredevops/pipelineTemplates/*.yml'
+      - '/utilities/pipelines/*'
+    exclude:
+      - '/utilities/pipelines/deploymentRemoval/*'
+      - '/**/*.md'
+
+variables:
+  - template: '../../settings.yml'
+  - group: 'PLATFORM_VARIABLES'
+  - name: modulePath
+    value: '/modules/relay/namespaces'
+
+stages:
+  - template: /.azuredevops/pipelineTemplates/stages.module.yml
+    parameters:
+      staticValidation: '${{ parameters.staticValidation }}'
+      deploymentValidation: '${{ parameters.deploymentValidation }}'
+      removeDeployment: '${{ parameters.removeDeployment }}'
+      prerelease: '${{ parameters.prerelease }}'

--- a/.github/workflows/ms.relay.namespaces.yml
+++ b/.github/workflows/ms.relay.namespaces.yml
@@ -1,0 +1,85 @@
+name: 'Relay - Namespaces'
+
+on:
+  workflow_dispatch:
+    inputs:
+      staticValidation:
+        type: boolean
+        description: 'Execute static validation'
+        required: false
+        default: true
+      deploymentValidation:
+        type: boolean
+        description: 'Execute deployment validation'
+        required: false
+        default: true
+      removeDeployment:
+        type: boolean
+        description: 'Remove deployed module'
+        required: false
+        default: true
+      prerelease:
+        type: boolean
+        description: 'Publish prerelease module'
+        required: false
+        default: false
+  push:
+    branches:
+      - main
+    paths:
+      - 'modules/relay/namespaces/**'
+      - 'modules/network/private-endpoints/**'
+      - '.github/actions/templates/**'
+      - '.github/workflows/template.module.yml'
+      - '.github/workflows/ms.relay.namespaces.yml'
+      - 'utilities/pipelines/**'
+      - '!utilities/pipelines/deploymentRemoval/**'
+      - '!*/**/README.md'
+
+env:
+  modulePath: 'modules/relay/namespaces'
+  workflowPath: '.github/workflows/ms.relay.namespaces.yml'
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  ###########################
+  #   Initialize pipeline   #
+  ###########################
+  job_initialize_pipeline:
+    runs-on: ubuntu-20.04
+    name: 'Initialize pipeline'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Set input parameters to output variables'
+        id: get-workflow-param
+        uses: ./.github/actions/templates/getWorkflowInput
+        with:
+          workflowPath: '${{ env.workflowPath}}'
+      - name: 'Get parameter file paths'
+        id: get-module-test-file-paths
+        uses: ./.github/actions/templates/getModuleTestFiles
+        with:
+          modulePath: '${{ env.modulePath }}'
+    outputs:
+      workflowInput: ${{ steps.get-workflow-param.outputs.workflowInput }}
+      moduleTestFilePaths: ${{ steps.get-module-test-file-paths.outputs.moduleTestFilePaths }}
+      modulePath: '${{ env.modulePath }}'
+
+  ##############################
+  #   Call reusable workflow   #
+  ##############################
+  call-workflow-passing-data:
+    name: 'Module'
+    needs:
+      - job_initialize_pipeline
+    uses: ./.github/workflows/template.module.yml
+    with:
+      workflowInput: '${{ needs.job_initialize_pipeline.outputs.workflowInput }}'
+      moduleTestFilePaths: '${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}'
+      modulePath: '${{ needs.job_initialize_pipeline.outputs.modulePath}}'
+    secrets: inherit

--- a/modules/relay/namespaces/.bicep/nested_roleAssignments.bicep
+++ b/modules/relay/namespaces/.bicep/nested_roleAssignments.bicep
@@ -21,18 +21,29 @@ param principalType string = ''
 @sys.description('Optional. The description of the role assignment.')
 param description string = ''
 
+@sys.description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
+param condition string = ''
+
+@sys.description('Optional. Version of the condition.')
+@allowed([
+  '2.0'
+])
+param conditionVersion string = '2.0'
+
+@sys.description('Optional. Id of the delegated managed identity resource.')
+param delegatedManagedIdentityResourceId string = ''
+
 var builtInRoleNames = {
   'App Compliance Automation Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')
+  'Azure Relay Listener': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26e0b698-aa6d-4085-9386-aadae190014d')
+  'Azure Relay Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2787bf04-f1f5-4bfe-8383-c8a24483ee38')
+  'Azure Relay Sender': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26baccc8-eea7-41f1-98f4-1762cc7f685d')
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
   'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')
-  'Logic App Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '87a39d53-fc1b-424a-814c-f7e04687dc9e')
-  'Logic App Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '515c2055-d9d4-4321-b1b9-bd0c9a0f79fe')
   'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')
   'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')
   'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')
-  'Microsoft Sentinel Automation Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f4c81013-99ee-4d62-a7ee-b3f1f648599a')
-  'Microsoft Sentinel Playbook Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '51d6186e-6489-4900-b93f-92e23144cca5')
   'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')
   'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
   Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
@@ -40,26 +51,22 @@ var builtInRoleNames = {
   'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')
   'Role Based Access Control Administrator (Preview)': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')
   'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
-  'Web Plan Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')
-  'Website Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
 }
 
-var appName = split(resourceId, '/')[indexOf(split(resourceId, '/'), 'sites') + 1]
-
-resource app 'Microsoft.Web/sites@2020-12-01' existing = {
-  name: appName
-  resource slot 'slots' existing = {
-    name: last(split(resourceId, '/'))!
-  }
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: last(split(resourceId, '/'))!
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = [for principalId in principalIds: {
-  name: guid(app::slot.id, principalId, roleDefinitionIdOrName)
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  name: guid(namespace.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
     principalType: !empty(principalType) ? any(principalType) : null
+    condition: !empty(condition) ? condition : null
+    conditionVersion: !empty(conditionVersion) && !empty(condition) ? conditionVersion : null
+    delegatedManagedIdentityResourceId: !empty(delegatedManagedIdentityResourceId) ? delegatedManagedIdentityResourceId : null
   }
-  scope: app::slot
+  scope: namespace
 }]

--- a/modules/relay/namespaces/.test/common/dependencies.bicep
+++ b/modules/relay/namespaces/.test/common/dependencies.bicep
@@ -7,15 +7,6 @@ param virtualNetworkName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-@description('Required. The name of the Server Farm to create.')
-param serverFarmName string
-
-@description('Required. The name of the Relay Namespace to create.')
-param namespaceName string
-
-@description('Required. The name of the Hybrid Connection to create.')
-param hybridConnectionName string
-
 var addressPrefix = '10.0.0.0/16'
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
@@ -39,7 +30,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
 }
 
 resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-    name: 'privatelink.azurewebsites.net'
+    name: 'privatelink.servicebus.windows.net'
     location: 'global'
 
     resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {
@@ -59,47 +50,6 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
     location: location
 }
 
-resource serverFarm 'Microsoft.Web/serverfarms@2022-03-01' = {
-    name: serverFarmName
-    location: location
-    sku: {
-        name: 'S1'
-        tier: 'Standard'
-        size: 'S1'
-        family: 'S'
-        capacity: 1
-    }
-    properties: {}
-}
-
-resource namespace 'Microsoft.Relay/namespaces@2021-11-01' = {
-    name: namespaceName
-    location: location
-    sku: {
-        name: 'Standard'
-    }
-    properties: {}
-}
-
-resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' = {
-    name: hybridConnectionName
-    parent: namespace
-    properties: {
-        requiresClientAuthorization: true
-        userMetadata: '[{"key":"endpoint","value":"db-server.constoso.com:1433"}]'
-    }
-}
-
-resource authorizationRule 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@2021-11-01' = {
-    name: 'defaultSender'
-    parent: hybridConnection
-    properties: {
-        rights: [
-            'Send'
-        ]
-    }
-}
-
 @description('The resource ID of the created Virtual Network Subnet.')
 output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 
@@ -109,11 +59,5 @@ output managedIdentityPrincipalId string = managedIdentity.properties.principalI
 @description('The resource ID of the created Managed Identity.')
 output managedIdentityResourceId string = managedIdentity.id
 
-@description('The resource ID of the created Server Farm.')
-output serverFarmResourceId string = serverFarm.id
-
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSZoneResourceId string = privateDNSZone.id
-
-@description('The resource ID of the created Hybrid Connection.')
-output hybridConnectionResourceId string = hybridConnection.id

--- a/modules/relay/namespaces/.test/common/main.test.bicep
+++ b/modules/relay/namespaces/.test/common/main.test.bicep
@@ -1,0 +1,169 @@
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param location string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'relcom'
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module nestedDependencies 'dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-nestedDependencies'
+  params: {
+    virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
+    managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
+  }
+}
+
+// Diagnostics
+// ===========
+module diagnosticDependencies '../../../../.shared/.templates/diagnostic.dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-diagnosticDependencies'
+  params: {
+    storageAccountName: 'dep<<namePrefix>>diasa${serviceShort}01'
+    logAnalyticsWorkspaceName: 'dep-<<namePrefix>>-law-${serviceShort}'
+    eventHubNamespaceEventHubName: 'dep-<<namePrefix>>-evh-${serviceShort}'
+    eventHubNamespaceName: 'dep-<<namePrefix>>-evhns-${serviceShort}'
+    location: location
+  }
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../main.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  params: {
+    enableDefaultTelemetry: enableDefaultTelemetry
+    name: '<<namePrefix>>${serviceShort}001'
+    lock: 'CanNotDelete'
+    skuName: 'Standard'
+    tags: {
+      Environment: 'Non-Prod'
+      Role: 'DeploymentValidation'
+    }
+    roleAssignments: [
+      {
+        roleDefinitionIdOrName: 'Reader'
+        principalIds: [
+          nestedDependencies.outputs.managedIdentityPrincipalId
+        ]
+        principalType: 'ServicePrincipal'
+      }
+    ]
+    networkRuleSets: {
+      defaultAction: 'Deny'
+      trustedServiceAccessEnabled: true
+      virtualNetworkRules: [
+        {
+          subnet: {
+            ignoreMissingVnetServiceEndpoint: true
+            id: nestedDependencies.outputs.subnetResourceId
+          }
+        }
+      ]
+      ipRules: [
+        {
+          ipMask: '10.0.1.0/32'
+          action: 'Allow'
+        }
+        {
+          ipMask: '10.0.2.0/32'
+          action: 'Allow'
+        }
+      ]
+    }
+    authorizationRules: [
+      {
+        name: 'RootManageSharedAccessKey'
+        rights: [
+          'Listen'
+          'Manage'
+          'Send'
+        ]
+      }
+      {
+        name: 'AnotherKey'
+        rights: [
+          'Listen'
+          'Send'
+        ]
+      }
+    ]
+    hybridConnections: [
+      {
+        name: '<<namePrefix>>${serviceShort}hc001'
+        roleAssignments: [
+          {
+            roleDefinitionIdOrName: 'Reader'
+            principalIds: [
+              nestedDependencies.outputs.managedIdentityPrincipalId
+            ]
+            principalType: 'ServicePrincipal'
+          }
+        ]
+        userMetadata: '[{"key":"endpoint","value":"db-server.constoso.com:1433"}]'
+      }
+    ]
+    wcfRelays: [
+      {
+        name: '<<namePrefix>>${serviceShort}wcf001'
+        roleAssignments: [
+          {
+            roleDefinitionIdOrName: 'Reader'
+            principalIds: [
+              nestedDependencies.outputs.managedIdentityPrincipalId
+            ]
+            principalType: 'ServicePrincipal'
+          }
+        ]
+        relayType: 'NetTcp'
+      }
+    ]
+    diagnosticLogsRetentionInDays: 7
+    diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId
+    diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
+    diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
+    diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+    privateEndpoints: [
+      {
+        service: 'namespace'
+        subnetResourceId: nestedDependencies.outputs.subnetResourceId
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            nestedDependencies.outputs.privateDNSZoneResourceId
+          ]
+        }
+        tags: {
+          Environment: 'Non-Prod'
+          Role: 'DeploymentValidation'
+        }
+      }
+    ]
+  }
+}

--- a/modules/relay/namespaces/.test/min/main.test.bicep
+++ b/modules/relay/namespaces/.test/min/main.test.bicep
@@ -1,0 +1,42 @@
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param location string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'sbnmin'
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../main.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  params: {
+    enableDefaultTelemetry: enableDefaultTelemetry
+    name: '<<namePrefix>>${serviceShort}001'
+  }
+}

--- a/modules/relay/namespaces/.test/pe/dependencies.bicep
+++ b/modules/relay/namespaces/.test/pe/dependencies.bicep
@@ -1,0 +1,49 @@
+@description('Optional. The location to deploy resources to.')
+param location string = resourceGroup().location
+
+@description('Required. The name of the Virtual Network to create.')
+param virtualNetworkName string
+
+var addressPrefix = '10.0.0.0/16'
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
+    name: virtualNetworkName
+    location: location
+    properties: {
+        addressSpace: {
+            addressPrefixes: [
+                addressPrefix
+            ]
+        }
+        subnets: [
+            {
+                name: 'defaultSubnet'
+                properties: {
+                    addressPrefix: addressPrefix
+                }
+            }
+        ]
+    }
+}
+
+resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+    name: 'privatelink.servicebus.windows.net'
+    location: 'global'
+
+    resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {
+        name: '${virtualNetwork.name}-vnetlink'
+        location: 'global'
+        properties: {
+            virtualNetwork: {
+                id: virtualNetwork.id
+            }
+            registrationEnabled: false
+        }
+    }
+}
+
+@description('The resource ID of the created Virtual Network Subnet.')
+output subnetResourceId string = virtualNetwork.properties.subnets[0].id
+
+@description('The resource ID of the created Private DNS Zone.')
+output privateDNSZoneResourceId string = privateDNSZone.id

--- a/modules/relay/namespaces/.test/pe/main.test.bicep
+++ b/modules/relay/namespaces/.test/pe/main.test.bicep
@@ -1,0 +1,70 @@
+targetScope = 'subscription'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param location string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'sbnpe'
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module nestedDependencies 'dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-nestedDependencies'
+  params: {
+    virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
+  }
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../main.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
+  params: {
+    enableDefaultTelemetry: enableDefaultTelemetry
+    name: '<<namePrefix>>${serviceShort}001'
+    skuName: 'Standard'
+    privateEndpoints: [
+      {
+        service: 'namespace'
+        subnetResourceId: nestedDependencies.outputs.subnetResourceId
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            nestedDependencies.outputs.privateDNSZoneResourceId
+          ]
+        }
+        tags: {
+          Environment: 'Non-Prod'
+          Role: 'DeploymentValidation'
+        }
+      }
+    ]
+    tags: {
+      Environment: 'Non-Prod'
+      Role: 'DeploymentValidation'
+    }
+  }
+}

--- a/modules/relay/namespaces/README.md
+++ b/modules/relay/namespaces/README.md
@@ -1,0 +1,771 @@
+# Relay Namespaces `[Microsoft.Relay/namespaces]`
+
+This module deploys a relay namespace resource.
+
+## Navigation
+
+- [Resource types](#Resource-types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+- [Deployment examples](#Deployment-examples)
+
+## Resource types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
+| `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
+| `Microsoft.Network/privateEndpoints` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints) |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints/privateDnsZoneGroups) |
+| `Microsoft.Relay/namespaces` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces) |
+| `Microsoft.Relay/namespaces/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/authorizationRules) |
+| `Microsoft.Relay/namespaces/hybridConnections` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/hybridConnections) |
+| `Microsoft.Relay/namespaces/hybridConnections/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/hybridConnections/authorizationRules) |
+| `Microsoft.Relay/namespaces/networkRuleSets` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/networkRuleSets) |
+| `Microsoft.Relay/namespaces/wcfRelays` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/wcfRelays) |
+| `Microsoft.Relay/namespaces/wcfRelays/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/wcfRelays/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | Name of the Relay Namespace. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `authorizationRules` | _[authorizationRules](authorization-rules/README.md)_ array | `[System.Management.Automation.OrderedHashtable]` |  | Authorization Rules for the Relay namespace. |
+| `diagnosticEventHubAuthorizationRuleId` | string | `''` |  | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
+| `diagnosticEventHubName` | string | `''` |  | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. |
+| `diagnosticLogCategoriesToEnable` | array | `[allLogs]` | `[allLogs, OperationalLogs]` | The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. |
+| `diagnosticLogsRetentionInDays` | int | `365` |  | Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
+| `diagnosticMetricsToEnable` | array | `[AllMetrics]` | `[AllMetrics]` | The name of metrics that will be streamed. |
+| `diagnosticSettingsName` | string | `''` |  | The name of the diagnostic setting, if deployed. If left empty, it defaults to "<resourceName>-diagnosticSettings". |
+| `diagnosticStorageAccountId` | string | `''` |  | Resource ID of the diagnostic storage account. |
+| `diagnosticWorkspaceId` | string | `''` |  | Resource ID of the diagnostic log analytics workspace. |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `hybridConnections` | _[hybridConnections](hybrid-connections/README.md)_ array | `[]` |  | The hybrid connections to create in the relay namespace. |
+| `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
+| `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `networkRuleSets` | _[networkRuleSets](network-rule-sets/README.md)_ object | `{object}` |  | Configure networking options for Relay. This object contains IPs/Subnets to allow or restrict access to private endpoints only. For security reasons, it is recommended to configure this object on the Namespace. |
+| `privateEndpoints` | array | `[]` |  | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
+| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+| `skuName` | string | `'Standard'` | `[Standard]` | Name of this SKU. |
+| `tags` | object | `{object}` |  | Tags of the resource. |
+| `wcfRelays` | _[wcfRelays](wcf-relays/README.md)_ array | `[]` |  | The wcf relays to create in the relay namespace. |
+
+
+### Parameter Usage: `roleAssignments`
+
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to `'ServicePrincipal'`. This will ensure the role assignment waits for the principal's propagation in Azure.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"roleAssignments": {
+    "value": [
+        {
+            "roleDefinitionIdOrName": "Reader",
+            "description": "Reader Role Assignment",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012", // object 1
+                "78945612-1234-1234-1234-123456789012" // object 2
+            ]
+        },
+        {
+            "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012" // object 1
+            ],
+            "principalType": "ServicePrincipal"
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+roleAssignments: [
+    {
+        roleDefinitionIdOrName: 'Reader'
+        description: 'Reader Role Assignment'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+            '78945612-1234-1234-1234-123456789012' // object 2
+        ]
+    }
+    {
+        roleDefinitionIdOrName: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+        ]
+        principalType: 'ServicePrincipal'
+    }
+]
+```
+
+</details>
+<p>
+
+### Parameter Usage: `privateEndpoints`
+
+To use Private Endpoint the following dependencies must be deployed:
+
+- Destination subnet must be created with the following configuration option - `"privateEndpointNetworkPolicies": "Disabled"`. Setting this option acknowledges that NSG rules are not applied to Private Endpoints (this capability is coming soon). A full example is available in the Virtual Network Module.
+- Although not strictly required, it is highly recommended to first create a private DNS Zone to host Private Endpoint DNS records. See [Azure Private Endpoint DNS configuration](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns) for more information.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"privateEndpoints": {
+    "value": [
+        // Example showing all available fields
+        {
+            "name": "sxx-az-pe", // Optional: Name will be automatically generated if one is not provided here
+            "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001",
+            "service": "<serviceName>", // e.g. vault, registry, blob
+            "privateDnsZoneGroup": {
+                "privateDNSResourceIds": [ // Optional: No DNS record will be created if a private DNS zone Resource ID is not specified
+                    "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/<privateDnsZoneName>" // e.g. privatelink.vaultcore.azure.net, privatelink.azurecr.io, privatelink.blob.core.windows.net
+                ]
+            },
+            "ipConfigurations":[
+                {
+                    "name": "myIPconfigTest02",
+                    "properties": {
+                        "groupId": "blob",
+                        "memberName": "blob",
+                        "privateIPAddress": "10.0.0.30"
+                    }
+                }
+            ],
+            "customDnsConfigs": [
+                {
+                    "fqdn": "customname.test.local",
+                    "ipAddresses": [
+                        "10.10.10.10"
+                    ]
+                }
+            ]
+        },
+        // Example showing only mandatory fields
+        {
+            "subnetResourceId": "/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001",
+            "service": "<serviceName>" // e.g. vault, registry, blob
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+privateEndpoints:  [
+    // Example showing all available fields
+    {
+        name: 'sxx-az-pe' // Optional: Name will be automatically generated if one is not provided here
+        subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001'
+        service: '<serviceName>' // e.g. vault, registry, blob
+        privateDnsZoneGroup: {
+            privateDNSResourceIds: [ // Optional: No DNS record will be created if a private DNS zone Resource ID is not specified
+                '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/privateDnsZones/<privateDnsZoneName>' // e.g. privatelink.vaultcore.azure.net, privatelink.azurecr.io, privatelink.blob.core.windows.net
+            ]
+        }
+        customDnsConfigs: [
+            {
+                fqdn: 'customname.test.local'
+                ipAddresses: [
+                    '10.10.10.10'
+                ]
+            }
+        ]
+        ipConfigurations:[
+          {
+            name: 'myIPconfigTest02'
+            properties: {
+              groupId: 'blob'
+              memberName: 'blob'
+              privateIPAddress: '10.0.0.30'
+            }
+          }
+        ]
+    }
+    // Example showing only mandatory fields
+    {
+        subnetResourceId: '/subscriptions/<<subscriptionId>>/resourceGroups/validation-rg/providers/Microsoft.Network/virtualNetworks/sxx-az-vnet-x-001/subnets/sxx-az-subnet-x-001'
+        service: '<serviceName>' // e.g. vault, registry, blob
+    }
+]
+```
+
+</details>
+<p>
+
+### Parameter Usage: `networkAcl`
+
+Configure networing options on premium SKU only.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"networkAclConfig": {
+    "value" : {
+        "publicNetworkAccess": "Disabled",
+        "allowTrustedServices": true
+    }
+}
+
+
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+networkingAclConfig: {
+    publicNetworkAccess: "Disabled"
+    allowTrustedServices: true
+}
+
+```
+
+</details>
+<p>
+
+### Parameter Usage: `tags`
+
+Tag names and tag values can be provided as needed. A tag can be left without a value.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"tags": {
+    "value": {
+        "Environment": "Non-Prod",
+        "Contact": "test.user@testcompany.com",
+        "PurchaseOrder": "1234",
+        "CostCenter": "7890",
+        "ServiceName": "DeploymentValidation",
+        "Role": "DeploymentValidation"
+    }
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+tags: {
+    Environment: 'Non-Prod'
+    Contact: 'test.user@testcompany.com'
+    PurchaseOrder: '1234'
+    CostCenter: '7890'
+    ServiceName: 'DeploymentValidation'
+    Role: 'DeploymentValidation'
+}
+```
+
+</details>
+<p>
+
+### Parameter Usage: `userAssignedIdentities`
+
+You can specify multiple user assigned identities to a resource by providing additional resource IDs using the following format:
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"userAssignedIdentities": {
+    "value": {
+        "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-001": {},
+        "/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-002": {}
+    }
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+userAssignedIdentities: {
+    '/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-001': {}
+    '/subscriptions/<<subscriptionId>>/resourcegroups/validation-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/adp-sxx-az-msi-x-002': {}
+}
+```
+
+</details>
+<p>
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `location` | string | The location the resource was deployed into. |
+| `name` | string | The name of the deployed relay namespace. |
+| `resourceGroupName` | string | The resource group of the deployed relay namespace. |
+| `resourceId` | string | The resource ID of the deployed relay namespace. |
+
+## Cross-referenced modules
+
+This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `network/private-endpoints` | Local reference |
+
+## Deployment examples
+
+The following module usage examples are retrieved from the content of the files hosted in the module's `.test` folder.
+   >**Note**: The name of each example is based on the name of the file from which it is taken.
+
+   >**Note**: Each example lists all the required parameters first, followed by the rest - each in alphabetical order.
+
+<h3>Example 1: Common</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module namespaces './relay/namespaces/main.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-test-relcom'
+  params: {
+    // Required parameters
+    name: '<<namePrefix>>relcom001'
+    // Non-required parameters
+    authorizationRules: [
+      {
+        name: 'RootManageSharedAccessKey'
+        rights: [
+          'Listen'
+          'Manage'
+          'Send'
+        ]
+      }
+      {
+        name: 'AnotherKey'
+        rights: [
+          'Listen'
+          'Send'
+        ]
+      }
+    ]
+    diagnosticEventHubAuthorizationRuleId: '<diagnosticEventHubAuthorizationRuleId>'
+    diagnosticEventHubName: '<diagnosticEventHubName>'
+    diagnosticLogsRetentionInDays: 7
+    diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
+    diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    hybridConnections: [
+      {
+        name: '<<namePrefix>>relcomhc001'
+        roleAssignments: [
+          {
+            principalIds: [
+              '<managedIdentityPrincipalId>'
+            ]
+            principalType: 'ServicePrincipal'
+            roleDefinitionIdOrName: 'Reader'
+          }
+        ]
+        userMetadata: '[{\'key\':\'endpoint\'\'value\':\'db-server.constoso.com:1433\'}]'
+      }
+    ]
+    lock: 'CanNotDelete'
+    networkRuleSets: {
+      defaultAction: 'Deny'
+      ipRules: [
+        {
+          action: 'Allow'
+          ipMask: '10.0.1.0/32'
+        }
+        {
+          action: 'Allow'
+          ipMask: '10.0.2.0/32'
+        }
+      ]
+      trustedServiceAccessEnabled: true
+      virtualNetworkRules: [
+        {
+          subnet: {
+            id: '<id>'
+            ignoreMissingVnetServiceEndpoint: true
+          }
+        }
+      ]
+    }
+    privateEndpoints: [
+      {
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            '<privateDNSZoneResourceId>'
+          ]
+        }
+        service: 'namespace'
+        subnetResourceId: '<subnetResourceId>'
+        tags: {
+          Environment: 'Non-Prod'
+          Role: 'DeploymentValidation'
+        }
+      }
+    ]
+    roleAssignments: [
+      {
+        principalIds: [
+          '<managedIdentityPrincipalId>'
+        ]
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'Reader'
+      }
+    ]
+    skuName: 'Standard'
+    tags: {
+      Environment: 'Non-Prod'
+      Role: 'DeploymentValidation'
+    }
+    wcfRelays: [
+      {
+        name: '<<namePrefix>>relcomwcf001'
+        relayType: 'NetTcp'
+        roleAssignments: [
+          {
+            principalIds: [
+              '<managedIdentityPrincipalId>'
+            ]
+            principalType: 'ServicePrincipal'
+            roleDefinitionIdOrName: 'Reader'
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "<<namePrefix>>relcom001"
+    },
+    // Non-required parameters
+    "authorizationRules": {
+      "value": [
+        {
+          "name": "RootManageSharedAccessKey",
+          "rights": [
+            "Listen",
+            "Manage",
+            "Send"
+          ]
+        },
+        {
+          "name": "AnotherKey",
+          "rights": [
+            "Listen",
+            "Send"
+          ]
+        }
+      ]
+    },
+    "diagnosticEventHubAuthorizationRuleId": {
+      "value": "<diagnosticEventHubAuthorizationRuleId>"
+    },
+    "diagnosticEventHubName": {
+      "value": "<diagnosticEventHubName>"
+    },
+    "diagnosticLogsRetentionInDays": {
+      "value": 7
+    },
+    "diagnosticStorageAccountId": {
+      "value": "<diagnosticStorageAccountId>"
+    },
+    "diagnosticWorkspaceId": {
+      "value": "<diagnosticWorkspaceId>"
+    },
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
+    "hybridConnections": {
+      "value": [
+        {
+          "name": "<<namePrefix>>relcomhc001",
+          "roleAssignments": [
+            {
+              "principalIds": [
+                "<managedIdentityPrincipalId>"
+              ],
+              "principalType": "ServicePrincipal",
+              "roleDefinitionIdOrName": "Reader"
+            }
+          ],
+          "userMetadata": "[{\"key\":\"endpoint\",\"value\":\"db-server.constoso.com:1433\"}]"
+        }
+      ]
+    },
+    "lock": {
+      "value": "CanNotDelete"
+    },
+    "networkRuleSets": {
+      "value": {
+        "defaultAction": "Deny",
+        "ipRules": [
+          {
+            "action": "Allow",
+            "ipMask": "10.0.1.0/32"
+          },
+          {
+            "action": "Allow",
+            "ipMask": "10.0.2.0/32"
+          }
+        ],
+        "trustedServiceAccessEnabled": true,
+        "virtualNetworkRules": [
+          {
+            "subnet": {
+              "id": "<id>",
+              "ignoreMissingVnetServiceEndpoint": true
+            }
+          }
+        ]
+      }
+    },
+    "privateEndpoints": {
+      "value": [
+        {
+          "privateDnsZoneGroup": {
+            "privateDNSResourceIds": [
+              "<privateDNSZoneResourceId>"
+            ]
+          },
+          "service": "namespace",
+          "subnetResourceId": "<subnetResourceId>",
+          "tags": {
+            "Environment": "Non-Prod",
+            "Role": "DeploymentValidation"
+          }
+        }
+      ]
+    },
+    "roleAssignments": {
+      "value": [
+        {
+          "principalIds": [
+            "<managedIdentityPrincipalId>"
+          ],
+          "principalType": "ServicePrincipal",
+          "roleDefinitionIdOrName": "Reader"
+        }
+      ]
+    },
+    "skuName": {
+      "value": "Standard"
+    },
+    "tags": {
+      "value": {
+        "Environment": "Non-Prod",
+        "Role": "DeploymentValidation"
+      }
+    },
+    "wcfRelays": {
+      "value": [
+        {
+          "name": "<<namePrefix>>relcomwcf001",
+          "relayType": "NetTcp",
+          "roleAssignments": [
+            {
+              "principalIds": [
+                "<managedIdentityPrincipalId>"
+              ],
+              "principalType": "ServicePrincipal",
+              "roleDefinitionIdOrName": "Reader"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<h3>Example 2: Min</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module namespaces './relay/namespaces/main.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-test-sbnmin'
+  params: {
+    // Required parameters
+    name: '<<namePrefix>>sbnmin001'
+    // Non-required parameters
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "<<namePrefix>>sbnmin001"
+    },
+    // Non-required parameters
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<h3>Example 3: Pe</h3>
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module namespaces './relay/namespaces/main.bicep' = {
+  name: '${uniqueString(deployment().name, location)}-test-sbnpe'
+  params: {
+    // Required parameters
+    name: '<<namePrefix>>sbnpe001'
+    // Non-required parameters
+    enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    privateEndpoints: [
+      {
+        privateDnsZoneGroup: {
+          privateDNSResourceIds: [
+            '<privateDNSZoneResourceId>'
+          ]
+        }
+        service: 'namespace'
+        subnetResourceId: '<subnetResourceId>'
+        tags: {
+          Environment: 'Non-Prod'
+          Role: 'DeploymentValidation'
+        }
+      }
+    ]
+    skuName: 'Standard'
+    tags: {
+      Environment: 'Non-Prod'
+      Role: 'DeploymentValidation'
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "<<namePrefix>>sbnpe001"
+    },
+    // Non-required parameters
+    "enableDefaultTelemetry": {
+      "value": "<enableDefaultTelemetry>"
+    },
+    "privateEndpoints": {
+      "value": [
+        {
+          "privateDnsZoneGroup": {
+            "privateDNSResourceIds": [
+              "<privateDNSZoneResourceId>"
+            ]
+          },
+          "service": "namespace",
+          "subnetResourceId": "<subnetResourceId>",
+          "tags": {
+            "Environment": "Non-Prod",
+            "Role": "DeploymentValidation"
+          }
+        }
+      ]
+    },
+    "skuName": {
+      "value": "Standard"
+    },
+    "tags": {
+      "value": {
+        "Environment": "Non-Prod",
+        "Role": "DeploymentValidation"
+      }
+    }
+  }
+}
+```
+
+</details>
+<p>

--- a/modules/relay/namespaces/authorization-rules/README.md
+++ b/modules/relay/namespaces/authorization-rules/README.md
@@ -1,0 +1,50 @@
+# Relay Namespace Authorization Rules `[Microsoft.Relay/namespaces/authorizationRules]`
+
+This module deploys authorization rules for a relay namespace.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Relay/namespaces/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the authorization rule. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `namespaceName` | string | The name of the parent Relay Namespace for the Relay Hybrid Connection. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `rights` | array | `[]` | `[Listen, Manage, Send]` | The rights associated with the rule. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the authorization rule. |
+| `resourceGroupName` | string | The name of the Resource Group the authorization rule was created in. |
+| `resourceId` | string | The resource ID of the authorization rule. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/authorization-rules/main.bicep
+++ b/modules/relay/namespaces/authorization-rules/main.bicep
@@ -1,0 +1,51 @@
+@description('Conditional. The name of the parent Relay Namespace for the Relay Hybrid Connection. Required if the template is used in a standalone deployment.')
+@minLength(6)
+@maxLength(50)
+param namespaceName string
+
+@description('Required. The name of the authorization rule.')
+param name string
+
+@description('Optional. The rights associated with the rule.')
+@allowed([
+  'Listen'
+  'Manage'
+  'Send'
+])
+param rights array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/authorizationRules@2021-11-01' = {
+  name: name
+  parent: namespace
+  properties: {
+    rights: rights
+  }
+}
+
+@description('The name of the authorization rule.')
+output name string = authorizationRule.name
+
+@description('The resource ID of the authorization rule.')
+output resourceId string = authorizationRule.id
+
+@description('The name of the Resource Group the authorization rule was created in.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/authorization-rules/metadata.json
+++ b/modules/relay/namespaces/authorization-rules/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Relay Namespace Authorization Rules",
+  "summary": "This module deploys authorization rules for a relay namespace.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/authorization-rules/version.json
+++ b/modules/relay/namespaces/authorization-rules/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/hybrid-connections/.bicep/nested_roleAssignments.bicep
+++ b/modules/relay/namespaces/hybrid-connections/.bicep/nested_roleAssignments.bicep
@@ -21,18 +21,29 @@ param principalType string = ''
 @sys.description('Optional. The description of the role assignment.')
 param description string = ''
 
+@sys.description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
+param condition string = ''
+
+@sys.description('Optional. Version of the condition.')
+@allowed([
+  '2.0'
+])
+param conditionVersion string = '2.0'
+
+@sys.description('Optional. Id of the delegated managed identity resource.')
+param delegatedManagedIdentityResourceId string = ''
+
 var builtInRoleNames = {
   'App Compliance Automation Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')
+  'Azure Relay Listener': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26e0b698-aa6d-4085-9386-aadae190014d')
+  'Azure Relay Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2787bf04-f1f5-4bfe-8383-c8a24483ee38')
+  'Azure Relay Sender': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26baccc8-eea7-41f1-98f4-1762cc7f685d')
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
   'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')
-  'Logic App Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '87a39d53-fc1b-424a-814c-f7e04687dc9e')
-  'Logic App Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '515c2055-d9d4-4321-b1b9-bd0c9a0f79fe')
   'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')
   'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')
   'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')
-  'Microsoft Sentinel Automation Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f4c81013-99ee-4d62-a7ee-b3f1f648599a')
-  'Microsoft Sentinel Playbook Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '51d6186e-6489-4900-b93f-92e23144cca5')
   'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')
   'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
   Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
@@ -40,26 +51,22 @@ var builtInRoleNames = {
   'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')
   'Role Based Access Control Administrator (Preview)': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')
   'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
-  'Web Plan Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')
-  'Website Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
 }
 
-var appName = split(resourceId, '/')[indexOf(split(resourceId, '/'), 'sites') + 1]
-
-resource app 'Microsoft.Web/sites@2020-12-01' existing = {
-  name: appName
-  resource slot 'slots' existing = {
-    name: last(split(resourceId, '/'))!
-  }
+resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' existing = {
+  name: '${split(resourceId, '/')[8]}/${split(resourceId, '/')[10]}'
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = [for principalId in principalIds: {
-  name: guid(app::slot.id, principalId, roleDefinitionIdOrName)
+resource roleAssigment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  name: guid(hybridConnection.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
     principalType: !empty(principalType) ? any(principalType) : null
+    condition: !empty(condition) ? condition : null
+    conditionVersion: !empty(conditionVersion) && !empty(condition) ? conditionVersion : null
+    delegatedManagedIdentityResourceId: !empty(delegatedManagedIdentityResourceId) ? delegatedManagedIdentityResourceId : null
   }
-  scope: app::slot
+  scope: hybridConnection
 }]

--- a/modules/relay/namespaces/hybrid-connections/README.md
+++ b/modules/relay/namespaces/hybrid-connections/README.md
@@ -1,0 +1,116 @@
+# Hybrid Connection Relay `[Microsoft.Relay/namespaces/hybridConnections]`
+
+This module deploys a hybrid connection relay resource.
+
+## Navigation
+
+- [Resource types](#Resource-types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
+| `Microsoft.Relay/namespaces/hybridConnections` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/hybridConnections) |
+| `Microsoft.Relay/namespaces/hybridConnections/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/hybridConnections/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | Name of the Relay Hybrid Connection. |
+| `userMetadata` | string | User-defined string data for the Relay Hybrid Connection. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `namespaceName` | string | The name of the parent Relay Namespace for the Relay Hybrid Connection. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `authorizationRules` | _[authorizationRules](authorization-rules/README.md)_ array | `[System.Management.Automation.OrderedHashtable, System.Management.Automation.OrderedHashtable, System.Management.Automation.OrderedHashtable]` |  | Authorization Rules for the Relay Hybrid Connection. |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `requiresClientAuthorization` | bool | `True` |  | A value indicating if this hybrid connection requires duplicate detection. |
+| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+
+
+### Parameter Usage: `roleAssignments`
+
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to `'ServicePrincipal'`. This will ensure the role assignment waits for the principal's propagation in Azure.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"roleAssignments": {
+    "value": [
+        {
+            "roleDefinitionIdOrName": "Reader",
+            "description": "Reader Role Assignment",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012", // object 1
+                "78945612-1234-1234-1234-123456789012" // object 2
+            ]
+        },
+        {
+            "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012" // object 1
+            ],
+            "principalType": "ServicePrincipal"
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+roleAssignments: [
+    {
+        roleDefinitionIdOrName: 'Reader'
+        description: 'Reader Role Assignment'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+            '78945612-1234-1234-1234-123456789012' // object 2
+        ]
+    }
+    {
+        roleDefinitionIdOrName: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+        ]
+        principalType: 'ServicePrincipal'
+    }
+]
+```
+
+</details>
+<p>
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the deployed hybrid connection. |
+| `resourceGroupName` | string | The resource group of the deployed hybrid connection. |
+| `resourceId` | string | The resource ID of the deployed hybrid connection. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/hybrid-connections/authorization-rules/README.md
+++ b/modules/relay/namespaces/hybrid-connections/authorization-rules/README.md
@@ -1,0 +1,51 @@
+# Hybrid Connection Relay Authorization Rules `[Microsoft.Relay/namespaces/hybridConnections/authorizationRules]`
+
+This module deploys authorization rules for a hybrid connection relay.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Relay/namespaces/hybridConnections/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/hybridConnections/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the relay namepace hybrid connection. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `hybridConnectionName` | string | The name of the parent Relay Namespace Hybrid Connection. Required if the template is used in a standalone deployment. |
+| `namespaceName` | string | The name of the parent Relay Namespace. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `rights` | array | `[]` | `[Listen, Manage, Send]` | The rights associated with the rule. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the authorization rule. |
+| `resourceGroupName` | string | The name of the Resource Group the authorization rule was created in. |
+| `resourceId` | string | The Resource ID of the authorization rule. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/hybrid-connections/authorization-rules/main.bicep
+++ b/modules/relay/namespaces/hybrid-connections/authorization-rules/main.bicep
@@ -1,0 +1,56 @@
+@description('Required. The name of the relay namepace hybrid connection.')
+param name string
+
+@description('Conditional. The name of the parent Relay Namespace. Required if the template is used in a standalone deployment.')
+param namespaceName string
+
+@description('Conditional. The name of the parent Relay Namespace Hybrid Connection. Required if the template is used in a standalone deployment.')
+param hybridConnectionName string
+
+@description('Optional. The rights associated with the rule.')
+@allowed([
+  'Listen'
+  'Manage'
+  'Send'
+])
+param rights array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+
+  resource hybridConnection 'hybridConnections@2021-11-01' existing = {
+    name: hybridConnectionName
+  }
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@2021-11-01' = {
+  name: name
+  parent: namespace::hybridConnection
+  properties: {
+    rights: rights
+  }
+}
+
+@description('The name of the authorization rule.')
+output name string = authorizationRule.name
+
+@description('The Resource ID of the authorization rule.')
+output resourceId string = authorizationRule.id
+
+@description('The name of the Resource Group the authorization rule was created in.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/hybrid-connections/authorization-rules/metadata.json
+++ b/modules/relay/namespaces/hybrid-connections/authorization-rules/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Hybrid Connection Relay Authorization Rules",
+  "summary": "This module deploys authorization rules for a hybrid connection relay.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/hybrid-connections/authorization-rules/version.json
+++ b/modules/relay/namespaces/hybrid-connections/authorization-rules/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/hybrid-connections/main.bicep
+++ b/modules/relay/namespaces/hybrid-connections/main.bicep
@@ -1,0 +1,122 @@
+@description('Conditional. The name of the parent Relay Namespace for the Relay Hybrid Connection. Required if the template is used in a standalone deployment.')
+@minLength(6)
+@maxLength(50)
+param namespaceName string
+
+@description('Required. Name of the Relay Hybrid Connection.')
+@minLength(6)
+@maxLength(50)
+param name string
+
+@description('Required. User-defined string data for the Relay Hybrid Connection.')
+param userMetadata string
+
+@description('Optional. A value indicating if this hybrid connection requires duplicate detection.')
+param requiresClientAuthorization bool = true
+
+@description('Optional. Authorization Rules for the Relay Hybrid Connection.')
+param authorizationRules array = [
+  {
+    name: 'RootManageSharedAccessKey'
+    rights: [
+      'Listen'
+      'Manage'
+      'Send'
+    ]
+  }
+  {
+    name: 'defaultListener'
+    rights: [
+      'Listen'
+    ]
+  }
+  {
+    name: 'defaultSender'
+    rights: [
+      'Send'
+    ]
+  }
+]
+
+@allowed([
+  ''
+  'CanNotDelete'
+  'ReadOnly'
+])
+@description('Optional. Specify the type of lock.')
+param lock string = ''
+
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
+param roleAssignments array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+var enableReferencedModulesTelemetry = false
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+}
+
+resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' = {
+  name: name
+  parent: namespace
+  properties: {
+    requiresClientAuthorization: requiresClientAuthorization
+    userMetadata: userMetadata
+  }
+}
+
+module hybridconnection_authorizationRules 'authorization-rules/main.bicep' = [for (authorizationRule, index) in authorizationRules: {
+  name: '${deployment().name}-AuthRule-${index}'
+  params: {
+    namespaceName: namespaceName
+    hybridConnectionName: hybridConnection.name
+    name: authorizationRule.name
+    rights: contains(authorizationRule, 'rights') ? authorizationRule.rights : []
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+resource hybridConnection_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock)) {
+  name: '${hybridConnection.name}-${lock}-lock'
+  properties: {
+    level: any(lock)
+    notes: lock == 'CanNotDelete' ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
+  }
+  scope: hybridConnection
+}
+
+module hybridConnection_roleAssignments '.bicep/nested_roleAssignments.bicep' = [for (roleAssignment, index) in roleAssignments: {
+  name: '${deployment().name}-Rbac-${index}'
+  params: {
+    description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
+    principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
+    roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
+    condition: contains(roleAssignment, 'condition') ? roleAssignment.condition : ''
+    delegatedManagedIdentityResourceId: contains(roleAssignment, 'delegatedManagedIdentityResourceId') ? roleAssignment.delegatedManagedIdentityResourceId : ''
+    resourceId: hybridConnection.id
+  }
+}]
+
+@description('The name of the deployed hybrid connection.')
+output name string = hybridConnection.name
+
+@description('The resource ID of the deployed hybrid connection.')
+output resourceId string = hybridConnection.id
+
+@description('The resource group of the deployed hybrid connection.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/hybrid-connections/metadata.json
+++ b/modules/relay/namespaces/hybrid-connections/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Hybrid Connection Relay",
+  "summary": "This module deploys a hybrid connection relay resource.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/hybrid-connections/version.json
+++ b/modules/relay/namespaces/hybrid-connections/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/main.bicep
+++ b/modules/relay/namespaces/main.bicep
@@ -1,0 +1,303 @@
+@description('Required. Name of the Relay Namespace.')
+@maxLength(50)
+param name string
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Name of this SKU.')
+@allowed([
+  'Standard'
+])
+param skuName string = 'Standard'
+
+@description('Optional. Authorization Rules for the Relay namespace.')
+param authorizationRules array = [
+  {
+    name: 'RootManageSharedAccessKey'
+    rights: [
+      'Listen'
+      'Manage'
+      'Send'
+    ]
+  }
+]
+
+@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
+@minValue(0)
+@maxValue(365)
+param diagnosticLogsRetentionInDays int = 365
+
+@description('Optional. Resource ID of the diagnostic storage account.')
+param diagnosticStorageAccountId string = ''
+
+@description('Optional. Resource ID of the diagnostic log analytics workspace.')
+param diagnosticWorkspaceId string = ''
+
+@description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
+param diagnosticEventHubAuthorizationRuleId string = ''
+
+@description('Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category.')
+param diagnosticEventHubName string = ''
+
+@allowed([
+  ''
+  'CanNotDelete'
+  'ReadOnly'
+])
+@description('Optional. Specify the type of lock.')
+param lock string = ''
+
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
+param roleAssignments array = []
+
+@description('Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.')
+param privateEndpoints array = []
+
+@description('Optional. Configure networking options for Relay. This object contains IPs/Subnets to allow or restrict access to private endpoints only. For security reasons, it is recommended to configure this object on the Namespace.')
+param networkRuleSets object = {}
+
+@description('Optional. Tags of the resource.')
+param tags object = {}
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+@description('Optional. The hybrid connections to create in the relay namespace.')
+param hybridConnections array = []
+
+@description('Optional. The wcf relays to create in the relay namespace.')
+param wcfRelays array = []
+
+@description('Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource.')
+@allowed([
+  'allLogs'
+  'OperationalLogs'
+])
+param diagnosticLogCategoriesToEnable array = [
+  'allLogs'
+]
+
+@description('Optional. The name of metrics that will be streamed.')
+@allowed([
+  'AllMetrics'
+])
+param diagnosticMetricsToEnable array = [
+  'AllMetrics'
+]
+
+@description('Optional. The name of the diagnostic setting, if deployed. If left empty, it defaults to "<resourceName>-diagnosticSettings".')
+param diagnosticSettingsName string = ''
+
+var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
+  category: category
+  enabled: true
+  retentionPolicy: {
+    enabled: true
+    days: diagnosticLogsRetentionInDays
+  }
+}]
+
+var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
+  {
+    categoryGroup: 'allLogs'
+    enabled: true
+    retentionPolicy: {
+      enabled: true
+      days: diagnosticLogsRetentionInDays
+    }
+  }
+] : diagnosticsLogsSpecified
+
+var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
+  category: metric
+  timeGrain: null
+  enabled: true
+  retentionPolicy: {
+    enabled: true
+    days: diagnosticLogsRetentionInDays
+  }
+}]
+
+var enableReferencedModulesTelemetry = false
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' = {
+  name: name
+  location: location
+  tags: empty(tags) ? null : tags
+  sku: {
+    name: skuName
+  }
+  properties: {}
+}
+
+module namespace_authorizationRules 'authorization-rules/main.bicep' = [for (authorizationRule, index) in authorizationRules: {
+  name: '${uniqueString(deployment().name, location)}-AuthorizationRules-${index}'
+  params: {
+    namespaceName: namespace.name
+    name: authorizationRule.name
+    rights: contains(authorizationRule, 'rights') ? authorizationRule.rights : []
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+module namespace_networkRuleSet 'network-rule-sets/main.bicep' = if (!empty(networkRuleSets) || !empty(privateEndpoints)) {
+  name: '${uniqueString(deployment().name, location)}-NetworkRuleSet'
+  params: {
+    namespaceName: namespace.name
+    publicNetworkAccess: contains(networkRuleSets, 'publicNetworkAccess') ? networkRuleSets.publicNetworkAccess : (!empty(privateEndpoints) && empty(networkRuleSets) ? 'Disabled' : 'Enabled')
+    defaultAction: contains(networkRuleSets, 'defaultAction') ? networkRuleSets.defaultAction : 'Allow'
+    ipRules: contains(networkRuleSets, 'ipRules') ? networkRuleSets.ipRules : []
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}
+
+module namespace_hybridConnections 'hybrid-connections/main.bicep' = [for (hybridConnection, index) in hybridConnections: {
+  name: '${uniqueString(deployment().name, location)}-hybridConnection-${index}'
+  params: {
+    namespaceName: namespace.name
+    name: hybridConnection.name
+    authorizationRules: contains(hybridConnection, 'authorizationRules') ? hybridConnection.authorizationRules : [
+      {
+        name: 'RootManageSharedAccessKey'
+        rights: [
+          'Listen'
+          'Manage'
+          'Send'
+        ]
+      }
+      {
+        name: 'defaultListener'
+        rights: [
+          'Listen'
+        ]
+      }
+      {
+        name: 'defaultSender'
+        rights: [
+          'Send'
+        ]
+      }
+    ]
+    requiresClientAuthorization: contains(hybridConnection, 'requiresClientAuthorization') ? hybridConnection.requiresClientAuthorization : true
+    userMetadata: hybridConnection.userMetadata
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+module namespace_wcfRelays 'wcf-relays/main.bicep' = [for (wcfRelay, index) in wcfRelays: {
+  name: '${uniqueString(deployment().name, location)}-wcfRelay-${index}'
+  params: {
+    namespaceName: namespace.name
+    name: wcfRelay.name
+    authorizationRules: contains(wcfRelay, 'authorizationRules') ? wcfRelay.authorizationRules : [
+      {
+        name: 'RootManageSharedAccessKey'
+        rights: [
+          'Listen'
+          'Manage'
+          'Send'
+        ]
+      }
+      {
+        name: 'defaultListener'
+        rights: [
+          'Listen'
+        ]
+      }
+      {
+        name: 'defaultSender'
+        rights: [
+          'Send'
+        ]
+      }
+    ]
+    relayType: wcfRelay.relayType
+    requiresClientAuthorization: contains(wcfRelay, 'requiresClientAuthorization') ? wcfRelay.requiresClientAuthorization : true
+    requiresTransportSecurity: contains(wcfRelay, 'requiresTransportSecurity') ? wcfRelay.requiresTransportSecurity : true
+    userMetadata: contains(wcfRelay, 'userMetadata') ? wcfRelay.userMetadata : null
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+resource namespace_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock)) {
+  name: '${namespace.name}-${lock}-lock'
+  properties: {
+    level: any(lock)
+    notes: lock == 'CanNotDelete' ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
+  }
+  scope: namespace
+}
+
+resource namespace_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(diagnosticStorageAccountId) || !empty(diagnosticWorkspaceId) || !empty(diagnosticEventHubAuthorizationRuleId) || !empty(diagnosticEventHubName)) {
+  name: !empty(diagnosticSettingsName) ? diagnosticSettingsName : '${name}-diagnosticSettings'
+  properties: {
+    storageAccountId: !empty(diagnosticStorageAccountId) ? diagnosticStorageAccountId : null
+    workspaceId: !empty(diagnosticWorkspaceId) ? diagnosticWorkspaceId : null
+    eventHubAuthorizationRuleId: !empty(diagnosticEventHubAuthorizationRuleId) ? diagnosticEventHubAuthorizationRuleId : null
+    eventHubName: !empty(diagnosticEventHubName) ? diagnosticEventHubName : null
+    metrics: diagnosticsMetrics
+    logs: diagnosticsLogs
+  }
+  scope: namespace
+}
+
+module namespace_privateEndpoints '../../network/private-endpoints/main.bicep' = [for (privateEndpoint, index) in privateEndpoints: {
+  name: '${uniqueString(deployment().name, location)}-Namespace-PrivateEndpoint-${index}'
+  params: {
+    groupIds: [
+      privateEndpoint.service
+    ]
+    name: contains(privateEndpoint, 'name') ? privateEndpoint.name : 'pe-${last(split(namespace.id, '/'))}-${privateEndpoint.service}-${index}'
+    serviceResourceId: namespace.id
+    subnetResourceId: privateEndpoint.subnetResourceId
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+    location: reference(split(privateEndpoint.subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location
+    lock: contains(privateEndpoint, 'lock') ? privateEndpoint.lock : lock
+    privateDnsZoneGroup: contains(privateEndpoint, 'privateDnsZoneGroup') ? privateEndpoint.privateDnsZoneGroup : {}
+    roleAssignments: contains(privateEndpoint, 'roleAssignments') ? privateEndpoint.roleAssignments : []
+    tags: contains(privateEndpoint, 'tags') ? privateEndpoint.tags : {}
+    manualPrivateLinkServiceConnections: contains(privateEndpoint, 'manualPrivateLinkServiceConnections') ? privateEndpoint.manualPrivateLinkServiceConnections : []
+    customDnsConfigs: contains(privateEndpoint, 'customDnsConfigs') ? privateEndpoint.customDnsConfigs : []
+    ipConfigurations: contains(privateEndpoint, 'ipConfigurations') ? privateEndpoint.ipConfigurations : []
+    applicationSecurityGroups: contains(privateEndpoint, 'applicationSecurityGroups') ? privateEndpoint.applicationSecurityGroups : []
+    customNetworkInterfaceName: contains(privateEndpoint, 'customNetworkInterfaceName') ? privateEndpoint.customNetworkInterfaceName : ''
+  }
+}]
+
+module namespace_roleAssignments '.bicep/nested_roleAssignments.bicep' = [for (roleAssignment, index) in roleAssignments: {
+  name: '${deployment().name}-Rbac-${index}'
+  params: {
+    description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
+    principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
+    roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
+    condition: contains(roleAssignment, 'condition') ? roleAssignment.condition : ''
+    delegatedManagedIdentityResourceId: contains(roleAssignment, 'delegatedManagedIdentityResourceId') ? roleAssignment.delegatedManagedIdentityResourceId : ''
+    resourceId: namespace.id
+  }
+}]
+
+@description('The resource ID of the deployed relay namespace.')
+output resourceId string = namespace.id
+
+@description('The resource group of the deployed relay namespace.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The name of the deployed relay namespace.')
+output name string = namespace.name
+
+@description('The location the resource was deployed into.')
+output location string = namespace.location

--- a/modules/relay/namespaces/metadata.json
+++ b/modules/relay/namespaces/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Relay Namespaces",
+  "summary": "This module deploys a relay namespace resource.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/network-rule-sets/README.md
+++ b/modules/relay/namespaces/network-rule-sets/README.md
@@ -1,0 +1,46 @@
+# Relay Namespaces Network Rules Sets `[Microsoft.Relay/namespaces/networkRuleSets]`
+
+This module deploys Relay Namespace Network Rule Sets.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Relay/namespaces/networkRuleSets` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/networkRuleSets) |
+
+## Parameters
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `namespaceName` | string | The name of the parent Relay Namespace for the Relay Network Rule Set. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `defaultAction` | string | `'Allow'` | `[Allow, Deny]` | Default Action for Network Rule Set. Default is "Allow". It will not be set if publicNetworkAccess is "Disabled". Otherwise, it will be set to "Deny" if ipRules or virtualNetworkRules are being used. |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `ipRules` | array | `[]` |  | List of IpRules. It will not be set if publicNetworkAccess is "Disabled". Otherwise, when used, defaultAction will be set to "Deny". |
+| `publicNetworkAccess` | string | `'Enabled'` | `[Disabled, Enabled]` | This determines if traffic is allowed over public network. Default is "Enabled". If set to "Disabled", traffic to this namespace will be restricted over Private Endpoints only and network rules will not be applied. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the network rule set. |
+| `resourceGroupName` | string | The name of the resource group the network rule set was created in. |
+| `resourceId` | string | The resource ID of the network rule set. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/network-rule-sets/main.bicep
+++ b/modules/relay/namespaces/network-rule-sets/main.bicep
@@ -1,0 +1,59 @@
+@description('Conditional. The name of the parent Relay Namespace for the Relay Network Rule Set. Required if the template is used in a standalone deployment.')
+@minLength(6)
+@maxLength(50)
+param namespaceName string
+
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+@description('Optional. This determines if traffic is allowed over public network. Default is "Enabled". If set to "Disabled", traffic to this namespace will be restricted over Private Endpoints only and network rules will not be applied.')
+param publicNetworkAccess string = 'Enabled'
+
+@allowed([
+  'Allow'
+  'Deny'
+])
+@description('Optional. Default Action for Network Rule Set. Default is "Allow". It will not be set if publicNetworkAccess is "Disabled". Otherwise, it will be set to "Deny" if ipRules or virtualNetworkRules are being used.')
+param defaultAction string = 'Allow'
+
+@description('Optional. List of IpRules. It will not be set if publicNetworkAccess is "Disabled". Otherwise, when used, defaultAction will be set to "Deny".')
+param ipRules array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+}
+
+resource networkRuleSet 'Microsoft.Relay/namespaces/networkRuleSets@2021-11-01' = {
+  name: 'default'
+  parent: namespace
+  properties: {
+    publicNetworkAccess: publicNetworkAccess
+    defaultAction: publicNetworkAccess == 'Disabled' ? null : (!empty(ipRules) ? 'Deny' : defaultAction)
+    ipRules: publicNetworkAccess == 'Disabled' ? null : ipRules
+  }
+}
+
+@description('The name of the network rule set.')
+output name string = networkRuleSet.name
+
+@description('The resource ID of the network rule set.')
+output resourceId string = networkRuleSet.id
+
+@description('The name of the resource group the network rule set was created in.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/network-rule-sets/metadata.json
+++ b/modules/relay/namespaces/network-rule-sets/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Relay Namespaces Network Rules Sets",
+  "summary": "This module deploys Relay Namespace Network Rule Sets.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/network-rule-sets/version.json
+++ b/modules/relay/namespaces/network-rule-sets/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.2",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/version.json
+++ b/modules/relay/namespaces/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.5",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/wcf-relays/.bicep/nested_roleAssignments.bicep
+++ b/modules/relay/namespaces/wcf-relays/.bicep/nested_roleAssignments.bicep
@@ -21,18 +21,29 @@ param principalType string = ''
 @sys.description('Optional. The description of the role assignment.')
 param description string = ''
 
+@sys.description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
+param condition string = ''
+
+@sys.description('Optional. Version of the condition.')
+@allowed([
+  '2.0'
+])
+param conditionVersion string = '2.0'
+
+@sys.description('Optional. Id of the delegated managed identity resource.')
+param delegatedManagedIdentityResourceId string = ''
+
 var builtInRoleNames = {
   'App Compliance Automation Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')
+  'Azure Relay Listener': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26e0b698-aa6d-4085-9386-aadae190014d')
+  'Azure Relay Owner': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2787bf04-f1f5-4bfe-8383-c8a24483ee38')
+  'Azure Relay Sender': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '26baccc8-eea7-41f1-98f4-1762cc7f685d')
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
   'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')
-  'Logic App Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '87a39d53-fc1b-424a-814c-f7e04687dc9e')
-  'Logic App Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '515c2055-d9d4-4321-b1b9-bd0c9a0f79fe')
   'Managed Application Contributor Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')
   'Managed Application Operator Role': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')
   'Managed Applications Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')
-  'Microsoft Sentinel Automation Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f4c81013-99ee-4d62-a7ee-b3f1f648599a')
-  'Microsoft Sentinel Playbook Operator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '51d6186e-6489-4900-b93f-92e23144cca5')
   'Monitoring Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')
   'Monitoring Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
   Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
@@ -40,26 +51,22 @@ var builtInRoleNames = {
   'Resource Policy Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')
   'Role Based Access Control Administrator (Preview)': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')
   'User Access Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')
-  'Web Plan Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')
-  'Website Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
 }
 
-var appName = split(resourceId, '/')[indexOf(split(resourceId, '/'), 'sites') + 1]
-
-resource app 'Microsoft.Web/sites@2020-12-01' existing = {
-  name: appName
-  resource slot 'slots' existing = {
-    name: last(split(resourceId, '/'))!
-  }
+resource wcfRelay 'Microsoft.Relay/namespaces/wcfRelays@2021-11-01' existing = {
+  name: '${split(resourceId, '/')[8]}/${split(resourceId, '/')[10]}'
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = [for principalId in principalIds: {
-  name: guid(app::slot.id, principalId, roleDefinitionIdOrName)
+resource roleAssigment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  name: guid(wcfRelay.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName
     principalId: principalId
     principalType: !empty(principalType) ? any(principalType) : null
+    condition: !empty(condition) ? condition : null
+    conditionVersion: !empty(conditionVersion) && !empty(condition) ? conditionVersion : null
+    delegatedManagedIdentityResourceId: !empty(delegatedManagedIdentityResourceId) ? delegatedManagedIdentityResourceId : null
   }
-  scope: app::slot
+  scope: wcfRelay
 }]

--- a/modules/relay/namespaces/wcf-relays/README.md
+++ b/modules/relay/namespaces/wcf-relays/README.md
@@ -1,0 +1,118 @@
+# WCF Relay `[Microsoft.Relay/namespaces/wcfRelays]`
+
+This module deploys a wcf relay resource.
+
+## Navigation
+
+- [Resource types](#Resource-types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
+| `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
+| `Microsoft.Relay/namespaces/wcfRelays` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/wcfRelays) |
+| `Microsoft.Relay/namespaces/wcfRelays/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/wcfRelays/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Allowed Values | Description |
+| :-- | :-- | :-- | :-- |
+| `name` | string |  | Name of the WCF Relay. |
+| `relayType` | string | `[Http, NetTcp]` | Type of WCF Relay. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `namespaceName` | string | The name of the parent Relay Namespace for the WCF Relay. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `authorizationRules` | _[authorizationRules](authorization-rules/README.md)_ array | `[System.Management.Automation.OrderedHashtable, System.Management.Automation.OrderedHashtable, System.Management.Automation.OrderedHashtable]` |  | Authorization Rules for the WCF Relay. |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `requiresClientAuthorization` | bool | `True` |  | A value indicating if this relay requires client authorization. |
+| `requiresTransportSecurity` | bool | `True` |  | A value indicating if this relay requires transport security. |
+| `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+| `userMetadata` | string | `''` |  | User-defined string data for the WCF Relay. |
+
+
+### Parameter Usage: `roleAssignments`
+
+Create a role assignment for the given resource. If you want to assign a service principal / managed identity that is created in the same deployment, make sure to also specify the `'principalType'` parameter and set it to `'ServicePrincipal'`. This will ensure the role assignment waits for the principal's propagation in Azure.
+
+<details>
+
+<summary>Parameter JSON format</summary>
+
+```json
+"roleAssignments": {
+    "value": [
+        {
+            "roleDefinitionIdOrName": "Reader",
+            "description": "Reader Role Assignment",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012", // object 1
+                "78945612-1234-1234-1234-123456789012" // object 2
+            ]
+        },
+        {
+            "roleDefinitionIdOrName": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+            "principalIds": [
+                "12345678-1234-1234-1234-123456789012" // object 1
+            ],
+            "principalType": "ServicePrincipal"
+        }
+    ]
+}
+```
+
+</details>
+
+<details>
+
+<summary>Bicep format</summary>
+
+```bicep
+roleAssignments: [
+    {
+        roleDefinitionIdOrName: 'Reader'
+        description: 'Reader Role Assignment'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+            '78945612-1234-1234-1234-123456789012' // object 2
+        ]
+    }
+    {
+        roleDefinitionIdOrName: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'
+        principalIds: [
+            '12345678-1234-1234-1234-123456789012' // object 1
+        ]
+        principalType: 'ServicePrincipal'
+    }
+]
+```
+
+</details>
+<p>
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the deployed wcf relay. |
+| `resourceGroupName` | string | The resource group of the deployed wcf relay. |
+| `resourceId` | string | The resource ID of the deployed wcf relay. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/wcf-relays/authorization-rules/README.md
+++ b/modules/relay/namespaces/wcf-relays/authorization-rules/README.md
@@ -1,0 +1,51 @@
+# WCF Relay Authorization Rules `[Microsoft.Relay/namespaces/wcfRelays/authorizationRules]`
+
+This module deploys authorization rules for a wcf relay.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Relay/namespaces/wcfRelays/authorizationRules` | [2021-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Relay/2021-11-01/namespaces/wcfRelays/authorizationRules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the relay namepace wcf relay. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `namespaceName` | string | The name of the parent Relay Namespace. Required if the template is used in a standalone deployment. |
+| `wcfRelayName` | string | The name of the parent Relay Namespace WCF Relay. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Allowed Values | Description |
+| :-- | :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `rights` | array | `[]` | `[Listen, Manage, Send]` | The rights associated with the rule. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the authorization rule. |
+| `resourceGroupName` | string | The name of the Resource Group the authorization rule was created in. |
+| `resourceId` | string | The Resource ID of the authorization rule. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/relay/namespaces/wcf-relays/authorization-rules/main.bicep
+++ b/modules/relay/namespaces/wcf-relays/authorization-rules/main.bicep
@@ -1,0 +1,56 @@
+@description('Required. The name of the relay namepace wcf relay.')
+param name string
+
+@description('Conditional. The name of the parent Relay Namespace. Required if the template is used in a standalone deployment.')
+param namespaceName string
+
+@description('Conditional. The name of the parent Relay Namespace WCF Relay. Required if the template is used in a standalone deployment.')
+param wcfRelayName string
+
+@description('Optional. The rights associated with the rule.')
+@allowed([
+  'Listen'
+  'Manage'
+  'Send'
+])
+param rights array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+
+  resource wcfRelay 'wcfRelays@2021-11-01' existing = {
+    name: wcfRelayName
+  }
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/wcfRelays/authorizationRules@2021-11-01' = {
+  name: name
+  parent: namespace::wcfRelay
+  properties: {
+    rights: rights
+  }
+}
+
+@description('The name of the authorization rule.')
+output name string = authorizationRule.name
+
+@description('The Resource ID of the authorization rule.')
+output resourceId string = authorizationRule.id
+
+@description('The name of the Resource Group the authorization rule was created in.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/wcf-relays/authorization-rules/metadata.json
+++ b/modules/relay/namespaces/wcf-relays/authorization-rules/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "WCF Relay Authorization Rules",
+  "summary": "This module deploys authorization rules for a wcf relay.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/wcf-relays/authorization-rules/version.json
+++ b/modules/relay/namespaces/wcf-relays/authorization-rules/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/relay/namespaces/wcf-relays/main.bicep
+++ b/modules/relay/namespaces/wcf-relays/main.bicep
@@ -1,0 +1,134 @@
+@description('Conditional. The name of the parent Relay Namespace for the WCF Relay. Required if the template is used in a standalone deployment.')
+@minLength(6)
+@maxLength(50)
+param namespaceName string
+
+@description('Required. Name of the WCF Relay.')
+@minLength(6)
+@maxLength(50)
+param name string
+
+@allowed([
+  'Http'
+  'NetTcp'
+])
+@description('Required. Type of WCF Relay.')
+param relayType string
+
+@description('Optional. A value indicating if this relay requires client authorization.')
+param requiresClientAuthorization bool = true
+
+@description('Optional. A value indicating if this relay requires transport security.')
+param requiresTransportSecurity bool = true
+
+@description('Optional. User-defined string data for the WCF Relay.')
+param userMetadata string = ''
+
+@description('Optional. Authorization Rules for the WCF Relay.')
+param authorizationRules array = [
+  {
+    name: 'RootManageSharedAccessKey'
+    rights: [
+      'Listen'
+      'Manage'
+      'Send'
+    ]
+  }
+  {
+    name: 'defaultListener'
+    rights: [
+      'Listen'
+    ]
+  }
+  {
+    name: 'defaultSender'
+    rights: [
+      'Send'
+    ]
+  }
+]
+
+@allowed([
+  ''
+  'CanNotDelete'
+  'ReadOnly'
+])
+@description('Optional. Specify the type of lock.')
+param lock string = ''
+
+@description('Optional. Array of role assignment objects that contain the \'roleDefinitionIdOrName\' and \'principalId\' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
+param roleAssignments array = []
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+var enableReferencedModulesTelemetry = false
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: namespaceName
+}
+
+resource wcfRelay 'Microsoft.Relay/namespaces/wcfRelays@2021-11-01' = {
+  name: name
+  parent: namespace
+  properties: {
+    relayType: relayType
+    requiresClientAuthorization: requiresClientAuthorization
+    requiresTransportSecurity: requiresTransportSecurity
+    userMetadata: !empty(userMetadata) ? userMetadata : null
+  }
+}
+
+module wcfRelay_authorizationRules 'authorization-rules/main.bicep' = [for (authorizationRule, index) in authorizationRules: {
+  name: '${deployment().name}-AuthRule-${index}'
+  params: {
+    namespaceName: namespaceName
+    wcfRelayName: wcfRelay.name
+    name: authorizationRule.name
+    rights: contains(authorizationRule, 'rights') ? authorizationRule.rights : []
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+resource wcfRelay_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock)) {
+  name: '${wcfRelay.name}-${lock}-lock'
+  properties: {
+    level: any(lock)
+    notes: lock == 'CanNotDelete' ? 'Cannot delete resource or child resources.' : 'Cannot modify the resource or child resources.'
+  }
+  scope: wcfRelay
+}
+
+module wcfRelay_roleAssignments '.bicep/nested_roleAssignments.bicep' = [for (roleAssignment, index) in roleAssignments: {
+  name: '${deployment().name}-Rbac-${index}'
+  params: {
+    description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
+    principalIds: roleAssignment.principalIds
+    principalType: contains(roleAssignment, 'principalType') ? roleAssignment.principalType : ''
+    roleDefinitionIdOrName: roleAssignment.roleDefinitionIdOrName
+    condition: contains(roleAssignment, 'condition') ? roleAssignment.condition : ''
+    delegatedManagedIdentityResourceId: contains(roleAssignment, 'delegatedManagedIdentityResourceId') ? roleAssignment.delegatedManagedIdentityResourceId : ''
+    resourceId: wcfRelay.id
+  }
+}]
+
+@description('The name of the deployed wcf relay.')
+output name string = wcfRelay.name
+
+@description('The resource ID of the deployed wcf relay.')
+output resourceId string = wcfRelay.id
+
+@description('The resource group of the deployed wcf relay.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/relay/namespaces/wcf-relays/metadata.json
+++ b/modules/relay/namespaces/wcf-relays/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "WCF Relay",
+  "summary": "This module deploys a wcf relay resource.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/relay/namespaces/wcf-relays/version.json
+++ b/modules/relay/namespaces/wcf-relays/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/web/sites/.bicep/nested_roleAssignments.bicep
+++ b/modules/web/sites/.bicep/nested_roleAssignments.bicep
@@ -34,6 +34,7 @@ param conditionVersion string = '2.0'
 param delegatedManagedIdentityResourceId string = ''
 
 var builtInRoleNames = {
+  'App Compliance Automation Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f37683f-2463-46b6-9ce7-9b788b988ba2')
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   'Log Analytics Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')
   'Log Analytics Reader': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')

--- a/modules/web/sites/.test/functionAppCommon/dependencies.bicep
+++ b/modules/web/sites/.test/functionAppCommon/dependencies.bicep
@@ -16,6 +16,12 @@ param storageAccountName string
 @description('Required. The name of the Application Insights instance to create.')
 param applicationInsightsName string
 
+@description('Required. The name of the Relay Namespace to create.')
+param namespaceName string
+
+@description('Required. The name of the Hybrid Connection to create.')
+param hybridConnectionName string
+
 var addressPrefix = '10.0.0.0/16'
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = {
@@ -89,6 +95,34 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     properties: {}
 }
 
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' = {
+    name: namespaceName
+    location: location
+    sku: {
+        name: 'Standard'
+    }
+    properties: {}
+}
+
+resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' = {
+    name: hybridConnectionName
+    parent: namespace
+    properties: {
+        requiresClientAuthorization: true
+        userMetadata: '[{"key":"endpoint","value":"db-server.constoso.com:1433"}]'
+    }
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@2021-11-01' = {
+    name: 'defaultSender'
+    parent: hybridConnection
+    properties: {
+        rights: [
+            'Send'
+        ]
+    }
+}
+
 @description('The resource ID of the created Virtual Network Subnet.')
 output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 
@@ -109,3 +143,6 @@ output applicationInsightsResourceId string = applicationInsights.id
 
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSZoneResourceId string = privateDNSZone.id
+
+@description('The resource ID of the created Hybrid Connection.')
+output hybridConnectionResourceId string = hybridConnection.id

--- a/modules/web/sites/.test/functionAppCommon/main.test.bicep
+++ b/modules/web/sites/.test/functionAppCommon/main.test.bicep
@@ -37,6 +37,8 @@ module nestedDependencies 'dependencies.bicep' = {
     serverFarmName: 'dep-<<namePrefix>>-sf-${serviceShort}'
     storageAccountName: 'dep<<namePrefix>>st${serviceShort}'
     applicationInsightsName: 'dep-<<namePrefix>>-appi-${serviceShort}'
+    namespaceName: 'dep-<<namePrefix>>-ns-${serviceShort}'
+    hybridConnectionName: 'dep-<<namePrefix>>-hc-${serviceShort}'
   }
 }
 
@@ -176,5 +178,11 @@ module testDeployment '../../main.bicep' = {
     userAssignedIdentities: {
       '${nestedDependencies.outputs.managedIdentityResourceId}': {}
     }
+    hybridConnectionRelays: [
+      {
+        resourceId: nestedDependencies.outputs.hybridConnectionResourceId
+        sendKeyName: 'defaultSender'
+      }
+    ]
   }
 }

--- a/modules/web/sites/.test/webAppCommon/main.test.bicep
+++ b/modules/web/sites/.test/webAppCommon/main.test.bicep
@@ -35,6 +35,8 @@ module nestedDependencies 'dependencies.bicep' = {
     virtualNetworkName: 'dep-<<namePrefix>>-vnet-${serviceShort}'
     managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
     serverFarmName: 'dep-<<namePrefix>>-sf-${serviceShort}'
+    namespaceName: 'dep-<<namePrefix>>-ns-${serviceShort}'
+    hybridConnectionName: 'dep-<<namePrefix>>-hc-${serviceShort}'
   }
 }
 
@@ -55,7 +57,6 @@ module diagnosticDependencies '../../../../.shared/.templates/diagnostic.depende
 // ============== //
 // Test Execution //
 // ============== //
-
 module testDeployment '../../main.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
@@ -111,6 +112,12 @@ module testDeployment '../../main.bicep' = {
             }
           ]
         }
+        hybridConnectionRelays: [
+          {
+            resourceId: nestedDependencies.outputs.hybridConnectionResourceId
+            sendKeyName: 'defaultSender'
+          }
+        ]
       }
       {
         name: 'slot2'
@@ -161,6 +168,12 @@ module testDeployment '../../main.bicep' = {
         name: 'scm'
       }
 
+    ]
+    hybridConnectionRelays: [
+      {
+        resourceId: nestedDependencies.outputs.hybridConnectionResourceId
+        sendKeyName: 'defaultSender'
+      }
     ]
   }
 }

--- a/modules/web/sites/README.md
+++ b/modules/web/sites/README.md
@@ -24,8 +24,10 @@ This module deploys a web or function app.
 | `Microsoft.Web/sites` | [2021-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2021-03-01/sites) |
 | `Microsoft.Web/sites/basicPublishingCredentialsPolicies` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/sites) |
 | `Microsoft.Web/sites/config` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/sites) |
+| `Microsoft.Web/sites/hybridConnectionNamespaces/relays` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/hybridConnectionNamespaces/relays) |
 | `Microsoft.Web/sites/slots` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/slots) |
 | `Microsoft.Web/sites/slots/config` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/sites) |
+| `Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/slots/hybridConnectionNamespaces/relays) |
 
 ## Parameters
 
@@ -66,6 +68,7 @@ This module deploys a web or function app.
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `hostNameSslStates` | array | `[]` |  | Hostname SSL states are used to manage the SSL bindings for app's hostnames. |
 | `httpsOnly` | bool | `True` |  | Configures a site to accept only HTTPS requests. Issues redirect for HTTP requests. |
+| `hybridConnectionRelays` | array | `[]` |  | Names of hybrid connection relays to connect app with. |
 | `hyperV` | bool | `False` |  | Hyper-V sandbox. |
 | `keyVaultAccessIdentityResourceId` | string | `''` |  | The resource ID of the assigned identity to be used to access a key vault with. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all Resources. |
@@ -536,6 +539,12 @@ module sites './web/sites/main.bicep' = {
     diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    hybridConnectionRelays: [
+      {
+        resourceId: '<resourceId>'
+        sendKeyName: 'defaultSender'
+      }
+    ]
     keyVaultAccessIdentityResourceId: '<keyVaultAccessIdentityResourceId>'
     lock: 'CanNotDelete'
     privateEndpoints: [
@@ -692,6 +701,14 @@ module sites './web/sites/main.bicep' = {
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },
+    "hybridConnectionRelays": {
+      "value": [
+        {
+          "resourceId": "<resourceId>",
+          "sendKeyName": "defaultSender"
+        }
+      ]
+    },
     "keyVaultAccessIdentityResourceId": {
       "value": "<keyVaultAccessIdentityResourceId>"
     },
@@ -844,6 +861,12 @@ module sites './web/sites/main.bicep' = {
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     httpsOnly: true
+    hybridConnectionRelays: [
+      {
+        resourceId: '<resourceId>'
+        sendKeyName: 'defaultSender'
+      }
+    ]
     privateEndpoints: [
       {
         privateDnsZoneGroup: {
@@ -884,6 +907,12 @@ module sites './web/sites/main.bicep' = {
         diagnosticLogsRetentionInDays: 7
         diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
         diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
+        hybridConnectionRelays: [
+          {
+            resourceId: '<resourceId>'
+            sendKeyName: 'defaultSender'
+          }
+        ]
         name: 'slot1'
         privateEndpoints: [
           {
@@ -985,6 +1014,14 @@ module sites './web/sites/main.bicep' = {
     "httpsOnly": {
       "value": true
     },
+    "hybridConnectionRelays": {
+      "value": [
+        {
+          "resourceId": "<resourceId>",
+          "sendKeyName": "defaultSender"
+        }
+      ]
+    },
     "privateEndpoints": {
       "value": [
         {
@@ -1032,6 +1069,12 @@ module sites './web/sites/main.bicep' = {
           "diagnosticLogsRetentionInDays": 7,
           "diagnosticStorageAccountId": "<diagnosticStorageAccountId>",
           "diagnosticWorkspaceId": "<diagnosticWorkspaceId>",
+          "hybridConnectionRelays": [
+            {
+              "resourceId": "<resourceId>",
+              "sendKeyName": "defaultSender"
+            }
+          ],
           "name": "slot1",
           "privateEndpoints": [
             {

--- a/modules/web/sites/config--appsettings/main.bicep
+++ b/modules/web/sites/config--appsettings/main.bicep
@@ -52,7 +52,7 @@ resource app 'Microsoft.Web/sites@2022-03-01' existing = {
   name: appName
 }
 
-resource appInsight 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
+resource appInsight 'microsoft.insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
   name: last(split(appInsightResourceId, '/'))!
   scope: resourceGroup(split(appInsightResourceId, '/')[2], split(appInsightResourceId, '/')[4])
 }

--- a/modules/web/sites/hybrid-connection-namespaces/relays/README.md
+++ b/modules/web/sites/hybrid-connection-namespaces/relays/README.md
@@ -1,0 +1,49 @@
+# Web/Function Apps Hybrid Connection Relay `[Microsoft.Web/sites/hybridConnectionNamespaces/relays]`
+
+This module configures a web or function app with a hybrid connection relay.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Web/sites/hybridConnectionNamespaces/relays` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/hybridConnectionNamespaces/relays) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceId` | string | The resource id of the resource. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `webAppName` | string | The name of the parent web site. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `location` | string | `[resourceGroup().location]` | Location for all Resources. |
+| `sendKeyName` | string | `'defaultSender'` | Name of the authorization rule send key to use. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The name of the resource group the resource was deployed into. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/web/sites/hybrid-connection-namespaces/relays/main.bicep
+++ b/modules/web/sites/hybrid-connection-namespaces/relays/main.bicep
@@ -1,0 +1,60 @@
+@description('Required. The resource id of the resource.')
+param resourceId string
+
+@description('Conditional. The name of the parent web site. Required if the template is used in a standalone deployment.')
+param webAppName string
+
+@description('Optional. Name of the authorization rule send key to use.')
+param sendKeyName string = 'defaultSender'
+
+@description('Optional. Location for all Resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+var splitResourceId = split(resourceId, '/')
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: splitResourceId[8]
+  scope: resourceGroup(splitResourceId[2], splitResourceId[4])
+}
+
+resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' existing = {
+  name: splitResourceId[10]
+  parent: namespace
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@2021-11-01' existing = {
+  name: sendKeyName
+  parent: hybridConnection
+}
+
+resource hybridConnectionRelay 'Microsoft.Web/sites/hybridConnectionNamespaces/relays@2022-03-01' = {
+  name: '${webAppName}/${splitResourceId[8]}/${splitResourceId[10]}'
+  properties: {
+    serviceBusNamespace: splitResourceId[8]
+    serviceBusSuffix: split(substring(namespace.properties.serviceBusEndpoint, indexOf(namespace.properties.serviceBusEndpoint, '.servicebus')), ':')[0]
+    relayName: splitResourceId[10]
+    relayArmUri: hybridConnection.id
+    hostname: split(json(hybridConnection.properties.userMetadata)[0].value, ':')[0]
+    port: int(split(json(hybridConnection.properties.userMetadata)[0].value, ':')[1])
+    sendKeyName: authorizationRule.name
+    sendKeyValue: authorizationRule.listKeys().primaryKey
+  }
+}
+
+@description('The name of the resource group the resource was deployed into.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/web/sites/hybrid-connection-namespaces/relays/metadata.json
+++ b/modules/web/sites/hybrid-connection-namespaces/relays/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Web/Function Apps Hybrid Connection Relay",
+  "summary": "This module configures a web or function app with a hybrid connection relay.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/web/sites/hybrid-connection-namespaces/relays/version.json
+++ b/modules/web/sites/hybrid-connection-namespaces/relays/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/web/sites/main.bicep
+++ b/modules/web/sites/main.bicep
@@ -195,6 +195,9 @@ param redundancyMode string = 'None'
 @description('Optional. The site publishing credential policy names which are associated with the sites.')
 param basicPublishingCredentialsPolicies array = []
 
+@description('Optional. Names of hybrid connection relays to connect app with.')
+param hybridConnectionRelays array = []
+
 // =========== //
 // Variables   //
 // =========== //
@@ -356,6 +359,7 @@ module app_slots 'slots/main.bicep' = [for (slot, index) in slots: {
     vnetContentShareEnabled: contains(slot, 'vnetContentShareEnabled') ? slot.vnetContentShareEnabled : false
     vnetImagePullEnabled: contains(slot, 'vnetImagePullEnabled') ? slot.vnetImagePullEnabled : false
     vnetRouteAllEnabled: contains(slot, 'vnetRouteAllEnabled') ? slot.vnetRouteAllEnabled : false
+    hybridConnectionRelays: contains(slot, 'hybridConnectionRelays') ? slot.hybridConnectionRelays : []
   }
 }]
 
@@ -364,6 +368,16 @@ module app_basicPublishingCredentialsPolicies 'basic-publishing-credentials-poli
   params: {
     webAppName: app.name
     name: basicPublishingCredentialsPolicy.name
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+module app_hybridConnectionRelays 'hybrid-connection-namespaces/relays/main.bicep' = [for (hybridConnectionRelay, index) in hybridConnectionRelays: {
+  name: '${uniqueString(deployment().name, location)}-HybridConnectionRelay-${index}'
+  params: {
+    resourceId: hybridConnectionRelay.resourceId
+    webAppName: app.name
+    sendKeyName: contains(hybridConnectionRelay, 'sendKeyName') ? hybridConnectionRelay.sendKeyName : null
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }]

--- a/modules/web/sites/slots/README.md
+++ b/modules/web/sites/slots/README.md
@@ -22,6 +22,7 @@ This module deploys a web or function app.
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints/privateDnsZoneGroups) |
 | `Microsoft.Web/sites/slots` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/slots) |
 | `Microsoft.Web/sites/slots/config` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/sites) |
+| `Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/slots/hybridConnectionNamespaces/relays) |
 
 ## Parameters
 
@@ -66,6 +67,7 @@ This module deploys a web or function app.
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via the Customer Usage Attribution ID (GUID). |
 | `hostNameSslStates` | array | `[]` |  | Hostname SSL states are used to manage the SSL bindings for app's hostnames. |
 | `httpsOnly` | bool | `True` |  | Configures a slot to accept only HTTPS requests. Issues redirect for HTTP requests. |
+| `hybridConnectionRelays` | array | `[]` |  | Names of hybrid connection relays to connect app with. |
 | `hyperV` | bool | `False` |  | Hyper-V sandbox. |
 | `keyVaultAccessIdentityResourceId` | string | `''` |  | The resource ID of the assigned identity to be used to access a key vault with. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all Resources. |

--- a/modules/web/sites/slots/config--appsettings/main.bicep
+++ b/modules/web/sites/slots/config--appsettings/main.bicep
@@ -59,7 +59,7 @@ resource app 'Microsoft.Web/sites@2022-03-01' existing = {
   }
 }
 
-resource appInsight 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
+resource appInsight 'microsoft.insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
   name: last(split(appInsightResourceId, '/'))!
   scope: resourceGroup(split(appInsightResourceId, '/')[2], split(appInsightResourceId, '/')[4])
 }

--- a/modules/web/sites/slots/hybrid-connection-namespaces/relays/README.md
+++ b/modules/web/sites/slots/hybrid-connection-namespaces/relays/README.md
@@ -1,0 +1,50 @@
+# Web/Function Apps Hybrid Connection Relay `[Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays]`
+
+This module configures a web or function app with a hybrid connection relay.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2022-03-01/sites/slots/hybridConnectionNamespaces/relays) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceId` | string | The resource id of the resource. |
+| `slotName` | string | Slot name to be configured. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `webAppName` | string | The name of the parent web site. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `location` | string | `[resourceGroup().location]` | Location for all Resources. |
+| `sendKeyName` | string | `'defaultSender'` | Name of the authorization rule send key to use. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `resourceGroupName` | string | The name of the resource group the resource was deployed into. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/web/sites/slots/hybrid-connection-namespaces/relays/main.bicep
+++ b/modules/web/sites/slots/hybrid-connection-namespaces/relays/main.bicep
@@ -1,0 +1,63 @@
+@description('Required. The resource id of the resource.')
+param resourceId string
+
+@description('Required. Slot name to be configured.')
+param slotName string
+
+@description('Conditional. The name of the parent web site. Required if the template is used in a standalone deployment.')
+param webAppName string
+
+@description('Optional. Name of the authorization rule send key to use.')
+param sendKeyName string = 'defaultSender'
+
+@description('Optional. Location for all Resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+var splitResourceId = split(resourceId, '/')
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource namespace 'Microsoft.Relay/namespaces@2021-11-01' existing = {
+  name: splitResourceId[8]
+  scope: resourceGroup(splitResourceId[2], splitResourceId[4])
+}
+
+resource hybridConnection 'Microsoft.Relay/namespaces/hybridConnections@2021-11-01' existing = {
+  name: splitResourceId[10]
+  parent: namespace
+}
+
+resource authorizationRule 'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@2021-11-01' existing = {
+  name: sendKeyName
+  parent: hybridConnection
+}
+
+resource hybridConnectionRelay 'Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays@2022-03-01' = {
+  name: '${webAppName}/${slotName}/${splitResourceId[8]}/${splitResourceId[10]}'
+  properties: {
+    serviceBusNamespace: splitResourceId[8]
+    serviceBusSuffix: split(substring(namespace.properties.serviceBusEndpoint, indexOf(namespace.properties.serviceBusEndpoint, '.servicebus')), ':')[0]
+    relayName: splitResourceId[10]
+    relayArmUri: hybridConnection.id
+    hostname: split(json(hybridConnection.properties.userMetadata)[0].value, ':')[0]
+    port: int(split(json(hybridConnection.properties.userMetadata)[0].value, ':')[1])
+    sendKeyName: authorizationRule.name
+    sendKeyValue: authorizationRule.listKeys().primaryKey
+  }
+}
+
+@description('The name of the resource group the resource was deployed into.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/web/sites/slots/hybrid-connection-namespaces/relays/metadata.json
+++ b/modules/web/sites/slots/hybrid-connection-namespaces/relays/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Web/Function Apps Hybrid Connection Relay",
+  "summary": "This module configures a web or function app with a hybrid connection relay.",
+  "owner": "Azure/module-maintainers"
+}

--- a/modules/web/sites/slots/hybrid-connection-namespaces/relays/version.json
+++ b/modules/web/sites/slots/hybrid-connection-namespaces/relays/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/modules/web/sites/slots/main.bicep
+++ b/modules/web/sites/slots/main.bicep
@@ -207,6 +207,9 @@ param vnetImagePullEnabled bool = false
 @description('Optional. Virtual Network Route All enabled. This causes all outbound traffic to have Virtual Network Security Groups and User Defined Routes applied.')
 param vnetRouteAllEnabled bool = false
 
+@description('Optional. Names of hybrid connection relays to connect app with.')
+param hybridConnectionRelays array = []
+
 // =========== //
 // Variables   //
 // =========== //
@@ -320,6 +323,17 @@ module slot_authsettingsv2 'config--authsettingsv2/main.bicep' = if (!empty(auth
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }
+
+module slot_hybridConnectionRelays 'hybrid-connection-namespaces/relays/main.bicep' = [for (hybridConnectionRelay, index) in hybridConnectionRelays: {
+  name: '${uniqueString(deployment().name, location)}-Slot-HybridConnectionRelay-${index}'
+  params: {
+    resourceId: hybridConnectionRelay.resourceId
+    webAppName: app.name
+    slotName: slot.name
+    sendKeyName: contains(hybridConnectionRelay, 'sendKeyName') ? hybridConnectionRelay.sendKeyName : null
+    enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
 
 resource slot_lock 'Microsoft.Authorization/locks@2017-04-01' = if (!empty(lock)) {
   name: '${slot.name}-${lock}-lock'


### PR DESCRIPTION
# Description

Resolves #3303

Added support for creating Azure Relay Namespaces with Hybrid Connections or WCF Relays.
Added support to connect Azure Web and Function apps to Hybrid Connections.

## Pipeline references

| Pipeline | Status |
| - | - |
| Microsoft.Relays | [![Relay - Namespaces](https://github.com/jeremytbrun/ResourceModules/actions/workflows/ms.relay.namespaces.yml/badge.svg)](https://github.com/jeremytbrun/ResourceModules/actions/workflows/ms.relay.namespaces.yml) |
| Microsoft.Web | [![Web - Sites](https://github.com/jeremytbrun/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg)](https://github.com/jeremytbrun/ResourceModules/actions/workflows/ms.web.sites.yml) |

# Type of Change

New feature (non-breaking change which adds functionality)

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
