### PR TITLE
[Modules] Enable AAD authentication (#3952)

### DIFF
--- a/modules/db-for-postgre-sql/flexible-server/.test/public/dependencies.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/.test/public/dependencies.bicep
@@ -51,6 +51,12 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 @description('The resource ID of the created Managed Identity.')
 output managedIdentityResourceId string = managedIdentity.id
 
+@description('The client ID of the created Managed Identity.')
+output managedIdentityClientId string = managedIdentity.properties.clientId
+
+@description('The name of the created Managed Identity.')
+output managedIdentityName string = managedIdentity.name
+
 @description('The resource ID of the created Key Vault.')
 output keyVaultResourceId string = keyVault.id
 

--- a/modules/db-for-postgre-sql/flexible-server/.test/public/main.test.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/.test/public/main.test.bicep
@@ -72,8 +72,13 @@ module testDeployment '../../main.bicep' = {
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '${namePrefix}${serviceShort}001'
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: password
+    administrators: [
+      {
+        objectId: nestedDependencies.outputs.managedIdentityClientId
+        principalName: nestedDependencies.outputs.managedIdentityName
+        principalType: 'ServicePrincipal'
+      }
+    ]
     skuName: 'Standard_D2s_v3'
     tier: 'GeneralPurpose'
     availabilityZone: '1'

--- a/modules/db-for-postgre-sql/flexible-server/README.md
+++ b/modules/db-for-postgre-sql/flexible-server/README.md
@@ -17,6 +17,7 @@ This module deploys a DBforPostgreSQL Flexible Server.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.DBforPostgreSQL/flexibleServers` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers) |
+| `Microsoft.DBforPostgreSQL/flexibleServers/administrators` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers/administrators) |
 | `Microsoft.DBforPostgreSQL/flexibleServers/configurations` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers/configurations) |
 | `Microsoft.DBforPostgreSQL/flexibleServers/databases` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers/databases) |
 | `Microsoft.DBforPostgreSQL/flexibleServers/firewallRules` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers/firewallRules) |
@@ -28,8 +29,6 @@ This module deploys a DBforPostgreSQL Flexible Server.
 
 | Parameter Name | Type | Allowed Values | Description |
 | :-- | :-- | :-- | :-- |
-| `administratorLogin` | string |  | The administrator login name of a server. Can only be specified when the PostgreSQL server is being created. |
-| `administratorLoginPassword` | securestring |  | The administrator login password. |
 | `name` | string |  | The name of the PostgreSQL flexible server. |
 | `skuName` | string |  | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. |
 | `tier` | string | `[Burstable, GeneralPurpose, MemoryOptimized]` | The tier of the particular SKU. Tier must align with the "skuName" property. Example, tier cannot be "Burstable" if skuName is "Standard_D4s_v3". |
@@ -48,6 +47,10 @@ This module deploys a DBforPostgreSQL Flexible Server.
 
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `activeDirectoryAuth` | string | `'Enabled'` | `[Disabled, Enabled]` | If Enabled, Azure Active Directory authentication is enabled. |
+| `administratorLogin` | string | `''` |  | The administrator login name of a server. Can only be specified when the PostgreSQL server is being created. |
+| `administratorLoginPassword` | securestring | `''` |  | The administrator login password. |
+| `administrators` | array | `[]` |  | The Azure AD administrators when AAD authentication enabled. |
 | `availabilityZone` | string | `''` | `['', 1, 2, 3]` | Availability zone information of the server. Default will have no preference set. |
 | `backupRetentionDays` | int | `7` |  | Backup retention days for the server. |
 | `cMKKeyName` | string | `''` |  | The name of the customer managed key to use for encryption. |
@@ -70,10 +73,12 @@ This module deploys a DBforPostgreSQL Flexible Server.
 | `location` | string | `[resourceGroup().location]` |  | Location for all resources. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
 | `maintenanceWindow` | object | `{object}` |  | Properties for the maintenence window. If provided, "customWindow" property must exist and set to "Enabled". |
+| `passwordAuth` | string | `'Disabled'` | `[Disabled, Enabled]` | If Enabled, password authentication is enabled. |
 | `privateDnsZoneArmResourceId` | string | `''` |  | Private dns zone arm resource ID. Used when the desired connectivity mode is "Private Access" and required when "delegatedSubnetResourceId" is used. The Private DNS Zone must be lined to the Virtual Network referenced in "delegatedSubnetResourceId". |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `storageSizeGB` | int | `32` | `[32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]` | Max storage allowed for a server. |
 | `tags` | object | `{object}` |  | Tags of the resource. |
+| `tenantId` | string | `''` |  | Tenant id of the server. |
 | `version` | string | `'15'` | `[11, 12, 13, 14, 15]` | PostgreSQL Server version. |
 
 
@@ -384,12 +389,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfpsfsmin'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfpsfsmin001'
     skuName: 'Standard_B2s'
     tier: 'Burstable'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
   }
 }
@@ -408,12 +413,6 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfpsfsmin001"
     },
@@ -424,6 +423,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
       "value": "Burstable"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     }
@@ -445,12 +450,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfpsfspvt'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfpsfspvt001'
     skuName: 'Standard_D2s_v3'
     tier: 'GeneralPurpose'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     configurations: [
       {
         name: 'log_min_messages'
@@ -503,12 +508,6 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfpsfspvt001"
     },
@@ -519,6 +518,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "configurations": {
       "value": [
         {
@@ -594,12 +599,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfpsfsp'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfpsfsp001'
     skuName: 'Standard_D2s_v3'
     tier: 'GeneralPurpose'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     availabilityZone: '1'
     backupRetentionDays: 20
     cMKKeyName: '<cMKKeyName>'
@@ -674,12 +679,6 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfpsfsp001"
     },
@@ -690,6 +689,12 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "availabilityZone": {
       "value": "1"
     },

--- a/modules/db-for-postgre-sql/flexible-server/README.md
+++ b/modules/db-for-postgre-sql/flexible-server/README.md
@@ -603,8 +603,13 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
     skuName: 'Standard_D2s_v3'
     tier: 'GeneralPurpose'
     // Non-required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
+    administrators: [
+      {
+        objectId: '<objectId>'
+        principalName: '<principalName>'
+        principalType: 'ServicePrincipal'
+      }
+    ]
     availabilityZone: '1'
     backupRetentionDays: 20
     cMKKeyName: '<cMKKeyName>'
@@ -689,11 +694,14 @@ module flexibleServer './db-for-postgre-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
+    "administrators": {
+      "value": [
+        {
+          "objectId": "<objectId>",
+          "principalName": "<principalName>",
+          "principalType": "ServicePrincipal"
+        }
+      ]
     },
     "availabilityZone": {
       "value": "1"

--- a/modules/db-for-postgre-sql/flexible-server/administrator/README.md
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/README.md
@@ -24,7 +24,6 @@ This module deploys a DBforPostgreSQL Flexible Server Administrator.
 | `objectId` | string |  | The objectId of the Active Directory administrator. |
 | `principalName` | string |  | Active Directory administrator principal name. |
 | `principalType` | string | `[Group, ServicePrincipal, Unknown, User]` | The principal type used to represent the type of Active Directory Administrator. |
-| `tenantId` | string |  | The tenantId of the Active Directory administrator. |
 
 **Conditional parameters**
 
@@ -38,6 +37,7 @@ This module deploys a DBforPostgreSQL Flexible Server Administrator.
 | :-- | :-- | :-- | :-- |
 | `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `location` | string | `[resourceGroup().location]` | Location for all resources. |
+| `tenantId` | string | `[tenant().tenantId]` | The tenantId of the Active Directory administrator. |
 
 
 ## Outputs

--- a/modules/db-for-postgre-sql/flexible-server/administrator/README.md
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/README.md
@@ -1,0 +1,53 @@
+# DBforPostgreSQL Flexible Server Administrators `[Microsoft.DBforPostgreSQL/flexibleServers/administrators]`
+
+This module deploys a DBforPostgreSQL Flexible Server Administrator.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.DBforPostgreSQL/flexibleServers/administrators` | [2022-12-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforPostgreSQL/2022-12-01/flexibleServers/administrators) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Allowed Values | Description |
+| :-- | :-- | :-- | :-- |
+| `objectId` | string |  | The objectId of the Active Directory administrator. |
+| `principalName` | string |  | Active Directory administrator principal name. |
+| `principalType` | string | `[Group, ServicePrincipal, Unknown, User]` | The principal type used to represent the type of Active Directory Administrator. |
+| `tenantId` | string |  | The tenantId of the Active Directory administrator. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `flexibleServerName` | string | The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `location` | string | `[resourceGroup().location]` | Location for all resources. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the deployed administrator. |
+| `resourceGroupName` | string | The resource group of the deployed administrator. |
+| `resourceId` | string | The resource ID of the deployed administrator. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/db-for-postgre-sql/flexible-server/administrator/main.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/main.bicep
@@ -20,8 +20,8 @@ param principalName string
 @description('Required. The principal type used to represent the type of Active Directory Administrator.')
 param principalType string
 
-@description('Required. The tenantId of the Active Directory administrator.')
-param tenantId string
+@description('Optional. The tenantId of the Active Directory administrator.')
+param tenantId string = tenant().tenantId
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location

--- a/modules/db-for-postgre-sql/flexible-server/administrator/main.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/main.bicep
@@ -1,0 +1,65 @@
+metadata name = 'DBforPostgreSQL Flexible Server Administrators'
+metadata description = 'This module deploys a DBforPostgreSQL Flexible Server Administrator.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment.')
+param flexibleServerName string
+
+@description('Required. The objectId of the Active Directory administrator.')
+param objectId string
+
+@description('Required. Active Directory administrator principal name.')
+param principalName string
+
+@allowed([
+  'Group'
+  'ServicePrincipal'
+  'Unknown'
+  'User'
+])
+@description('Required. The principal type used to represent the type of Active Directory Administrator.')
+param principalType string
+
+@description('Required. The tenantId of the Active Directory administrator.')
+param tenantId string
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource flexibleServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' existing = {
+  name: flexibleServerName
+}
+
+resource administrator 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2022-12-01' = {
+  name: objectId
+  parent: flexibleServer
+  properties: {
+    principalName: principalName
+    principalType: principalType
+    tenantId: tenantId
+  }
+}
+
+@description('The name of the deployed administrator.')
+output name string = administrator.name
+
+@description('The resource ID of the deployed administrator.')
+output resourceId string = administrator.id
+
+@description('The resource group of the deployed administrator.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/db-for-postgre-sql/flexible-server/administrator/main.json
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "15603250169041540085"
+      "templateHash": "14812998248518641282"
     },
     "name": "DBforPostgreSQL Flexible Server Administrators",
     "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",
@@ -44,8 +44,9 @@
     },
     "tenantId": {
       "type": "string",
+      "defaultValue": "[tenant().tenantId]",
       "metadata": {
-        "description": "Required. The tenantId of the Active Directory administrator."
+        "description": "Optional. The tenantId of the Active Directory administrator."
       }
     },
     "location": {

--- a/modules/db-for-postgre-sql/flexible-server/administrator/main.json
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/main.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.21.1.54444",
+      "templateHash": "15603250169041540085"
+    },
+    "name": "DBforPostgreSQL Flexible Server Administrators",
+    "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",
+    "owner": "Azure/module-maintainers"
+  },
+  "parameters": {
+    "flexibleServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+      }
+    },
+    "objectId": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. The objectId of the Active Directory administrator."
+      }
+    },
+    "principalName": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Active Directory administrator principal name."
+      }
+    },
+    "principalType": {
+      "type": "string",
+      "allowedValues": [
+        "Group",
+        "ServicePrincipal",
+        "Unknown",
+        "User"
+      ],
+      "metadata": {
+        "description": "Required. The principal type used to represent the type of Active Directory Administrator."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. The tenantId of the Active Directory administrator."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Optional. Location for all resources."
+      }
+    },
+    "enableDefaultTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+      }
+    }
+  },
+  "resources": [
+    {
+      "condition": "[parameters('enableDefaultTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2021-04-01",
+      "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/administrators",
+      "apiVersion": "2022-12-01",
+      "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('objectId'))]",
+      "properties": {
+        "principalName": "[parameters('principalName')]",
+        "principalType": "[parameters('principalType')]",
+        "tenantId": "[parameters('tenantId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the deployed administrator."
+      },
+      "value": "[parameters('objectId')]"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the deployed administrator."
+      },
+      "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/administrators', parameters('flexibleServerName'), parameters('objectId'))]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the deployed administrator."
+      },
+      "value": "[resourceGroup().name]"
+    }
+  }
+}

--- a/modules/db-for-postgre-sql/flexible-server/administrator/version.json
+++ b/modules/db-for-postgre-sql/flexible-server/administrator/version.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1",
+    "pathFilters": [
+        "./main.json"
+    ]
+}

--- a/modules/db-for-postgre-sql/flexible-server/main.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/main.bicep
@@ -24,6 +24,7 @@ param activeDirectoryAuth string = 'Enabled'
   'Enabled'
 ])
 @description('Optional. If Enabled, password authentication is enabled.')
+#disable-next-line secure-secrets-in-params
 param passwordAuth string = 'Disabled'
 
 @description('Optional. Tenant id of the server.')
@@ -362,7 +363,7 @@ module flexibleServer_administrators 'administrator/main.bicep' = [for (administ
     objectId: administrator.objectId
     principalName: administrator.principalName
     principalType: administrator.principalType
-    tenantId: administrator.tenantId
+    tenantId: contains(administrator, 'tenantId') ? administrator.tenantId : tenant().tenantId
   }
 }]
 

--- a/modules/db-for-postgre-sql/flexible-server/main.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/main.bicep
@@ -5,12 +5,32 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the PostgreSQL flexible server.')
 param name string
 
-@description('Required. The administrator login name of a server. Can only be specified when the PostgreSQL server is being created.')
-param administratorLogin string
+@description('Optional. The administrator login name of a server. Can only be specified when the PostgreSQL server is being created.')
+param administratorLogin string = ''
 
-@description('Required. The administrator login password.')
+@description('Optional. The administrator login password.')
 @secure()
-param administratorLoginPassword string
+param administratorLoginPassword string = ''
+
+@allowed([
+  'Disabled'
+  'Enabled'
+])
+@description('Optional. If Enabled, Azure Active Directory authentication is enabled.')
+param activeDirectoryAuth string = 'Enabled'
+
+@allowed([
+  'Disabled'
+  'Enabled'
+])
+@description('Optional. If Enabled, password authentication is enabled.')
+param passwordAuth string = 'Disabled'
+
+@description('Optional. Tenant id of the server.')
+param tenantId string = ''
+
+@description('Optional. The Azure AD administrators when AAD authentication enabled.')
+param administrators array = []
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -233,8 +253,13 @@ resource flexibleServer 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' =
     userAssignedIdentities: !empty(userAssignedIdentities) ? userAssignedIdentities : {}
   }
   properties: {
-    administratorLogin: administratorLogin
-    administratorLoginPassword: administratorLoginPassword
+    administratorLogin: !empty(administratorLogin) ? administratorLogin : null
+    administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
+    authConfig: {
+      activeDirectoryAuth: activeDirectoryAuth
+      passwordAuth: passwordAuth
+      tenantId: !empty(tenantId) ? tenantId : null
+    }
     availabilityZone: availabilityZone
     backup: {
       backupRetentionDays: backupRetentionDays
@@ -328,6 +353,17 @@ module flexibleServer_configurations 'configuration/main.bicep' = [for (configur
   dependsOn: [
     flexibleServer_firewallRules
   ]
+}]
+
+module flexibleServer_administrators 'administrator/main.bicep' = [for (administrator, index) in administrators: {
+  name: '${uniqueString(deployment().name, location)}-PostgreSQL-Administrators-${index}'
+  params: {
+    flexibleServerName: flexibleServer.name
+    objectId: administrator.objectId
+    principalName: administrator.principalName
+    principalType: administrator.principalType
+    tenantId: administrator.tenantId
+  }
 }]
 
 resource flexibleServer_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if ((!empty(diagnosticStorageAccountId)) || (!empty(diagnosticWorkspaceId)) || (!empty(diagnosticEventHubAuthorizationRuleId)) || (!empty(diagnosticEventHubName))) {

--- a/modules/db-for-postgre-sql/flexible-server/main.json
+++ b/modules/db-for-postgre-sql/flexible-server/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "9979434012524626426"
+      "templateHash": "12855050974164502649"
     },
     "name": "DBforPostgreSQL Flexible Servers",
     "description": "This module deploys a DBforPostgreSQL Flexible Server.",
@@ -20,14 +20,52 @@
     },
     "administratorLogin": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
-        "description": "Required. The administrator login name of a server. Can only be specified when the PostgreSQL server is being created."
+        "description": "Optional. The administrator login name of a server. Can only be specified when the PostgreSQL server is being created."
       }
     },
     "administratorLoginPassword": {
       "type": "securestring",
+      "defaultValue": "",
       "metadata": {
-        "description": "Required. The administrator login password."
+        "description": "Optional. The administrator login password."
+      }
+    },
+    "activeDirectoryAuth": {
+      "type": "string",
+      "defaultValue": "Enabled",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
+      "metadata": {
+        "description": "Optional. If Enabled, Azure Active Directory authentication is enabled."
+      }
+    },
+    "passwordAuth": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
+      "metadata": {
+        "description": "Optional. If Enabled, password authentication is enabled."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. Tenant id of the server."
+      }
+    },
+    "administrators": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. The Azure AD administrators when AAD authentication enabled."
       }
     },
     "location": {
@@ -389,8 +427,13 @@
         "userAssignedIdentities": "[if(not(empty(parameters('userAssignedIdentities'))), parameters('userAssignedIdentities'), createObject())]"
       },
       "properties": {
-        "administratorLogin": "[parameters('administratorLogin')]",
-        "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+        "administratorLogin": "[if(not(empty(parameters('administratorLogin'))), parameters('administratorLogin'), null())]",
+        "administratorLoginPassword": "[if(not(empty(parameters('administratorLoginPassword'))), parameters('administratorLoginPassword'), null())]",
+        "authConfig": {
+          "activeDirectoryAuth": "[parameters('activeDirectoryAuth')]",
+          "passwordAuth": "[parameters('passwordAuth')]",
+          "tenantId": "[if(not(empty(parameters('tenantId'))), parameters('tenantId'), null())]"
+        },
         "availabilityZone": "[parameters('availabilityZone')]",
         "backup": {
           "backupRetentionDays": "[parameters('backupRetentionDays')]",
@@ -992,6 +1035,156 @@
       "dependsOn": [
         "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]",
         "flexibleServer_firewallRules"
+      ]
+    },
+    {
+      "copy": {
+        "name": "flexibleServer_administrators",
+        "count": "[length(parameters('administrators'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-PostgreSQL-Administrators-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "flexibleServerName": {
+            "value": "[parameters('name')]"
+          },
+          "objectId": {
+            "value": "[parameters('administrators')[copyIndex()].objectId]"
+          },
+          "principalName": {
+            "value": "[parameters('administrators')[copyIndex()].principalName]"
+          },
+          "principalType": {
+            "value": "[parameters('administrators')[copyIndex()].principalType]"
+          },
+          "tenantId": {
+            "value": "[parameters('administrators')[copyIndex()].tenantId]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.21.1.54444",
+              "templateHash": "5950920282464628930"
+            },
+            "name": "DBforPostgreSQL Flexible Server Administrators ",
+            "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",
+            "owner": "Azure/module-maintainers"
+          },
+          "parameters": {
+            "flexibleServerName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent PostgreSQL flexible server. Required if the template is used in a standalone deployment."
+              }
+            },
+            "objectId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The objectId of the Active Directory administrator."
+              }
+            },
+            "principalName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Active Directory administrator principal name."
+              }
+            },
+            "principalType": {
+              "type": "string",
+              "allowedValues": [
+                "Group",
+                "ServicePrincipal",
+                "Unknown",
+                "User"
+              ],
+              "metadata": {
+                "description": "Required. The principal type used to represent the type of Active Directory Administrator."
+              }
+            },
+            "tenantId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The tenantId of the Active Directory administrator."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.DBforPostgreSQL/flexibleServers/administrators",
+              "apiVersion": "2022-12-01",
+              "name": "[format('{0}/{1}', parameters('flexibleServerName'), parameters('objectId'))]",
+              "properties": {
+                "principalName": "[parameters('principalName')]",
+                "principalType": "[parameters('principalType')]",
+                "tenantId": "[parameters('tenantId')]"
+              }
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed administrator."
+              },
+              "value": "[parameters('objectId')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed administrator."
+              },
+              "value": "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers/administrators', parameters('flexibleServerName'), parameters('objectId'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed administrator."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', parameters('name'))]"
       ]
     }
   ],

--- a/modules/db-for-postgre-sql/flexible-server/main.json
+++ b/modules/db-for-postgre-sql/flexible-server/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "12855050974164502649"
+      "templateHash": "16240139018001575474"
     },
     "name": "DBforPostgreSQL Flexible Servers",
     "description": "This module deploys a DBforPostgreSQL Flexible Server.",
@@ -1063,9 +1063,7 @@
           "principalType": {
             "value": "[parameters('administrators')[copyIndex()].principalType]"
           },
-          "tenantId": {
-            "value": "[parameters('administrators')[copyIndex()].tenantId]"
-          }
+          "tenantId": "[if(contains(parameters('administrators')[copyIndex()], 'tenantId'), createObject('value', parameters('administrators')[copyIndex()].tenantId), createObject('value', tenant().tenantId))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1074,9 +1072,9 @@
             "_generator": {
               "name": "bicep",
               "version": "0.21.1.54444",
-              "templateHash": "5950920282464628930"
+              "templateHash": "14812998248518641282"
             },
-            "name": "DBforPostgreSQL Flexible Server Administrators ",
+            "name": "DBforPostgreSQL Flexible Server Administrators",
             "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",
             "owner": "Azure/module-maintainers"
           },
@@ -1113,8 +1111,9 @@
             },
             "tenantId": {
               "type": "string",
+              "defaultValue": "[tenant().tenantId]",
               "metadata": {
-                "description": "Required. The tenantId of the Active Directory administrator."
+                "description": "Optional. The tenantId of the Active Directory administrator."
               }
             },
             "location": {


### PR DESCRIPTION
# Description

Changes to enable AAD authentication and set AAD admins to the PostgreSQL flexibleServers. Changed the administratorLogin and administratorLoginPassword parameters to optional to set AAD authentication only

Based on #3952

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![DbForPostgreSQL - FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml/badge.svg?branch=users%2Falsehr%2Fppotturi%2Fpostgresql-add-auth)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
