### PR TITLE
[Fixes] Updated a "depends on" condtion on natgateway for pip address

### DIFF
--- a/modules/network/nat-gateways/main.bicep
+++ b/modules/network/nat-gateways/main.bicep
@@ -146,6 +146,7 @@ resource natGateway 'Microsoft.Network/natGateways@2022-07-01' = {
     publicIpAddresses: publicIPAddressResourceIds
   }
   zones: zones
+  dependsOn: [ publicIPAddress ]
 }
 
 resource natGateway_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock)) {


### PR DESCRIPTION
…atGatewayPublicIpAddress=true"

Error Encountered: PublicIPAddress Not Found- In the main.bicep file, if we set the parameter value of natGatewayPublicIpAddress to true, the module throws an error indicating that the publicipaddress cannot be found.

>Thank you for your contribution !

The module in main.bicep throws an error stating that the publicipaddress is not found when we set the parameter value of natGatewayPublicIpAddress to true. To resolve this issue, it is necessary to include a dependency condition in the natgateway resource, ensuring it depends on the publicipaddress module.

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
