### PR TITLE
[Modules] Updated Redis RBAC nested module naming

### DIFF
--- a/modules/cache/redis/main.bicep
+++ b/modules/cache/redis/main.bicep
@@ -233,7 +233,7 @@ resource redisCache_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@20
 }
 
 module redisCache_rbac '.bicep/nested_roleAssignments.bicep' = [for (roleAssignment, index) in roleAssignments: {
-  name: '${uniqueString(deployment().name, location)}-AppGateway-Rbac-${index}'
+  name: '${uniqueString(deployment().name, location)}-redisCache-Rbac-${index}'
   params: {
     description: contains(roleAssignment, 'description') ? roleAssignment.description : ''
     principalIds: roleAssignment.principalIds

--- a/modules/cache/redis/main.json
+++ b/modules/cache/redis/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.20.4.51522",
-      "templateHash": "10989484367118565473"
+      "templateHash": "17613971923220537390"
     },
     "name": "Redis Cache",
     "description": "This module deploys a Redis Cache.",
@@ -387,7 +387,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-AppGateway-Rbac-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-redisCache-Rbac-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"


### PR DESCRIPTION
# Description

Name syntax error for the RBAC submodule.

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
|[![Cache - Redis](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml/badge.svg?branch=users%2Fahmad%2FredisUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
