### PR TITLE
[CI environment] Get yml pipeline name based on specs resourcetype

### DIFF
--- a/utilities/pipelines/staticValidation/helper/helper.psm1
+++ b/utilities/pipelines/staticValidation/helper/helper.psm1
@@ -8,6 +8,7 @@ $repoRootPath = (Get-Item $PSScriptRoot).Parent.Parent.Parent.Parent.FullName
 . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-ModuleTestFileList.ps1')
 . (Join-Path $repoRootPath 'utilities' 'tools' 'Get-CrossReferencedModuleList.ps1')
 . (Join-Path $repoRootPath 'utilities' 'tools' 'helper' 'ConvertTo-OrderedHashtable.ps1')
+. (Join-Path $repoRootPath 'utilities' 'tools' 'helper' 'Get-PipelineFileName.ps1')
 
 ####################################
 #   Load test-specific functions   #

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -171,7 +171,6 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             )
 
             $workflowsFolderName = Join-Path $repoRootPath '.github' 'workflows'
-            # $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
             $workflowFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
             $workflowPath = Join-Path $workflowsFolderName $workflowFileName
             Test-Path $workflowPath | Should -Be $true -Because "path [$workflowPath] should exist."
@@ -192,7 +191,6 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             }
 
             $workflowsFolderName = Join-Path $repoRootPath '.github' 'workflows'
-            # $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
             $workflowFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
             $workflowFilePath = Join-Path $workflowsFolderName $workflowFileName
             $workflowContent = Get-Content -Path $workflowFilePath
@@ -243,7 +241,6 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
 
             $pipelinesFolderName = Join-Path $repoRootPath '.azuredevops' 'modulePipelines'
             $pipelineFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
-            # $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
             Write-Verbose "pipelineFileName $pipelineFileName" -Verbose
             $pipelinePath = Join-Path $pipelinesFolderName $pipelineFileName
             Test-Path $pipelinePath | Should -Be $true -Because "path [$pipelinePath] should exist."
@@ -265,7 +262,6 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
 
             $pipelinesFolderName = Join-Path $repoRootPath '.azuredevops' 'modulePipelines'
             $pipelineFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
-            # $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
             $pipelineFilePath = Join-Path $pipelinesFolderName $pipelineFileName
             $pipelineContent = Get-Content -Path $pipelineFilePath
 

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -171,7 +171,8 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             )
 
             $workflowsFolderName = Join-Path $repoRootPath '.github' 'workflows'
-            $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            # $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            $workflowFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
             $workflowPath = Join-Path $workflowsFolderName $workflowFileName
             Test-Path $workflowPath | Should -Be $true -Because "path [$workflowPath] should exist."
         }
@@ -191,7 +192,8 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             }
 
             $workflowsFolderName = Join-Path $repoRootPath '.github' 'workflows'
-            $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            # $workflowFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            $workflowFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
             $workflowFilePath = Join-Path $workflowsFolderName $workflowFileName
             $workflowContent = Get-Content -Path $workflowFilePath
 
@@ -240,7 +242,9 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             )
 
             $pipelinesFolderName = Join-Path $repoRootPath '.azuredevops' 'modulePipelines'
-            $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            $pipelineFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
+            # $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            Write-Verbose "pipelineFileName $pipelineFileName" -Verbose
             $pipelinePath = Join-Path $pipelinesFolderName $pipelineFileName
             Test-Path $pipelinePath | Should -Be $true -Because "path [$pipelinePath] should exist."
         }
@@ -260,7 +264,8 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             }
 
             $pipelinesFolderName = Join-Path $repoRootPath '.azuredevops' 'modulePipelines'
-            $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
+            $pipelineFileName = Get-PipelineFileName -ResourceIdentifier $moduleFolderName
+            # $pipelineFileName = 'ms.{0}.yml' -f $moduleFolderName.Replace('\', '/').Replace('/', '.').Replace('-', '').ToLower()
             $pipelineFilePath = Join-Path $pipelinesFolderName $pipelineFileName
             $pipelineContent = Get-Content -Path $pipelineFilePath
 

--- a/utilities/tools/helper/Get-PipelineFileName.ps1
+++ b/utilities/tools/helper/Get-PipelineFileName.ps1
@@ -29,7 +29,7 @@ function Get-PipelineFileName {
 
     . (Join-Path $PSScriptRoot 'Get-SpecsAlignedResourceName.ps1')
 
-    $provider, $parentType, $childTypeString = $ResourceIdentifier -split '/', 3
+    $provider, $parentType, $childTypeString = $ResourceIdentifier -split '[\/|\\]', 3
     $parentResourceIdentifier = $provider, $parentType -join '/'
     $formattedParentResourceType = Get-SpecsAlignedResourceName -ResourceIdentifier $parentResourceIdentifier
     $pipelineFileName = '{0}.yml' -f $formattedParentResourceType.Replace('Microsoft.', 'ms.').Replace('/', '.').ToLower()

--- a/utilities/tools/helper/Get-PipelineFileName.ps1
+++ b/utilities/tools/helper/Get-PipelineFileName.ps1
@@ -1,0 +1,38 @@
+﻿<#
+.SYNOPSIS
+Find the correct yml pipeline naming for a given resource identifier.
+
+.DESCRIPTION
+Find the correct yml pipeline naming for a given resource identifier.
+If a child resource type is provided, the corresponding yml pipeline name is the one of its parent resource type
+
+.PARAMETER ResourceIdentifier
+Mandatory. The resource identifier to search for, i.e. the relative module file path starting from the resource provider folder.
+
+.EXAMPLE
+Get-PipelineFileName -ResourceIdentifier 'storage/storage-account/blob-service/container/immutability-policy'.
+
+Returns 'ms.storage.storageaccounts.yml'.
+
+.EXAMPLE
+Get-PipelineFileName -ResourceIdentifier 'storage/storage-account'.
+
+Returns 'ms.storage.storageaccounts.yml'.
+#>
+function Get-PipelineFileName {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $ResourceIdentifier
+    )
+
+    . (Join-Path $PSScriptRoot 'Get-SpecsAlignedResourceName.ps1')
+
+    $provider, $parentType, $childTypeString = $ResourceIdentifier -split '/', 3
+    $parentResourceIdentifier = $provider, $parentType -join '/'
+    $formattedParentResourceType = Get-SpecsAlignedResourceName -ResourceIdentifier $parentResourceIdentifier
+    $pipelineFileName = '{0}.yml' -f $formattedParentResourceType.Replace('Microsoft.', 'ms.').Replace('/', '.').ToLower()
+
+    return $pipelineFileName
+}


### PR DESCRIPTION
# Description

Closes #3476

Update pester tests checking ADO, GH and cross references pipeline existence.
Leveraging apispecs to get correct naming for yml files
Works with both singular and plural module folder names, hence can be merged to main

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Storage - StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Favm%2Fpester_pipelines)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml) |
| [![ContainerRegistry - Registries](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerregistry.registries.yml/badge.svg?branch=users%2Favm%2Fpester_pipelines)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerregistry.registries.yml) |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
