### PR TITLE
[Fixes] Fixed WhatIf output on databases when nested deploying using server module

### DIFF
--- a/modules/sql/servers/main.bicep
+++ b/modules/sql/servers/main.bicep
@@ -176,7 +176,7 @@ module server_databases 'databases/main.bicep' = [for (database, index) in datab
     diagnosticEventHubAuthorizationRuleId: contains(database, 'diagnosticEventHubAuthorizationRuleId') ? database.diagnosticEventHubAuthorizationRuleId : ''
     diagnosticEventHubName: contains(database, 'diagnosticEventHubName') ? database.diagnosticEventHubName : ''
     isLedgerOn: contains(database, 'isLedgerOn') ? database.isLedgerOn : false
-    location: contains(database, 'location') ? database.location : location
+    location: location
     diagnosticLogCategoriesToEnable: contains(database, 'diagnosticLogCategoriesToEnable') ? database.diagnosticLogCategoriesToEnable : []
     licenseType: contains(database, 'licenseType') ? database.licenseType : ''
     maintenanceConfigurationId: contains(database, 'maintenanceConfigurationId') ? database.maintenanceConfigurationId : ''
@@ -222,7 +222,7 @@ module server_elasticPools 'elastic-pools/main.bicep' = [for (elasticPool, index
     skuTier: contains(elasticPool, 'skuTier') ? elasticPool.skuTier : 'GeneralPurpose'
     zoneRedundant: contains(elasticPool, 'zoneRedundant') ? elasticPool.zoneRedundant : false
     enableDefaultTelemetry: enableReferencedModulesTelemetry
-    location: contains(elasticPool, 'location') ? elasticPool.location : server.location
+    location: location
     tags: contains(elasticPool, 'tags') ? elasticPool.tags : {}
   }
 }]

--- a/modules/sql/servers/main.bicep
+++ b/modules/sql/servers/main.bicep
@@ -176,7 +176,7 @@ module server_databases 'databases/main.bicep' = [for (database, index) in datab
     diagnosticEventHubAuthorizationRuleId: contains(database, 'diagnosticEventHubAuthorizationRuleId') ? database.diagnosticEventHubAuthorizationRuleId : ''
     diagnosticEventHubName: contains(database, 'diagnosticEventHubName') ? database.diagnosticEventHubName : ''
     isLedgerOn: contains(database, 'isLedgerOn') ? database.isLedgerOn : false
-    location: contains(database, 'location') ? database.location : server.location
+    location: contains(database, 'location') ? database.location : location
     diagnosticLogCategoriesToEnable: contains(database, 'diagnosticLogCategoriesToEnable') ? database.diagnosticLogCategoriesToEnable : []
     licenseType: contains(database, 'licenseType') ? database.licenseType : ''
     maintenanceConfigurationId: contains(database, 'maintenanceConfigurationId') ? database.maintenanceConfigurationId : ''


### PR DESCRIPTION
# Description

WhatIf deploymens of microsoft.sql/servers/ does not show output for databases if "server.location" is used. Changing it to "location" (which server.location is built from) solves the issue. (Perhaps related to https://github.com/Azure/arm-template-whatif/issues/157 ?)

That being said it could be hard-coded to `location: location` instead of `location: contains(database, 'location') ? database.location : location` as it is not possible to deploy a database in a different location than the server, so it is a confusing parameter to have.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
