### PR TITLE
[PSRule] Fix Rule Azure.Policy.AssignmentDescriptors #2668

### DIFF
--- a/.ps-rule/min-suppress.Rule.yaml
+++ b/.ps-rule/min-suppress.Rule.yaml
@@ -8,6 +8,7 @@ spec:
   rule:
    - Azure.Resource.UseTags
    - Azure.KeyVault.Logs
+   - Azure.Policy.AssignmentDescriptors
   if:
     name: '.'
     contains:

--- a/modules/authorization/policy-assignment/.test/mg.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/mg.min/main.test.bicep
@@ -23,8 +23,6 @@ module testDeployment '../../main.bicep' = {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '${namePrefix}${serviceShort}001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
-    description: '[Description] Policy Assignment at the management group scope'
-    displayName: '[Display Name] Policy Assignment at the management group scope'
     metadata: {
       assignedBy: 'Bicep'
     }

--- a/modules/authorization/policy-assignment/.test/rg.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/rg.min/main.test.bicep
@@ -43,9 +43,7 @@ module testDeployment '../../resource-group/main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
     subscriptionId: subscription().subscriptionId
-    description: '[Description] Policy Assignment at the resource group scope'
-    displayName: '[Display Name] Policy Assignment at the resource group scope'
-      metadata: {
+    metadata: {
       assignedBy: 'Bicep'
     }
   }

--- a/modules/authorization/policy-assignment/.test/sub.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/sub.min/main.test.bicep
@@ -24,8 +24,6 @@ module testDeployment '../../subscription/main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
     subscriptionId: subscription().subscriptionId
-    description: '[Description] Policy Assignment at the subscription scope'
-    displayName: '[Display Name] Policy Assignment at the subscription scope'
     metadata: {
       category: 'Security'
       version: '1.0'

--- a/modules/authorization/policy-assignment/README.md
+++ b/modules/authorization/policy-assignment/README.md
@@ -399,8 +399,6 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
     name: 'apamgmin001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
     // Non-required parameters
-    description: '[Description] Policy Assignment at the management group scope'
-    displayName: '[Display Name] Policy Assignment at the management group scope'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     metadata: {
       assignedBy: 'Bicep'
@@ -429,12 +427,6 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
       "value": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
     },
     // Non-required parameters
-    "description": {
-      "value": "[Description] Policy Assignment at the management group scope"
-    },
-    "displayName": {
-      "value": "[Display Name] Policy Assignment at the management group scope"
-    },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },
@@ -675,9 +667,10 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
     name: 'apargmin001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
     // Non-required parameters
-    description: '[Description] Policy Assignment at the resource group scope'
-    displayName: '[Display Name] Policy Assignment at the resource group scope'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
+    metadata: {
+      assignedBy: 'Bicep'
+    }
     subscriptionId: '<subscriptionId>'
   }
 }
@@ -703,14 +696,13 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
       "value": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
     },
     // Non-required parameters
-    "description": {
-      "value": "[Description] Policy Assignment at the resource group scope"
-    },
-    "displayName": {
-      "value": "[Display Name] Policy Assignment at the resource group scope"
-    },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
+    },
+    "metadata": {
+      "value": {
+        "assignedBy": "Bicep"
+      }
     },
     "subscriptionId": {
       "value": "<subscriptionId>"
@@ -943,8 +935,6 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
     name: 'apasubmin001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d'
     // Non-required parameters
-    description: '[Description] Policy Assignment at the subscription scope'
-    displayName: '[Display Name] Policy Assignment at the subscription scope'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     metadata: {
       assignedBy: 'Bicep'
@@ -976,12 +966,6 @@ module policyAssignment './authorization/policy-assignment/main.bicep' = {
       "value": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
     },
     // Non-required parameters
-    "description": {
-      "value": "[Description] Policy Assignment at the subscription scope"
-    },
-    "displayName": {
-      "value": "[Display Name] Policy Assignment at the subscription scope"
-    },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     },


### PR DESCRIPTION
# Description

Configured min-suppress.Rule-yaml to exclude evaluation of rule Azure.Policy.AssignmentDescriptors for min files:
ResourceModules/modules/Microsoft.Authorization/policyAssignments/.test/sub.min/deploy.test.bicep 
ResourceModules/modules/Microsoft.Authorization/policyAssignments/.test/rg.min/deploy.test.bicep 
ResourceModules/modules/Microsoft.Authorization/policyAssignments/.test/mg.min/deploy.test.bicep 

closes #2668 

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
|[![Authorization - PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
