### PR TITLE
[Modules] Fixed EventHub role assignment naming issues

### DIFF
--- a/modules/event-hub/namespaces/.test/common/main.test.bicep
+++ b/modules/event-hub/namespaces/.test/common/main.test.bicep
@@ -91,6 +91,15 @@ module testDeployment '../../main.bicep' = {
     eventhubs: [
       {
         name: '${namePrefix}-az-evh-x-001'
+        roleAssignments: [
+          {
+            roleDefinitionIdOrName: 'Reader'
+            principalIds: [
+              nestedDependencies.outputs.managedIdentityPrincipalId
+            ]
+            principalType: 'ServicePrincipal'
+          }
+        ]
       }
       {
         name: '${namePrefix}-az-evh-x-002'

--- a/modules/event-hub/namespaces/README.md
+++ b/modules/event-hub/namespaces/README.md
@@ -378,6 +378,15 @@ module namespaces './event-hub/namespaces/main.bicep' = {
     eventhubs: [
       {
         name: 'az-evh-x-001'
+        roleAssignments: [
+          {
+            principalIds: [
+              '<managedIdentityPrincipalId>'
+            ]
+            principalType: 'ServicePrincipal'
+            roleDefinitionIdOrName: 'Reader'
+          }
+        ]
       }
       {
         authorizationRules: [
@@ -541,7 +550,16 @@ module namespaces './event-hub/namespaces/main.bicep' = {
     "eventhubs": {
       "value": [
         {
-          "name": "az-evh-x-001"
+          "name": "az-evh-x-001",
+          "roleAssignments": [
+            {
+              "principalIds": [
+                "<managedIdentityPrincipalId>"
+              ],
+              "principalType": "ServicePrincipal",
+              "roleDefinitionIdOrName": "Reader"
+            }
+          ]
         },
         {
           "authorizationRules": [

--- a/modules/event-hub/namespaces/eventhubs/.bicep/nested_roleAssignments.bicep
+++ b/modules/event-hub/namespaces/eventhubs/.bicep/nested_roleAssignments.bicep
@@ -59,7 +59,7 @@ resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2022-01-01-preview' e
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
-  name: guid(split(resourceId, '/')[0], split(resourceId, '/')[1], principalId, roleDefinitionIdOrName)
+  name: guid(eventHub.id, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/modules/event-hub/namespaces/eventhubs/main.json
+++ b/modules/event-hub/namespaces/eventhubs/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.18.4.5664",
-      "templateHash": "10222556087726415534"
+      "templateHash": "3626705120581865104"
     }
   },
   "parameters": {
@@ -535,7 +535,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.18.4.5664",
-              "templateHash": "15621031357191909045"
+              "templateHash": "17884890758704755863"
             }
           },
           "parameters": {
@@ -635,7 +635,7 @@
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
               "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
-              "name": "[guid(split(parameters('resourceId'), '/')[0], split(parameters('resourceId'), '/')[1], parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+              "name": "[guid(resourceId('Microsoft.EventHub/namespaces/eventhubs', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
               "properties": {
                 "description": "[parameters('description')]",
                 "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",

--- a/modules/event-hub/namespaces/main.json
+++ b/modules/event-hub/namespaces/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.18.4.5664",
-      "templateHash": "12863324937037450144"
+      "templateHash": "234993039195821021"
     }
   },
   "parameters": {
@@ -695,7 +695,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.18.4.5664",
-              "templateHash": "10222556087726415534"
+              "templateHash": "3626705120581865104"
             }
           },
           "parameters": {
@@ -1225,7 +1225,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.18.4.5664",
-                      "templateHash": "15621031357191909045"
+                      "templateHash": "17884890758704755863"
                     }
                   },
                   "parameters": {
@@ -1325,7 +1325,7 @@
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2022-04-01",
                       "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
-                      "name": "[guid(split(parameters('resourceId'), '/')[0], split(parameters('resourceId'), '/')[1], parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                      "name": "[guid(resourceId('Microsoft.EventHub/namespaces/eventhubs', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
                       "properties": {
                         "description": "[parameters('description')]",
                         "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",


### PR DESCRIPTION
# Description

This PR resolves #3439 by generating role assignment names, which are unique within an EventHub workspace.

## Pipeline references

| Pipeline |
| - |
| [![EventHub - Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml/badge.svg?branch=users%2Fkrbar%2F3439-eventhub-role-assignments-fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml) |

# Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
