### PR TITLE
[Fixes] Update ADO pipeline conditions to make it impossible to continue on canceled job

### DIFF
--- a/.azuredevops/pipelineTemplates/stages.module.yml
+++ b/.azuredevops/pipelineTemplates/stages.module.yml
@@ -15,7 +15,7 @@ stages:
 
   - stage: deployment
     displayName: Deployment validation
-    condition: and(eq('${{ parameters.deploymentValidation }}', 'True'), ne(dependencies.validation.result, 'Failed'))
+    condition: and(eq('${{ parameters.deploymentValidation }}', 'True'), not(in(dependencies.validation.result, 'Failed', 'Canceled')))
     dependsOn:
       - validation
     jobs:


### PR DESCRIPTION
# Description

- Update ADO pipeline conditions to make it impossible to continue on canceled job
- Based on #3579

Tested pipeline cases
| Runtime Static | Runtime Deployment | Runtime Pre-Release | Manual Action | Result |
| - | - | - | - | - |
| ✅ | ✅ | ✅ | - | Runs all |
| ✅ | ✅ | ✅ | Cancel during static | Skipps deployment & publishing |
| ✅ | ✅ | ✅ | Cancel during deployment | Skipps publishing |
| :x: | ✅ | ✅ | - | Skipps publishing |
| ✅  | :x: | ✅ | - | Skipps publishing |

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Build Status](https://dev.azure.com/carml/CARML/_apis/build/status%2FModules%2FResources%20-%20ResourceGroups?branchName=users%2Falsehr%2FadoCond)](https://dev.azure.com/carml/CARML/_build/latest?definitionId=84&branchName=users%2Falsehr%2FadoCond) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
