### PR TITLE
[Modules] Added support for Azure AD Authentication for MySQL Flexible Server

### DIFF
--- a/modules/db-for-my-sql/flexible-server/.test/private/dependencies.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/private/dependencies.bicep
@@ -64,6 +64,9 @@ output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSResourceId string = privateDNSZone.id
 
+@description('The name of the created Managed Identity.')
+output managedIdentityName string = managedIdentity.name
+
 @description('The resource ID of the created Managed Identity.')
 output managedIdentityResourceId string = managedIdentity.id
 

--- a/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
@@ -109,5 +109,13 @@ module testDeployment '../../main.bicep' = {
     diagnosticWorkspaceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
     diagnosticEventHubAuthorizationRuleId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+    administrators: [
+      {
+        identityResourceId: nestedDependencies.outputs.managedIdentityResourceId
+        login: 'adminUserName'
+        sid: nestedDependencies.outputs.managedIdentityPrincipalId
+        tenantId: subscription().tenantId
+      }
+    ]
   }
 }

--- a/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
@@ -112,9 +112,8 @@ module testDeployment '../../main.bicep' = {
     administrators: [
       {
         identityResourceId: nestedDependencies.outputs.managedIdentityResourceId
-        login: 'adminUserName'
+        login: nestedDependencies.outputs.managedIdentityName
         sid: nestedDependencies.outputs.managedIdentityPrincipalId
-        tenantId: subscription().tenantId
       }
     ]
   }

--- a/modules/db-for-my-sql/flexible-server/README.md
+++ b/modules/db-for-my-sql/flexible-server/README.md
@@ -319,9 +319,8 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
     administrators: [
       {
         identityResourceId: '<identityResourceId>'
-        login: 'adminUserName'
+        login: '<login>'
         sid: '<sid>'
-        tenantId: '<tenantId>'
       }
     ]
     backupRetentionDays: 10
@@ -398,9 +397,8 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
       "value": [
         {
           "identityResourceId": "<identityResourceId>",
-          "login": "adminUserName",
-          "sid": "<sid>",
-          "tenantId": "<tenantId>"
+          "login": "<login>",
+          "sid": "<sid>"
         }
       ]
     },

--- a/modules/db-for-my-sql/flexible-server/README.md
+++ b/modules/db-for-my-sql/flexible-server/README.md
@@ -28,8 +28,6 @@ This module deploys a DBforMySQL Flexible Server.
 
 | Parameter Name | Type | Allowed Values | Description |
 | :-- | :-- | :-- | :-- |
-| `administratorLogin` | string |  | The administrator login name of a server. Can only be specified when the MySQL server is being created. |
-| `administratorLoginPassword` | securestring |  | The administrator login password. |
 | `name` | string |  | The name of the MySQL flexible server. |
 | `skuName` | string |  | The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3. |
 | `tier` | string | `[Burstable, GeneralPurpose, MemoryOptimized]` | The tier of the particular SKU. Tier must align with the "skuName" property. Example, tier cannot be "Burstable" if skuName is "Standard_D4s_v3". |
@@ -52,6 +50,8 @@ This module deploys a DBforMySQL Flexible Server.
 
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `administratorLogin` | string | `''` |  | The administrator login name of a server. Can only be specified when the MySQL server is being created. |
+| `administratorLoginPassword` | securestring | `''` |  | The administrator login password. |
 | `administrators` | array | `[]` |  | The Azure AD administrators when AAD authentication enabled. |
 | `availabilityZone` | string | `''` | `['', 1, 2, 3]` | Availability zone information of the server. Default will have no preference set. |
 | `backupRetentionDays` | int | `7` |  | Backup retention days for the server. |
@@ -249,12 +249,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfmsfsmin'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfmsfsmin001'
     skuName: 'Standard_B1ms'
     tier: 'Burstable'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
   }
 }
@@ -273,12 +273,6 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfmsfsmin001"
     },
@@ -289,6 +283,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
       "value": "Burstable"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "enableDefaultTelemetry": {
       "value": "<enableDefaultTelemetry>"
     }
