### PR TITLE
[Modules] Updated Cosmos DB Module tests to support dynamic primary and secondary region locations

### DIFF
--- a/modules/document-db/database-account/.test/gremlindb/dependencies.bicep
+++ b/modules/document-db/database-account/.test/gremlindb/dependencies.bicep
@@ -4,10 +4,46 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+@description('Required. The name of the Deployment Script to create to get the paired region name.')
+param pairedRegionScriptName string
+
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
     name: managedIdentityName
     location: location
 }
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+    name: guid('msi-${location}-${managedIdentity.id}-Reader-RoleAssignment')
+    properties: {
+        principalId: managedIdentity.properties.principalId
+        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7') // Reader
+        principalType: 'ServicePrincipal'
+    }
+}
+
+resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+    name: pairedRegionScriptName
+    location: location
+    kind: 'AzurePowerShell'
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            '${managedIdentity.id}': {}
+        }
+    }
+    properties: {
+        azPowerShellVersion: '8.0'
+        retentionInterval: 'P1D'
+        arguments: '-Location \\"${location}\\"'
+        scriptContent: loadTextContent('../../../../.shared/.scripts/Get-PairedRegion.ps1')
+    }
+    dependsOn: [
+        roleAssignment
+    ]
+}
+
+@description('The name of the paired region.')
+output pairedRegionName string = getPairedRegionScript.properties.outputs.pairedRegionName
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/modules/document-db/database-account/.test/gremlindb/main.test.bicep
+++ b/modules/document-db/database-account/.test/gremlindb/main.test.bicep
@@ -36,6 +36,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
+    pairedRegionScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
   }
 }
 
@@ -67,12 +68,12 @@ module testDeployment '../../main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: location
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: nestedDependencies.outputs.pairedRegionName
       }
     ]
     capabilitiesToAdd: [

--- a/modules/document-db/database-account/.test/mongodb/dependencies.bicep
+++ b/modules/document-db/database-account/.test/mongodb/dependencies.bicep
@@ -4,10 +4,46 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+@description('Required. The name of the Deployment Script to create to get the paired region name.')
+param pairedRegionScriptName string
+
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
     name: managedIdentityName
     location: location
 }
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+    name: guid('msi-${location}-${managedIdentity.id}-Reader-RoleAssignment')
+    properties: {
+        principalId: managedIdentity.properties.principalId
+        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7') // Reader
+        principalType: 'ServicePrincipal'
+    }
+}
+
+resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+    name: pairedRegionScriptName
+    location: location
+    kind: 'AzurePowerShell'
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            '${managedIdentity.id}': {}
+        }
+    }
+    properties: {
+        azPowerShellVersion: '8.0'
+        retentionInterval: 'P1D'
+        arguments: '-Location \\"${location}\\"'
+        scriptContent: loadTextContent('../../../../.shared/.scripts/Get-PairedRegion.ps1')
+    }
+    dependsOn: [
+        roleAssignment
+    ]
+}
+
+@description('The name of the paired region.')
+output pairedRegionName string = getPairedRegionScript.properties.outputs.pairedRegionName
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/modules/document-db/database-account/.test/mongodb/main.test.bicep
+++ b/modules/document-db/database-account/.test/mongodb/main.test.bicep
@@ -36,6 +36,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
+    pairedRegionScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
   }
 }
 
@@ -67,12 +68,12 @@ module testDeployment '../../main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: location
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: nestedDependencies.outputs.pairedRegionName
       }
     ]
     diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId

--- a/modules/document-db/database-account/.test/plain/dependencies.bicep
+++ b/modules/document-db/database-account/.test/plain/dependencies.bicep
@@ -4,10 +4,46 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+@description('Required. The name of the Deployment Script to create to get the paired region name.')
+param pairedRegionScriptName string
+
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
     name: managedIdentityName
     location: location
 }
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+    name: guid('msi-${location}-${managedIdentity.id}-Reader-RoleAssignment')
+    properties: {
+        principalId: managedIdentity.properties.principalId
+        roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7') // Reader
+        principalType: 'ServicePrincipal'
+    }
+}
+
+resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+    name: pairedRegionScriptName
+    location: location
+    kind: 'AzurePowerShell'
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            '${managedIdentity.id}': {}
+        }
+    }
+    properties: {
+        azPowerShellVersion: '8.0'
+        retentionInterval: 'P1D'
+        arguments: '-Location \\"${location}\\"'
+        scriptContent: loadTextContent('../../../../.shared/.scripts/Get-PairedRegion.ps1')
+    }
+    dependsOn: [
+        roleAssignment
+    ]
+}
+
+@description('The name of the paired region.')
+output pairedRegionName string = getPairedRegionScript.properties.outputs.pairedRegionName
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/modules/document-db/database-account/.test/plain/main.test.bicep
+++ b/modules/document-db/database-account/.test/plain/main.test.bicep
@@ -36,6 +36,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
+    pairedRegionScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
   }
 }
 
