### PR TITLE
[CI Environment] Re-Enabled PBR overwrite

### DIFF
--- a/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
+++ b/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
@@ -96,5 +96,3 @@ function Publish-ModuleToPrivateBicepRegistry {
         Write-Debug ('{0} exited' -f $MyInvocation.MyCommand)
     }
 }
-Publish-ModuleToPrivateBicepRegistry -TemplateFilePath 'C:\dev\ip\Azure-ResourceModules\ResourceModules\modules\aad\domain-services\main.bicep' -ModuleVersion '0.1' -BicepRegistryName 'adpsxxazacrx001' -BicepRegistryRgName 'artifacts-rg' -Verbose
-

--- a/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
+++ b/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
@@ -96,3 +96,5 @@ function Publish-ModuleToPrivateBicepRegistry {
         Write-Debug ('{0} exited' -f $MyInvocation.MyCommand)
     }
 }
+Publish-ModuleToPrivateBicepRegistry -TemplateFilePath 'C:\dev\ip\Azure-ResourceModules\ResourceModules\modules\aad\domain-services\main.bicep' -ModuleVersion '0.1' -BicepRegistryName 'adpsxxazacrx001' -BicepRegistryRgName 'artifacts-rg' -Verbose
+

--- a/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
+++ b/utilities/pipelines/resourcePublish/Publish-ModuleToPrivateBicepRegistry.ps1
@@ -87,7 +87,7 @@ function Publish-ModuleToPrivateBicepRegistry {
         #############################################
         $publishingTarget = 'br:{0}.azurecr.io/{1}:{2}' -f $BicepRegistryName, $moduleRegistryIdentifier, $ModuleVersion
         if ($PSCmdlet.ShouldProcess("Private bicep registry entry [$moduleRegistryIdentifier] version [$ModuleVersion] to registry [$BicepRegistryName]", 'Publish')) {
-            bicep publish $TemplateFilePath --target $publishingTarget
+            bicep publish $TemplateFilePath --target $publishingTarget --force
         }
         Write-Verbose 'Publish complete'
     }


### PR DESCRIPTION
# Description

Re-Enabled PBR overwrite

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

```PowerShell
# Run without `--force`
PS C:\dev\ip\Azure-ResourceModules\ResourceModules> . 'C:\dev\ip\Azure-ResourceModules\ResourceModules\utilities\pipelines\resourcePublish\Publish-ModuleToPrivateBicepRegistry.ps1'
VERBOSE: Performing the operation "Publish" on target "Private bicep registry entry [bicep/modules/aad.domain-services] version [0.1] to registry [adpsxxazacrx001]".
The module "br:adpsxxazacrx001.azurecr.io/bicep/modules/aad.domain-services:0.1" already exists in registry. Use --force to overwrite the existing module.
VERBOSE: Publish complete

# Run with `--force`
PS C:\dev\ip\Azure-ResourceModules\ResourceModules> . 'C:\dev\ip\Azure-ResourceModules\ResourceModules\utilities\pipelines\resourcePublish\Publish-ModuleToPrivateBicepRegistry.ps1'
VERBOSE: Performing the operation "Publish" on target "Private bicep registry entry [bicep/modules/aad.domain-services] version [0.1] to registry [adpsxxazacrx001]".
VERBOSE: Publish complete
```

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

