### PR TITLE
[Modules] Data Factory: Added gitDisablePublish parameter

### DIFF
--- a/modules/data-factory/factories/README.md
+++ b/modules/data-factory/factories/README.md
@@ -57,6 +57,7 @@ This module deploys a Data Factory.
 | `gitAccountName` | string | `''` |  | The account name. |
 | `gitCollaborationBranch` | string | `'main'` |  | The collaboration branch name. Default is 'main'. |
 | `gitConfigureLater` | bool | `True` |  | Boolean to define whether or not to configure git during template deployment. |
+| `gitDisablePublish` | bool | `False` |  | Disable manual publish operation in ADF studio to favor automated publish. |
 | `gitHostName` | string | `''` |  | The GitHub Enterprise Server host (prefixed with 'https://'). Only relevant for 'FactoryGitHubConfiguration'. |
 | `gitProjectName` | string | `''` |  | The project name. Only relevant for 'FactoryVSTSConfiguration'. |
 | `gitRepositoryName` | string | `''` |  | The repository name. |

--- a/modules/data-factory/factories/main.bicep
+++ b/modules/data-factory/factories/main.bicep
@@ -39,6 +39,9 @@ param gitRepositoryName string = ''
 @description('Optional. The collaboration branch name. Default is \'main\'.')
 param gitCollaborationBranch string = 'main'
 
+@description('Optional. Disable manual publish operation in ADF studio to favor automated publish.')
+param gitDisablePublish bool = false
+
 @description('Optional. The root folder path name. Default is \'/\'.')
 param gitRootFolder string = '/'
 
@@ -200,6 +203,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' = {
         repositoryName: gitRepositoryName
         collaborationBranch: gitCollaborationBranch
         rootFolder: gitRootFolder
+        disablePublish: gitDisablePublish
       }, (gitRepoType == 'FactoryVSTSConfiguration' ? {
         projectName: gitProjectName
       } : {}), {})

--- a/modules/data-factory/factories/main.json
+++ b/modules/data-factory/factories/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.18.4.5664",
-      "templateHash": "7237850138219692258"
+      "templateHash": "2473085453227848462"
     }
   },
   "parameters": {
@@ -97,6 +97,13 @@
         "description": "Optional. The collaboration branch name. Default is 'main'."
       }
     },
+    "gitDisablePublish": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Disable manual publish operation in ADF studio to favor automated publish."
+      }
+    },
     "gitRootFolder": {
       "type": "string",
       "defaultValue": "/",
@@ -108,7 +115,7 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Optional. The GitHub Enterprise Server host (prefixed with 'https://'). . Only relevant for 'FactoryGitHubConfiguration'. Default is ''."
+        "description": "Optional. The GitHub Enterprise Server host (prefixed with 'https://'). Only relevant for 'FactoryGitHubConfiguration'."
       }
     },
     "globalParameters": {
@@ -334,7 +341,7 @@
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
       "properties": {
-        "repoConfiguration": "[if(bool(parameters('gitConfigureLater')), null(), union(createObject('type', parameters('gitRepoType'), 'hostName', parameters('gitHostName'), 'accountName', parameters('gitAccountName'), 'repositoryName', parameters('gitRepositoryName'), 'collaborationBranch', parameters('gitCollaborationBranch'), 'rootFolder', parameters('gitRootFolder')), if(equals(parameters('gitRepoType'), 'FactoryVSTSConfiguration'), createObject('projectName', parameters('gitProjectName')), createObject()), createObject()))]",
+        "repoConfiguration": "[if(bool(parameters('gitConfigureLater')), null(), union(createObject('type', parameters('gitRepoType'), 'hostName', parameters('gitHostName'), 'accountName', parameters('gitAccountName'), 'repositoryName', parameters('gitRepositoryName'), 'collaborationBranch', parameters('gitCollaborationBranch'), 'rootFolder', parameters('gitRootFolder'), 'disablePublish', parameters('gitDisablePublish')), if(equals(parameters('gitRepoType'), 'FactoryVSTSConfiguration'), createObject('projectName', parameters('gitProjectName')), createObject()), createObject()))]",
         "globalParameters": "[if(not(empty(parameters('globalParameters'))), parameters('globalParameters'), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(not(empty(parameters('privateEndpoints'))), 'Disabled', null()))]",
         "encryption": "[if(not(empty(parameters('cMKKeyName'))), createObject('identity', createObject('userAssignedIdentity', parameters('cMKUserAssignedIdentityResourceId')), 'keyName', parameters('cMKKeyName'), 'keyVersion', if(not(empty(parameters('cMKKeyVersion'))), parameters('cMKKeyVersion'), null()), 'vaultBaseUrl', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('cMKKeyVaultResourceId'), '/')[2], split(parameters('cMKKeyVaultResourceId'), '/')[4]), 'Microsoft.KeyVault/vaults', last(split(parameters('cMKKeyVaultResourceId'), '/'))), '2021-10-01').vaultUri), null())]"


### PR DESCRIPTION
# Description

This PR resolves #3436 and adds the `disablePublish` property to the Repo Configuration of the Data Factory.

## Pipeline references

| Pipeline |
| - |
| [![DataFactory - Factories](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml/badge.svg?branch=users%2Fkrbar%2F3436-adf-disablepublish)](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