@@ -310,12 +310,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfmsfspvt'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfmsfspvt001'
     skuName: 'Standard_D2ds_v4'
     tier: 'GeneralPurpose'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     administrators: [
       {
         identityResourceId: '<identityResourceId>'
@@ -377,12 +377,6 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfmsfspvt001"
     },
@@ -393,6 +387,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "administrators": {
       "value": [
         {
@@ -495,12 +495,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   name: '${uniqueString(deployment().name, location)}-test-dfmsfsp'
   params: {
     // Required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
     name: 'dfmsfsp001'
     skuName: 'Standard_D2ds_v4'
     tier: 'GeneralPurpose'
     // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
     availabilityZone: '1'
     backupRetentionDays: 20
     cMKKeyName: '<cMKKeyName>'
@@ -585,12 +585,6 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
-    },
     "name": {
       "value": "dfmsfsp001"
     },
@@ -601,6 +595,12 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
     "availabilityZone": {
       "value": "1"
     },

--- a/modules/db-for-my-sql/flexible-server/README.md
+++ b/modules/db-for-my-sql/flexible-server/README.md
@@ -17,6 +17,7 @@ This module deploys a DBforMySQL Flexible Server.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.DBforMySQL/flexibleServers` | [2022-09-30-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforMySQL/2022-09-30-preview/flexibleServers) |
+| `Microsoft.DBforMySQL/flexibleServers/administrators` | [2022-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforMySQL/2022-01-01/flexibleServers/administrators) |
 | `Microsoft.DBforMySQL/flexibleServers/databases` | [2022-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforMySQL/2022-01-01/flexibleServers/databases) |
 | `Microsoft.DBforMySQL/flexibleServers/firewallRules` | [2022-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforMySQL/2022-01-01/flexibleServers/firewallRules) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
@@ -51,6 +52,7 @@ This module deploys a DBforMySQL Flexible Server.
 
 | Parameter Name | Type | Default Value | Allowed Values | Description |
 | :-- | :-- | :-- | :-- | :-- |
+| `administrators` | array | `[]` |  | The Azure AD administrators when AAD authentication enabled. |
 | `availabilityZone` | string | `''` | `['', 1, 2, 3]` | Availability zone information of the server. Default will have no preference set. |
 | `backupRetentionDays` | int | `7` |  | Backup retention days for the server. |
 | `cMKKeyName` | string | `''` |  | The name of the customer managed key to use for encryption. |
@@ -314,6 +316,14 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
     skuName: 'Standard_D2ds_v4'
     tier: 'GeneralPurpose'
     // Non-required parameters
+    administrators: [
+      {
+        identityResourceId: '<identityResourceId>'
+        login: 'adminUserName'
+        sid: '<sid>'
+        tenantId: '<tenantId>'
+      }
+    ]
     backupRetentionDays: 10
     databases: [
       {
@@ -384,6 +394,16 @@ module flexibleServer './db-for-my-sql/flexible-server/main.bicep' = {
       "value": "GeneralPurpose"
     },
     // Non-required parameters
+    "administrators": {
+      "value": [
+        {
+          "identityResourceId": "<identityResourceId>",
+          "login": "adminUserName",
+          "sid": "<sid>",
+          "tenantId": "<tenantId>"
+        }
+      ]
+    },
     "backupRetentionDays": {
       "value": 10
     },

--- a/modules/db-for-my-sql/flexible-server/administrator/README.md
+++ b/modules/db-for-my-sql/flexible-server/administrator/README.md
@@ -1,0 +1,53 @@
+# DBforMySQL Flexible Server Administrators `[Microsoft.DBforMySQL/flexibleServers/administrators]`
+
+This module deploys a DBforMySQL Flexible Server Administrator.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.DBforMySQL/flexibleServers/administrators` | [2022-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DBforMySQL/2022-01-01/flexibleServers/administrators) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `identityResourceId` | string | The resource ID of the identity used for AAD Authentication. |
+| `login` | string | Login name of the server administrator. |
+| `sid` | string | SID (object ID) of the server administrator. |
+
+**Conditional parameters**
+
+| Parameter Name | Type | Description |
+| :-- | :-- | :-- |
+| `flexibleServerName` | string | The name of the parent DBforMySQL flexible server. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter Name | Type | Default Value | Description |
+| :-- | :-- | :-- | :-- |
+| `enableDefaultTelemetry` | bool | `True` | Enable telemetry via a Globally Unique Identifier (GUID). |
+| `location` | string | `[resourceGroup().location]` | Location for all resources. |
+| `tenantId` | string | `[tenant().tenantId]` | The tenantId of the Active Directory administrator. |
+
+
+## Outputs
+
+| Output Name | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the deployed administrator. |
+| `resourceGroupName` | string | The resource group of the deployed administrator. |
+| `resourceId` | string | The resource ID of the deployed administrator. |
+
+## Cross-referenced modules
+
+_None_

--- a/modules/db-for-my-sql/flexible-server/administrator/main.bicep
+++ b/modules/db-for-my-sql/flexible-server/administrator/main.bicep
@@ -1,0 +1,61 @@
+metadata name = 'DBforMySQL Flexible Server Administrators'
+metadata description = 'This module deploys a DBforMySQL Flexible Server Administrator.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Conditional. The name of the parent DBforMySQL flexible server. Required if the template is used in a standalone deployment.')
+param flexibleServerName string
+
+@description('Required. SID (object ID) of the server administrator.')
+param sid string
+
+@description('Required. The resource ID of the identity used for AAD Authentication.')
+param identityResourceId string
+
+@description('Required. Login name of the server administrator.')
+param login string
+
+@description('Optional. The tenantId of the Active Directory administrator.')
+param tenantId string = tenant().tenantId
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
+param enableDefaultTelemetry bool = true
+
+resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
+  name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name, location)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+resource flexibleServer 'Microsoft.DBforMySQL/flexibleServers@2022-01-01' existing = {
+  name: flexibleServerName
+}
+
+resource administrator 'Microsoft.DBforMySQL/flexibleServers/administrators@2022-01-01' = {
+  name: 'ActiveDirectory'
+  parent: flexibleServer
+  properties: {
+    administratorType: 'ActiveDirectory'
+    identityResourceId: identityResourceId
+    login: login
+    sid: sid
+    tenantId: tenantId
+  }
+}
+
+@description('The name of the deployed administrator.')
+output name string = administrator.name
+
+@description('The resource ID of the deployed administrator.')
+output resourceId string = administrator.id
+
+@description('The resource group of the deployed administrator.')
+output resourceGroupName string = resourceGroup().name

--- a/modules/db-for-my-sql/flexible-server/administrator/main.json
+++ b/modules/db-for-my-sql/flexible-server/administrator/main.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.21.1.54444",
+      "templateHash": "6026324512499502510"
+    },
+    "name": "DBforMySQL Flexible Server Administrators",
+    "description": "This module deploys a DBforMySQL Flexible Server Administrator.",
+    "owner": "Azure/module-maintainers"
+  },
+  "parameters": {
+    "flexibleServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent DBforMySQL flexible server. Required if the template is used in a standalone deployment."
+      }
+    },
+    "sid": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. SID (object ID) of the server administrator."
+      }
+    },
+    "identityResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. The resource ID of the identity used for AAD Authentication."
+      }
+    },
+    "login": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Login name of the server administrator."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "[tenant().tenantId]",
+      "metadata": {
+        "description": "Optional. The tenantId of the Active Directory administrator."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Optional. Location for all resources."
+      }
+    },
+    "enableDefaultTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+      }
+    }
+  },
+  "resources": [
+    {
+      "condition": "[parameters('enableDefaultTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2021-04-01",
+      "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+      "apiVersion": "2022-01-01",
+      "name": "[format('{0}/{1}', parameters('flexibleServerName'), 'ActiveDirectory')]",
+      "properties": {
+        "administratorType": "ActiveDirectory",
+        "identityResourceId": "[parameters('identityResourceId')]",
+        "login": "[parameters('login')]",
+        "sid": "[parameters('sid')]",
+        "tenantId": "[parameters('tenantId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the deployed administrator."
+      },
+      "value": "ActiveDirectory"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the deployed administrator."
+      },
+      "value": "[resourceId('Microsoft.DBforMySQL/flexibleServers/administrators', parameters('flexibleServerName'), 'ActiveDirectory')]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the deployed administrator."
+      },
+      "value": "[resourceGroup().name]"
+    }
+  }
+}

