### PR TITLE
[Fixes] Align input child parameter objects to resourceType casing

### DIFF
--- a/modules/api-management/service/README.md
+++ b/modules/api-management/service/README.md
@@ -76,7 +76,7 @@ This module deploys an API management service.
 | `newGuidValue` | string | `[newGuid()]` |  | Necessary to create a new GUID. |
 | `notificationSenderEmail` | string | `'apimgmt-noreply@mail.windowsazure.com'` |  | The notification sender email address for the service. |
 | `policies` | _[policies](policies/README.md)_ array | `[]` |  | Policies. |
-| `portalSettings` | _[portalSettings](portal-settings/README.md)_ array | `[]` |  | Portal settings. |
+| `portalsettings` | _[portalsettings](portalsettings/README.md)_ array | `[]` |  | Portal settings. |
 | `products` | _[products](products/README.md)_ array | `[]` |  | Products. |
 | `restore` | bool | `False` |  | Undelete API Management Service if it was previously soft-deleted. If this flag is specified and set to True all other properties will be ignored. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |

--- a/modules/api-management/service/main.bicep
+++ b/modules/api-management/service/main.bicep
@@ -154,7 +154,7 @@ param namedValues array = []
 param policies array = []
 
 @description('Optional. Portal settings.')
-param portalSettings array = []
+param portalsettings array = []
 
 @description('Optional. Products.')
 param products array = []
@@ -392,12 +392,12 @@ module service_namedValues 'named-values/main.bicep' = [for (namedValue, index) 
   }
 }]
 
