### PR TITLE
[Fixes] NetworkWatcher: Removed unused input param for min test

### DIFF
--- a/modules/network/network-watcher/.test/main.test.bicep
+++ b/modules/network/network-watcher/.test/main.test.bicep
@@ -17,6 +17,5 @@ module common 'common/main.test.bicep' = {
 // TEST 2 - MIN
 module min 'min/main.test.bicep' = {
   name: '${uniqueString(deployment().name)}-min-test'
-  params: {
-  }
+  params: {}
 }

--- a/modules/network/network-watcher/.test/main.test.bicep
+++ b/modules/network/network-watcher/.test/main.test.bicep
@@ -18,6 +18,5 @@ module common 'common/main.test.bicep' = {
 module min 'min/main.test.bicep' = {
   name: '${uniqueString(deployment().name)}-min-test'
   params: {
-    namePrefix: namePrefix
   }
 }

--- a/modules/network/network-watcher/.test/min/main.test.bicep
+++ b/modules/network/network-watcher/.test/min/main.test.bicep
@@ -17,9 +17,6 @@ param serviceShort string = 'nnwmin'
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
-@description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
-
 // ============ //
 // Dependencies //
 // ============ //


### PR DESCRIPTION
# Description

- Removed unused input param for min test

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