--- a/modules/db-for-my-sql/flexible-server/administrator/version.json
+++ b/modules/db-for-my-sql/flexible-server/administrator/version.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1",
+    "pathFilters": [
+        "./main.json"
+    ]
+}

--- a/modules/db-for-my-sql/flexible-server/main.bicep
+++ b/modules/db-for-my-sql/flexible-server/main.bicep
@@ -19,12 +19,12 @@ param location string = resourceGroup().location
 @description('Optional. Tags of the resource.')
 param tags object = {}
 
-@description('Required. The administrator login name of a server. Can only be specified when the MySQL server is being created.')
-param administratorLogin string
+@description('Optional. The administrator login name of a server. Can only be specified when the MySQL server is being created.')
+param administratorLogin string = ''
 
-@description('Required. The administrator login password.')
+@description('Optional. The administrator login password.')
 @secure()
-param administratorLoginPassword string
+param administratorLoginPassword string = ''
 
 @description('Optional. The Azure AD administrators when AAD authentication enabled.')
 param administrators array = []
@@ -283,8 +283,8 @@ resource flexibleServer 'Microsoft.DBforMySQL/flexibleServers@2022-09-30-preview
   }
   identity: identity
   properties: {
-    administratorLogin: administratorLogin
-    administratorLoginPassword: administratorLoginPassword
+    administratorLogin: !empty(administratorLogin) ? administratorLogin : null
+    administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
     availabilityZone: availabilityZone
     backup: {
       backupRetentionDays: backupRetentionDays

--- a/modules/db-for-my-sql/flexible-server/main.bicep
+++ b/modules/db-for-my-sql/flexible-server/main.bicep
@@ -26,6 +26,9 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
+@description('Optional. The Azure AD administrators when AAD authentication enabled.')
+param administrators array = []
+
 @description('Required. The name of the sku, typically, tier + family + cores, e.g. Standard_D4s_v3.')
 param skuName string
 
@@ -363,6 +366,17 @@ module flexibleServer_firewallRules 'firewall-rule/main.bicep' = [for (firewallR
     startIpAddress: firewallRule.startIpAddress
     endIpAddress: firewallRule.endIpAddress
     enableDefaultTelemetry: enableReferencedModulesTelemetry
+  }
+}]
+
+module flexibleServer_administrators 'administrator/main.bicep' = [for (administrator, index) in administrators: {
+  name: '${uniqueString(deployment().name, location)}-MySQL-Administrators-${index}'
+  params: {
+    flexibleServerName: flexibleServer.name
+    login: administrator.login
+    sid: administrator.sid
+    identityResourceId: administrator.identityResourceId
+    tenantId: contains(administrator, 'tenantId') ? administrator.tenantId : tenant().tenantId
   }
 }]
 

--- a/modules/db-for-my-sql/flexible-server/main.json
+++ b/modules/db-for-my-sql/flexible-server/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "5052409641732809878"
+      "templateHash": "11042164284975783101"
     },
     "name": "DBforMySQL Flexible Servers",
     "description": "This module deploys a DBforMySQL Flexible Server.",
