### PR TITLE
[Fixes] Adjusted case-handling for NFSv3 to improve idempotency

### DIFF
--- a/modules/storage/storage-account/main.bicep
+++ b/modules/storage/storage-account/main.bicep
@@ -291,7 +291,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     supportsHttpsTrafficOnly: supportsHttpsTrafficOnly
     isHnsEnabled: enableHierarchicalNamespace ? enableHierarchicalNamespace : null
     isSftpEnabled: enableSftp
-    isNfsV3Enabled: enableNfsV3 ? enableNfsV3 : null
+    isNfsV3Enabled: enableNfsV3 ? enableNfsV3 : any('')
     largeFileSharesState: (skuName == 'Standard_LRS') || (skuName == 'Standard_ZRS') ? largeFileSharesState : null
     minimumTlsVersion: minimumTlsVersion
     networkAcls: !empty(networkAcls) ? {

--- a/modules/storage/storage-account/main.json
+++ b/modules/storage/storage-account/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.20.4.51522",
-      "templateHash": "10986828824616002333"
+      "version": "0.21.1.54444",
+      "templateHash": "16000593123995919041"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -481,7 +481,7 @@
         "supportsHttpsTrafficOnly": "[parameters('supportsHttpsTrafficOnly')]",
         "isHnsEnabled": "[if(parameters('enableHierarchicalNamespace'), parameters('enableHierarchicalNamespace'), null())]",
         "isSftpEnabled": "[parameters('enableSftp')]",
-        "isNfsV3Enabled": "[if(parameters('enableNfsV3'), parameters('enableNfsV3'), null())]",
+        "isNfsV3Enabled": "[if(parameters('enableNfsV3'), parameters('enableNfsV3'), '')]",
         "largeFileSharesState": "[if(or(equals(parameters('skuName'), 'Standard_LRS'), equals(parameters('skuName'), 'Standard_ZRS')), parameters('largeFileSharesState'), null())]",
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
         "networkAcls": "[if(not(empty(parameters('networkAcls'))), createObject('bypass', if(contains(parameters('networkAcls'), 'bypass'), parameters('networkAcls').bypass, null()), 'defaultAction', if(contains(parameters('networkAcls'), 'defaultAction'), parameters('networkAcls').defaultAction, null()), 'virtualNetworkRules', if(contains(parameters('networkAcls'), 'virtualNetworkRules'), parameters('networkAcls').virtualNetworkRules, createArray()), 'ipRules', if(contains(parameters('networkAcls'), 'ipRules'), parameters('networkAcls').ipRules, createArray())), null())]",
@@ -555,8 +555,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "12642833522973709137"
+              "version": "0.21.1.54444",
+              "templateHash": "11907799862370162022"
             }
           },
           "parameters": {
@@ -748,8 +748,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "13560297539192628062"
+              "version": "0.21.1.54444",
+              "templateHash": "17036874096652764314"
             },
             "name": "Private Endpoints",
             "description": "This module deploys a Private Endpoint.",
@@ -948,8 +948,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "17831763001460207830"
+                      "version": "0.21.1.54444",
+                      "templateHash": "2469208411936339153"
                     },
                     "name": "Private Endpoint Private DNS Zone Groups",
                     "description": "This module deploys a Private Endpoint Private DNS Zone Group.",
@@ -1086,8 +1086,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "11548486149222715894"
+                      "version": "0.21.1.54444",
+                      "templateHash": "13032708393704093995"
                     }
                   },
                   "parameters": {
@@ -1293,8 +1293,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "2581396185828179457"
+              "version": "0.21.1.54444",
+              "templateHash": "17802687193811353215"
             },
             "name": "Storage Account Management Policies",
             "description": "This module deploys a Storage Account Management Policy.",
@@ -1421,8 +1421,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "17498007234218946474"
+              "version": "0.21.1.54444",
+              "templateHash": "5592009806531122832"
             },
             "name": "Storage Account Local Users",
             "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication.",
@@ -1593,8 +1593,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "16838270897726250953"
+              "version": "0.21.1.54444",
+              "templateHash": "14857884899377443071"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service.",
@@ -1930,8 +1930,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "7500144031846073123"
+                      "version": "0.21.1.54444",
+                      "templateHash": "2160985780685831754"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container.",
@@ -2096,8 +2096,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.20.4.51522",
-                              "templateHash": "5668549883344653702"
+                              "version": "0.21.1.54444",
+                              "templateHash": "2613657638807054807"
                             },
                             "name": "Storage Account Blob Container Immutability Policies",
                             "description": "This module deploys a Storage Account Blob Container Immutability Policy.",
@@ -2235,8 +2235,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.20.4.51522",
-                              "templateHash": "8600687658951622621"
+                              "version": "0.21.1.54444",
+                              "templateHash": "5334204341302869645"
                             }
                           },
                           "parameters": {
@@ -2472,8 +2472,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "17282775888269025572"
+              "version": "0.21.1.54444",
+              "templateHash": "2386001216210231583"
             },
             "name": "Storage Account File Share Services",
             "description": "This module deploys a Storage Account File Share Service.",
@@ -2692,8 +2692,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "15634855845265993886"
+                      "version": "0.21.1.54444",
+                      "templateHash": "14297307444519260355"
                     },
                     "name": "Storage Account File Shares",
                     "description": "This module deploys a Storage Account File Share.",
@@ -2838,8 +2838,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.20.4.51522",
-                              "templateHash": "17068545632348399169"
+                              "version": "0.21.1.54444",
+                              "templateHash": "12515062620278558169"
                             }
                           },
                           "parameters": {
@@ -3076,8 +3076,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "3707030790801090324"
+              "version": "0.21.1.54444",
+              "templateHash": "1925955822576678061"
             },
             "name": "Storage Account Queue Services",
             "description": "This module deploys a Storage Account Queue Service.",
@@ -3264,8 +3264,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "7293459815655804615"
+                      "version": "0.21.1.54444",
+                      "templateHash": "9907508200314623520"
                     },
                     "name": "Storage Account Queues",
                     "description": "This module deploys a Storage Account Queue.",
@@ -3364,8 +3364,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.20.4.51522",
-                              "templateHash": "16848435230262465953"
+                              "version": "0.21.1.54444",
+                              "templateHash": "256624618142232879"
                             }
                           },
                           "parameters": {
@@ -3599,8 +3599,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.20.4.51522",
-              "templateHash": "16178057085724361046"
+              "version": "0.21.1.54444",
+              "templateHash": "18301751490631788521"
             },
             "name": "Storage Account Table Services",
             "description": "This module deploys a Storage Account Table Service.",
@@ -3785,8 +3785,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.20.4.51522",
-                      "templateHash": "3732027241762478422"
+                      "version": "0.21.1.54444",
+                      "templateHash": "7147839666884687311"
                     },
                     "name": "Storage Account Table",
                     "description": "This module deploys a Storage Account Table.",


### PR DESCRIPTION
# Description

- Changed `else` case to `any('')` which is accepted by the provider and works idempotently.

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![Storage - StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Falsehr%2Fntfsv3Fix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
