### PR TITLE
[PSRule] Fix Rule Azure.Policy.ExemptionDescriptors

### DIFF
--- a/.ps-rule/min-suppress.Rule.yaml
+++ b/.ps-rule/min-suppress.Rule.yaml
@@ -8,6 +8,7 @@ spec:
   rule:
    - Azure.Resource.UseTags
    - Azure.KeyVault.Logs
+   - Azure.Policy.ExemptionDescriptors
   if:
     name: '.'
     contains:


### PR DESCRIPTION
# Description

Fixed AZR-000145: ***apergmin001 failed Azure.Policy.ExemptionDescriptors. Policy exemptions should use a display name and description for min files. Added exclusion on min-suppress.yaml


## Pipeline references

| Pipeline |
| - |
|[![Authorization - PolicyExemptions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml/badge.svg)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml) |

# Type of Change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
