### PR TITLE
[CI Platform] Fixed ADO Publish Job for Bicep Registry ordering for prerelease and feature branch publishing

### DIFF
--- a/.azuredevops/pipelineTemplates/jobs.publishModule.yml
+++ b/.azuredevops/pipelineTemplates/jobs.publishModule.yml
@@ -179,7 +179,7 @@ jobs:
             $missingModules = Get-ModulesMissingFromUniversalArtifactsFeed @missingInputObject -BearerToken $env:TOKEN
 
             foreach($missingModule in $missingModules) {
-              if($modulsToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
+              if($modulesToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
                 $modulesToPublish += $missingModule
               }
             }
@@ -288,7 +288,7 @@ jobs:
             $missingModules = Get-ModulesMissingFromTemplateSpecsRG @missingInputObject
 
             foreach($missingModule in $missingModules) {
-              if($modulsToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
+              if($modulesToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
                 $modulesToPublish += $missingModule
               }
             }
@@ -397,17 +397,17 @@ jobs:
 
             $missingModules = Get-ModulesMissingFromPrivateBicepRegistry @missingInputObject
 
+            foreach($missingModule in $missingModules) {
+              if($modulesToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
+                $modulesToPublish += $missingModule
+              }
+            }
+
             # Filter modules to publish 'prerelease' only if branch is not main/master
             $BranchName = '$(Build.SourceBranch)'
             if ($BranchName -ne 'refs/heads/main' -and $BranchName -ne 'refs/heads/master') {
               Write-Verbose "Filtering modules to only publish a [prerelease] version as the current branch [$BranchName] is not [main/master]." -Verbose
               $modulesToPublish = $modulesToPublish | Where-Object -Property version -like '*-prerelease'
-            }
-
-            foreach($missingModule in $missingModules) {
-              if($modulsToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
-                $modulesToPublish += $missingModule
-              }
             }
 
             #################

--- a/.github/actions/templates/publishModule/action.yml
+++ b/.github/actions/templates/publishModule/action.yml
@@ -136,7 +136,7 @@ runs:
           $missingModules = Get-ModulesMissingFromTemplateSpecsRG @missingInputObject
 
           foreach($missingModule in $missingModules) {
-            if($modulsToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
+            if($modulesToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
               $modulesToPublish += $missingModule
             }
           }
@@ -224,7 +224,7 @@ runs:
           $missingModules = Get-ModulesMissingFromPrivateBicepRegistry @missingInputObject
 
           foreach($missingModule in $missingModules) {
-            if($modulsToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
+            if($modulesToPublish.TemplateFilePath -notcontains $missingModule.TemplateFilePath) {
               $modulesToPublish += $missingModule
             }
           }


### PR DESCRIPTION
# Description

Fixed an ordering for the publish stage in ADO - Bicep Registry as the order is not right. This is a copy/paste error when #3906 was implemented. The reason it didn't appear in that PR is that it was tested correctly initially, but when standardizing the code block across Artifacts, Template Specs, and Bicep Registry, the code block was copied to the incorrect space. This causes the following error for only ADO - BR - Feature branch publishing:

### Before

![image](https://github.com/Azure/ResourceModules/assets/28486158/f2df9a30-31d5-4914-812b-c77e43748521)

```powershell
VERBOSE: Looking for modified files under: [managed-identity/user-assigned-identity]
VERBOSE: Modified modules found: [1]
VERBOSE:  - [managed-identity/user-assigned-identity]
VERBOSE: Publish the following modules:
VERBOSE:  - [managed-identity/user-assigned-identity] [0.11.2251-prerelease] 
VERBOSE: Invoke Get-ModulesMissingFromPrivateBicepRegistry with
VERBOSE: {
  "BicepRegistryName": "ahmadcarmldemobr",
  "PublishLatest": true,
  "BicepRegistryRgName": "artifacts-rg",
  "UseApiSpecsAlignedName": false,
  "TemplateFilePath": "/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/main.bicep"
}

VERBOSE: Missing module [/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep] will be considered for publishing with version(s) [0.4.0, 0.4, 0, latest]
VERBOSE: Missing module [/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/main.bicep] will be considered for publishing with version(s) [0.11.0, 0.11, 0, latest]
VERBOSE: Filtering modules to only publish a [prerelease] version as the current branch [refs/heads/users/ahmad/pubfix] is not [main/master].
Item has already been added. Key in dictionary: 'TemplateFilePath'  Key being added: 'TemplateFilePath'
At /home/vsts/work/_temp/azureclitaskscript1694481746400_inlinescript.ps1:70 char:5
+     $modulesToPublish += $missingModule
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (:) [], ArgumentException
+ FullyQualifiedErrorId : System.ArgumentException
##[error]Script failed with exit code: 1
/usr/bin/az account clear
Finishing: Publish module to private bicep registry

```

### After

![image](https://github.com/Azure/ResourceModules/assets/28486158/b04b9788-b504-48f5-afd5-22d0c20b2141)

```powershell
VERBOSE: Missing module [/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep] will be considered for publishing with version(s) [0.4.0, 0.4, 0, latest]
VERBOSE: Missing module [/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/main.bicep] will be considered for publishing with version(s) [0.11.0, 0.11, 0, latest]
VERBOSE: Filtering modules to only publish a [prerelease] version as the current branch [refs/heads/users/ahmad/pubfix] is not [main/master].
 - [managed-identity/user-assigned-identity] [0.11.2252-prerelease]
VERBOSE: Invoke Publish-ModuleToPrivateBicepRegistry with
VERBOSE: {
  "TemplateFilePath": "/home/vsts/work/1/s/modules/managed-identity/user-assigned-identity/main.bicep",
  "BicepRegistryRgName": "artifacts-rg",
  "BicepRegistryName": "ahmadcarmldemobr",
  "ModuleVersion": "0.11.2252-prerelease",
  "UseApiSpecsAlignedName": false,
  "BicepRegistryRgLocation": "West Europe"
}

VERBOSE: Performing the operation "Publish" on target "Private bicep registry entry [bicep/modules/managed-identity.user-assigned-identity] version [0.11.2252-prerelease] to registry [ahmadcarmldemobr]".
VERBOSE: Publish complete
/usr/bin/az account clear
Finishing: Publish module to private bicep registry

```

In addition, there was an old typo `$modulsToPublish.TemplateFilePath` which has been changed to `$modulesToPublish.TemplateFilePath`. This is applicable to ADO and GHA

> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.
-->

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![Network - ApplicationSecurityGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml/badge.svg?branch=users%2Fahmad%2Fpubfix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml)|
| [![ManagedIdentity - UserAssignedIdentities](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedidentity.userassignedidentities.yml/badge.svg?branch=users%2Fahmad%2Fpubfix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedidentity.userassignedidentities.yml)| 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
