### PR TITLE
Fix Rule Azure.Policy.Descriptors

### DIFF
--- a/.ps-rule/min-suppress.Rule.yaml
+++ b/.ps-rule/min-suppress.Rule.yaml
@@ -8,6 +8,7 @@ spec:
   rule:
    - Azure.Resource.UseTags
    - Azure.KeyVault.Logs
+   - Azure.Policy.Descriptors
   if:
     name: '.'
     contains:


### PR DESCRIPTION
# Description

Added exclusion for AZR-000142: ***apdmgmin001 failed Azure.Policy.Descriptors. Policy and initiative definitions should use a display name, description, and category for min test files.

closes #3894 

## Pipeline references
| Pipeline |
| - |
|[![Authorization - PolicyDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
