### PR TITLE
[Fixes] Update deployment search to not prematurely throw an exception

### DIFF
--- a/utilities/pipelines/resourceRemoval/helper/Get-DeploymentTargetResourceList.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Get-DeploymentTargetResourceList.ps1
@@ -216,7 +216,8 @@ function Get-DeploymentTargetResourceList {
     } while ($searchRetryCount -le $searchRetryLimit)
 
     if (-not $targetResources) {
-        throw "No deployment target resources found for [$name]"
+        Write-Warning "No deployment target resources found for [$name]"
+        return @()
     }
 
     return $targetResources

--- a/utilities/pipelines/resourceRemoval/helper/Remove-Deployment.ps1
+++ b/utilities/pipelines/resourceRemoval/helper/Remove-Deployment.ps1
@@ -103,6 +103,10 @@ function Remove-Deployment {
             $deployedTargetResources += Get-DeploymentTargetResourceList @deploymentsInputObject
         }
 
+        if ($deployedTargetResources.Count -eq 0) {
+            throw 'No deployment target resources found.'
+        }
+
         [array] $deployedTargetResources = $deployedTargetResources | Select-Object -Unique
 
         Write-Verbose ('Total number of deployment target resources after fetching deployments [{0}]' -f $deployedTargetResources.Count) -Verbose


### PR DESCRIPTION
# Description

- Updated deployment search to not prematurely throw an exception if a deployment name does not yield deployed resources
- Currently, the logic searches the deployment name until the timeout is reached and throws an exception if no deployments are found (which is an issue if runnning, for example, retries)
- Instead it should then continue with the next name and only throw an exception if no deployment is found after checking all names

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| [![Network - NetworkInterfaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkinterfaces.yml/badge.svg?branch=users%2Falsehr%2FadjustDeplSearchLogic)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkinterfaces.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
