### PR TITLE
[Fixes] Align GH removal with ADO

### DIFF
--- a/.github/actions/templates/validateModuleDeployment/action.yml
+++ b/.github/actions/templates/validateModuleDeployment/action.yml
@@ -252,7 +252,7 @@ runs:
     # [Deployment removal] task(s)
     # ----------------------------
     - name: 'Remove deployed resources'
-      if: ${{ always() && inputs.removeDeployment == 'true' && steps.deploy_step.outputs.deploymentNames != '' }}
+      if: ${{ (success() || failure()) && inputs.removeDeployment == 'true' && steps.deploy_step.outputs.deploymentNames != '' }}
       uses: azure/powershell@v1
       with:
         azPSVersion: 'latest'


### PR DESCRIPTION
Fixes #3590
Replaces: #3591

# Description

Aligning GH resource removal condition with ADO.

## Pipeline references

| Pipeline  | Expected behavior | Actual result | 
| - | - | - |
| [Regular deploy](https://github.com/MariusStorhaug/ResourceModules/actions/runs/6051481775) | Success | ✅ |
| [Deploy with failure](https://github.com/MariusStorhaug/ResourceModules/actions/runs/6052501714/job/16426102603) | Fail deployment, resources removed | ✅ |
| [Deploy with cancel](https://github.com/MariusStorhaug/ResourceModules/actions/runs/6052763057/job/16426990507) | Deploy some resources, cancel whole workflow | ✅ |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