@@ -46,14 +46,16 @@
     },
     "administratorLogin": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
-        "description": "Required. The administrator login name of a server. Can only be specified when the MySQL server is being created."
+        "description": "Optional. The administrator login name of a server. Can only be specified when the MySQL server is being created."
       }
     },
     "administratorLoginPassword": {
       "type": "securestring",
+      "defaultValue": "",
       "metadata": {
-        "description": "Required. The administrator login password."
+        "description": "Optional. The administrator login password."
       }
     },
     "administrators": {
@@ -453,8 +455,8 @@
       },
       "identity": "[variables('identity')]",
       "properties": {
-        "administratorLogin": "[parameters('administratorLogin')]",
-        "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+        "administratorLogin": "[if(not(empty(parameters('administratorLogin'))), parameters('administratorLogin'), null())]",
+        "administratorLoginPassword": "[if(not(empty(parameters('administratorLoginPassword'))), parameters('administratorLoginPassword'), null())]",
         "availabilityZone": "[parameters('availabilityZone')]",
         "backup": {
           "backupRetentionDays": "[parameters('backupRetentionDays')]",

--- a/modules/db-for-my-sql/flexible-server/main.json
+++ b/modules/db-for-my-sql/flexible-server/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.20.4.51522",
-      "templateHash": "8843810505050220871"
+      "version": "0.21.1.54444",
+      "templateHash": "5052409641732809878"
     },
     "name": "DBforMySQL Flexible Servers",
     "description": "This module deploys a DBforMySQL Flexible Server.",
@@ -54,6 +54,13 @@
       "type": "securestring",
       "metadata": {
         "description": "Required. The administrator login password."
+      }
+    },
+    "administrators": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. The Azure AD administrators when AAD authentication enabled."
       }
     },
     "skuName": {
@@ -539,8 +546,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "2852140057642466667"
+              "version": "0.21.1.54444",
+              "templateHash": "17154165990398141081"
             }
           },
           "parameters": {
@@ -686,8 +693,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "12647720847614647024"
+              "version": "0.21.1.54444",
+              "templateHash": "17356615394418311167"
             },
             "name": "DBforMySQL Flexible Server Databases",
             "description": "This module deploys a DBforMySQL Flexible Server Database.",
