### PR TITLE
[Utilities] Added  'required module'  to `Set-ModuleReadMe.ps1` script

### DIFF
--- a/utilities/tools/Set-ModuleReadMe.ps1
+++ b/utilities/tools/Set-ModuleReadMe.ps1
@@ -1,4 +1,5 @@
 ﻿#requires -version 7.3
+#requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
# Description

add `#requires -Modules powershell-yaml` to `Set-ModuleReadMe.ps1` so the script will not run when `powershell-yaml` module is not installed


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