-module service_portalSettings 'portalsettings/main.bicep' = [for (portalSetting, index) in portalSettings: {
+module service_portalsettings 'portalsettings/main.bicep' = [for (portalsetting, index) in portalsettings: {
   name: '${uniqueString(deployment().name, location)}-Apim-PortalSetting-${index}'
   params: {
     apiManagementServiceName: service.name
-    name: portalSetting.name
-    properties: contains(portalSetting, 'properties') ? portalSetting.properties : {}
+    name: portalsetting.name
+    properties: contains(portalsetting, 'properties') ? portalsetting.properties : {}
     enableDefaultTelemetry: enableReferencedModulesTelemetry
   }
 }]

--- a/modules/event-grid/topics/metadata.json
+++ b/modules/event-grid/topics/metadata.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
-  "name": "Event Grid Topics",
-  "summary": "This module deploys an event grid topic.",
-  "owner": "Azure/module-maintainers"
+    "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+    "name": "Event Grid Topics",
+    "summary": "This module deploys an Event Grid Topic.",
+    "owner": "Azure/module-maintainers"
 }

--- a/modules/event-hub/namespaces/.test/common/main.test.bicep
+++ b/modules/event-hub/namespaces/.test/common/main.test.bicep
@@ -88,7 +88,7 @@ module testDeployment '../../main.bicep' = {
     diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
-    eventHubs: [
+    eventhubs: [
       {
         name: '${namePrefix}-az-evh-x-001'
       }
@@ -120,7 +120,7 @@ module testDeployment '../../main.bicep' = {
         captureDescriptionIntervalInSeconds: 300
         captureDescriptionSizeLimitInBytes: 314572800
         captureDescriptionSkipEmptyArchives: true
-        consumerGroups: [
+        consumergroups: [
           {
             name: 'custom'
             userMetadata: 'customMetadata'

--- a/modules/event-hub/namespaces/README.md
+++ b/modules/event-hub/namespaces/README.md
@@ -50,7 +50,7 @@ This module deploys an event hub namespace.
 | `diagnosticWorkspaceId` | string | `''` |  | Resource ID of the diagnostic log analytics workspace. |
 | `disasterRecoveryConfig` | object | `{object}` |  | The disaster recovery config for this namespace. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
-| `eventHubs` | _[eventHubs](event-hubs/README.md)_ array | `[]` |  | The event hubs to deploy into this namespace. |
+| `eventhubs` | _[eventhubs](eventhubs/README.md)_ array | `[]` |  | The event hubs to deploy into this namespace. |
 | `isAutoInflateEnabled` | bool | `False` |  | Switch to enable the Auto Inflate feature of Event Hub. |
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
@@ -360,7 +360,7 @@ module namespaces './event-hub/namespaces/main.bicep' = {
     diagnosticStorageAccountId: '<diagnosticStorageAccountId>'
     diagnosticWorkspaceId: '<diagnosticWorkspaceId>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
-    eventHubs: [
+    eventhubs: [
       {
         name: '<<namePrefix>>-az-evh-x-001'
       }
@@ -391,7 +391,7 @@ module namespaces './event-hub/namespaces/main.bicep' = {
         captureDescriptionIntervalInSeconds: 300
         captureDescriptionSizeLimitInBytes: 314572800
         captureDescriptionSkipEmptyArchives: true
-        consumerGroups: [
+        consumergroups: [
           {
             name: 'custom'
             userMetadata: 'customMetadata'
@@ -519,7 +519,7 @@ module namespaces './event-hub/namespaces/main.bicep' = {
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },
-    "eventHubs": {
+    "eventhubs": {
       "value": [
         {
           "name": "<<namePrefix>>-az-evh-x-001"
@@ -551,7 +551,7 @@ module namespaces './event-hub/namespaces/main.bicep' = {
           "captureDescriptionIntervalInSeconds": 300,
           "captureDescriptionSizeLimitInBytes": 314572800,
           "captureDescriptionSkipEmptyArchives": true,
-          "consumerGroups": [
+          "consumergroups": [
             {
               "name": "custom",
               "userMetadata": "customMetadata"

--- a/modules/event-hub/namespaces/eventhubs/README.md
+++ b/modules/event-hub/namespaces/eventhubs/README.md
@@ -47,7 +47,7 @@ This module deploys an Event Hub.
 | `captureDescriptionIntervalInSeconds` | int | `300` |  | The time window allows you to set the frequency with which the capture to Azure Blobs will happen. |
 | `captureDescriptionSizeLimitInBytes` | int | `314572800` |  | The size window defines the amount of data built up in your Event Hub before an capture operation. |
 | `captureDescriptionSkipEmptyArchives` | bool | `False` |  | A value that indicates whether to Skip Empty Archives. |
-| `consumerGroups` | _[consumerGroups](consumer-groups/README.md)_ array | `[System.Management.Automation.OrderedHashtable]` |  | The consumer groups to create in this event hub instance. |
+| `consumergroups` | _[consumergroups](consumergroups/README.md)_ array | `[System.Management.Automation.OrderedHashtable]` |  | The consumer groups to create in this event hub instance. |
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
 | `messageRetentionInDays` | int | `1` |  | Number of days to retain the events for this Event Hub, value should be 1 to 7 days. |

--- a/modules/event-hub/namespaces/eventhubs/main.bicep
+++ b/modules/event-hub/namespaces/eventhubs/main.bicep
@@ -41,7 +41,7 @@ param partitionCount int = 2
 param status string = 'Active'
 
 @description('Optional. The consumer groups to create in this event hub instance.')
-param consumerGroups array = [
+param consumergroups array = [
   {
     name: '$Default'
   }
@@ -155,7 +155,7 @@ resource eventHub_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(l
   scope: eventHub
 }
 
-module eventHub_consumergroups 'consumergroups/main.bicep' = [for (consumerGroup, index) in consumerGroups: {
+module eventHub_consumergroups 'consumergroups/main.bicep' = [for (consumerGroup, index) in consumergroups: {
   name: '${deployment().name}-ConsumerGroup-${index}'
   params: {
     namespaceName: namespaceName

--- a/modules/event-hub/namespaces/main.bicep
+++ b/modules/event-hub/namespaces/main.bicep
@@ -87,7 +87,7 @@ param tags object = {}
 param enableDefaultTelemetry bool = true
 
 @description('Optional. The event hubs to deploy into this namespace.')
-param eventHubs array = []
+param eventhubs array = []
 
 @description('Optional. The disaster recovery config for this namespace.')
 param disasterRecoveryConfig object = {}
@@ -210,7 +210,7 @@ module eventHubNamespace_disasterRecoveryConfig 'disaster-recovery-configs/main.
   }
 }
 
-module eventHubNamespace_eventHubs 'eventhubs/main.bicep' = [for (eventHub, index) in eventHubs: {
+module eventHubNamespace_eventhubs 'eventhubs/main.bicep' = [for (eventHub, index) in eventhubs: {
   name: '${uniqueString(deployment().name, location)}-EvhbNamespace-EventHub-${index}'
   params: {
     namespaceName: eventHubNamespace.name
@@ -234,7 +234,7 @@ module eventHubNamespace_eventHubs 'eventhubs/main.bicep' = [for (eventHub, inde
     captureDescriptionIntervalInSeconds: contains(eventHub, 'captureDescriptionIntervalInSeconds') ? eventHub.captureDescriptionIntervalInSeconds : 300
     captureDescriptionSizeLimitInBytes: contains(eventHub, 'captureDescriptionSizeLimitInBytes') ? eventHub.captureDescriptionSizeLimitInBytes : 314572800
     captureDescriptionSkipEmptyArchives: contains(eventHub, 'captureDescriptionSkipEmptyArchives') ? eventHub.captureDescriptionSkipEmptyArchives : false
-    consumerGroups: contains(eventHub, 'consumerGroups') ? eventHub.consumerGroups : []
+    consumergroups: contains(eventHub, 'consumergroups') ? eventHub.consumergroups : []
     lock: contains(eventHub, 'lock') ? eventHub.lock : ''
     messageRetentionInDays: contains(eventHub, 'messageRetentionInDays') ? eventHub.messageRetentionInDays : 1
     partitionCount: contains(eventHub, 'partitionCount') ? eventHub.partitionCount : 2

--- a/modules/insights/action-groups/README.md
+++ b/modules/insights/action-groups/README.md
@@ -1,4 +1,4 @@
-# Action Groups `[Microsoft.Insights/actionGroups]`
+# Action Groups `[microsoft.insights/actionGroups]`
 
 This module deploys an Action Group.
 
@@ -15,7 +15,7 @@ This module deploys an Action Group.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Insights/actionGroups` | [2019-06-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2019-06-01/actionGroups) |
+| `microsoft.insights/actionGroups` | [2019-06-01](https://learn.microsoft.com/en-us/azure/templates/microsoft.insights/2019-06-01/actionGroups) |
 
 ## Parameters
 

--- a/modules/insights/private-link-scopes/README.md
+++ b/modules/insights/private-link-scopes/README.md
@@ -1,4 +1,4 @@
-# Azure Monitor Private Link Scopes `[Microsoft.Insights/privateLinkScopes]`
+# Azure Monitor Private Link Scopes `[microsoft.insights/privateLinkScopes]`
 
 This module deploys an Azure Monitor Private Link Scope.
 
@@ -16,7 +16,7 @@ This module deploys an Azure Monitor Private Link Scope.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Insights/privateLinkScopes` | [2019-10-17-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2019-10-17-preview/privateLinkScopes) |
+| `microsoft.insights/privateLinkScopes` | [2019-10-17-preview](https://learn.microsoft.com/en-us/azure/templates/microsoft.insights/2019-10-17-preview/privateLinkScopes) |
 | `Microsoft.Insights/privateLinkScopes/scopedResources` | [2021-07-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-07-01-preview/privateLinkScopes/scopedResources) |
 | `Microsoft.Network/privateEndpoints` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints) |
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-07-01/privateEndpoints/privateDnsZoneGroups) |

--- a/modules/insights/webtests/README.md
+++ b/modules/insights/webtests/README.md
@@ -176,7 +176,7 @@ The following module usage examples are retrieved from the content of the files 
 <summary>via Bicep module</summary>
 
 ```bicep
-module webTests './insights/web-tests/main.bicep' = {
+module webtests './insights/webtests/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-iwtcom'
   params: {
     // Required parameters
@@ -263,7 +263,7 @@ module webTests './insights/web-tests/main.bicep' = {
 <summary>via Bicep module</summary>
 
 ```bicep
-module webTests './insights/web-tests/main.bicep' = {
+module webtests './insights/webtests/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-iwtmin'
   params: {
     // Required parameters


### PR DESCRIPTION
# Description

- Align casing of the input child parameter objects to the corresponding resourceType
  > Example: `eventhubs` input object in the `event-hub/namespace` module must be `eventhubs` and not `eventHubs` since its corresponding resourceType is `Microsoft.EventHub/namespaces/eventhubs`.
  
   This is to allow the readme generator file to retrieve the link to the child module readme documentation and add that to the parent readme

- Update readme files

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