@@ -825,8 +832,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "5263296307327888660"
+              "version": "0.21.1.54444",
+              "templateHash": "10162316213188664200"
             },
             "name": "DBforMySQL Flexible Server Firewall Rules",
             "description": "This module deploys a DBforMySQL Flexible Server Firewall Rule.",
@@ -909,6 +916,151 @@
               "type": "string",
               "metadata": {
                 "description": "The resource group of the deployed firewall rule."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DBforMySQL/flexibleServers', parameters('name'))]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "flexibleServer_administrators",
+        "count": "[length(parameters('administrators'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-MySQL-Administrators-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "flexibleServerName": {
+            "value": "[parameters('name')]"
+          },
+          "login": {
+            "value": "[parameters('administrators')[copyIndex()].login]"
+          },
+          "sid": {
+            "value": "[parameters('administrators')[copyIndex()].sid]"
+          },
+          "identityResourceId": {
+            "value": "[parameters('administrators')[copyIndex()].identityResourceId]"
+          },
+          "tenantId": "[if(contains(parameters('administrators')[copyIndex()], 'tenantId'), createObject('value', parameters('administrators')[copyIndex()].tenantId), createObject('value', tenant().tenantId))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.21.1.54444",
+              "templateHash": "6026324512499502510"
+            },
+            "name": "DBforMySQL Flexible Server Administrators",
+            "description": "This module deploys a DBforMySQL Flexible Server Administrator.",
+            "owner": "Azure/module-maintainers"
+          },
+          "parameters": {
+            "flexibleServerName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent DBforMySQL flexible server. Required if the template is used in a standalone deployment."
+              }
+            },
+            "sid": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. SID (object ID) of the server administrator."
+              }
+            },
+            "identityResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The resource ID of the identity used for AAD Authentication."
+              }
+            },
+            "login": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Login name of the server administrator."
+              }
+            },
+            "tenantId": {
+              "type": "string",
+              "defaultValue": "[tenant().tenantId]",
+              "metadata": {
+                "description": "Optional. The tenantId of the Active Directory administrator."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.DBforMySQL/flexibleServers/administrators",
+              "apiVersion": "2022-01-01",
+              "name": "[format('{0}/{1}', parameters('flexibleServerName'), 'ActiveDirectory')]",
+              "properties": {
+                "administratorType": "ActiveDirectory",
+                "identityResourceId": "[parameters('identityResourceId')]",
+                "login": "[parameters('login')]",
+                "sid": "[parameters('sid')]",
+                "tenantId": "[parameters('tenantId')]"
+              }
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed administrator."
+              },
+              "value": "ActiveDirectory"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed administrator."
+              },
+              "value": "[resourceId('Microsoft.DBforMySQL/flexibleServers/administrators', parameters('flexibleServerName'), 'ActiveDirectory')]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed administrator."
               },
               "value": "[resourceGroup().name]"
             }


### PR DESCRIPTION
Closes #3948 

# Description

Added child module `administrator` to support Azure AD Auth. 

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![DbForMySQL - FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbformysql.flexibleservers.yml/badge.svg?branch=users%2Fahmad%2Fmysql)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbformysql.flexibleservers.yml)|

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