@@ -67,12 +68,12 @@ module testDeployment '../../main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: location
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: nestedDependencies.outputs.pairedRegionName
       }
     ]
     diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId

--- a/modules/document-db/database-account/.test/sqldb/dependencies.bicep
+++ b/modules/document-db/database-account/.test/sqldb/dependencies.bicep
@@ -7,6 +7,9 @@ param managedIdentityName string
 @description('Required. The name of the Virtual Network to create.')
 param virtualNetworkName string
 
+@description('Required. The name of the Deployment Script to create to get the paired region name.')
+param pairedRegionScriptName string
+
 var addressPrefix = '10.0.0.0/16'
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -49,6 +52,39 @@ resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     }
   }
 }
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('msi-${location}-${managedIdentity.id}-Reader-RoleAssignment')
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7') // Reader
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: pairedRegionScriptName
+  location: location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
+  }
+  properties: {
+    azPowerShellVersion: '8.0'
+    retentionInterval: 'P1D'
+    arguments: '-Location \\"${location}\\"'
+    scriptContent: loadTextContent('../../../../.shared/.scripts/Get-PairedRegion.ps1')
+  }
+  dependsOn: [
+    roleAssignment
+  ]
+}
+
+@description('The name of the paired region.')
+output pairedRegionName string = getPairedRegionScript.properties.outputs.pairedRegionName
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/modules/document-db/database-account/.test/sqldb/main.test.bicep
+++ b/modules/document-db/database-account/.test/sqldb/main.test.bicep
@@ -37,6 +37,7 @@ module nestedDependencies 'dependencies.bicep' = {
   params: {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
+    pairedRegionScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
   }
 }
 
@@ -68,12 +69,12 @@ module testDeployment '../../main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: location
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: nestedDependencies.outputs.pairedRegionName
       }
     ]
     diagnosticStorageAccountId: diagnosticDependencies.outputs.storageAccountResourceId

--- a/modules/document-db/database-account/README.md
+++ b/modules/document-db/database-account/README.md
@@ -666,12 +666,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: '<location>'
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: '<locationName>'
       }
     ]
     name: 'dddagrm002'
@@ -770,12 +770,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
         {
           "failoverPriority": 0,
           "isZoneRedundant": false,
-          "locationName": "West Europe"
+          "locationName": "<location>"
         },
         {
           "failoverPriority": 1,
           "isZoneRedundant": false,
-          "locationName": "North Europe"
+          "locationName": "<locationName>"
         }
       ]
     },
@@ -899,12 +899,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: '<location>'
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: '<locationName>'
       }
     ]
     name: 'dddamng001'
@@ -1136,12 +1136,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
         {
           "failoverPriority": 0,
           "isZoneRedundant": false,
-          "locationName": "West Europe"
+          "locationName": "<location>"
         },
         {
           "failoverPriority": 1,
           "isZoneRedundant": false,
-          "locationName": "North Europe"
+          "locationName": "<locationName>"
         }
       ]
     },
@@ -1396,12 +1396,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: '<location>'
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: '<locationName>'
       }
     ]
     name: 'dddapln001'
@@ -1448,12 +1448,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
         {
           "failoverPriority": 0,
           "isZoneRedundant": false,
-          "locationName": "West Europe"
+          "locationName": "<location>"
         },
         {
           "failoverPriority": 1,
           "isZoneRedundant": false,
-          "locationName": "North Europe"
+          "locationName": "<locationName>"
         }
       ]
     },
@@ -1519,12 +1519,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
       {
         failoverPriority: 0
         isZoneRedundant: false
-        locationName: 'West Europe'
+        locationName: '<location>'
       }
       {
         failoverPriority: 1
         isZoneRedundant: false
-        locationName: 'North Europe'
+        locationName: '<locationName>'
       }
     ]
     name: 'dddasql001'
@@ -1666,12 +1666,12 @@ module databaseAccount './document-db/database-account/main.bicep' = {
         {
           "failoverPriority": 0,
           "isZoneRedundant": false,
-          "locationName": "West Europe"
+          "locationName": "<location>"
         },
         {
           "failoverPriority": 1,
           "isZoneRedundant": false,
-          "locationName": "North Europe"
+          "locationName": "<locationName>"
         }
       ]
     },


### PR DESCRIPTION
# Description

Updated Cosmos DB to support dynamic location for primary and secondary regions in test file. Used the deployment script pattern we applied for other modules.

| Pipeline |
| - |
| [![DocumentDB - DatabaseAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Fahmad%2FcosmosUpdate)](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml)|

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
