### PR TITLE
[CI Environment] Updated the way the test file is found

### DIFF
--- a/utilities/pipelines/staticValidation/Set-PesterGitHubOutput.ps1
+++ b/utilities/pipelines/staticValidation/Set-PesterGitHubOutput.ps1
@@ -128,13 +128,13 @@ function Set-PesterGitHubOutput {
             $testName = (($intermediateNameElements -join ' / ' | Out-String) -replace '\|', '\|').Trim()
 
             $errorTestLine = $failedTest.ErrorRecord.TargetObject.Line
-            $errorTestFile = (Split-Path $failedTest.ErrorRecord.TargetObject.File -Leaf).Trim()
+            $errorTestFile = (($failedTest.ErrorRecord.TargetObject.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
             $errorMessage = $failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
             $testReference = '{0}:{1}' -f $errorTestFile, $errorTestLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
-                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/utilities/pipelines/staticValidation/module.tests.ps1#L$errorTestLine)"
+                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$errorTestFile#L$errorTestLine)"
             }
 
             $fileContent += '| {0} | {1} | <code>{2}</code> |' -f $testName, $errorMessage, $testReference
@@ -173,12 +173,12 @@ function Set-PesterGitHubOutput {
             $testName = (($intermediateNameElements -join ' / ' | Out-String) -replace '\|', '\|').Trim()
 
             $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
-            $testFile = (Split-Path $passedTest.ScriptBlock.File -Leaf).Trim()
+            $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
             $testReference = '{0}:{1}' -f $testFile, $testLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
-                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/utilities/pipelines/staticValidation/module.tests.ps1#L$testLine)"
+                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
             }
 
             $fileContent += '| {0} | <code>{1}</code> |' -f $testName, $testReference
@@ -220,12 +220,12 @@ function Set-PesterGitHubOutput {
             $reason = ('Test {0}' -f $skippedTest.ErrorRecord.Exception.Message -replace '\|', '\|').Trim()
 
             $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
-            $testFile = (Split-Path $passedTest.ScriptBlock.File -Leaf).Trim()
+            $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
             $testReference = '{0}:{1}' -f $testFile, $testLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
-                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/utilities/pipelines/staticValidation/module.tests.ps1#L$testLine)"
+                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
             }
 
             $fileContent += '| {0} | {1} | <code>{2}</code> |' -f $testName, $reason, $testReference

--- a/utilities/pipelines/staticValidation/Set-PesterGitHubOutput.ps1
+++ b/utilities/pipelines/staticValidation/Set-PesterGitHubOutput.ps1
@@ -131,7 +131,7 @@ function Set-PesterGitHubOutput {
             $errorTestFile = (($failedTest.ErrorRecord.TargetObject.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
             $errorMessage = $failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
-            $testReference = '{0}:{1}' -f $errorTestFile, $errorTestLine
+            $testReference = '{0}:{1}' -f (Split-Path $errorTestFile -Leaf), $errorTestLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
                 $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$errorTestFile#L$errorTestLine)"
@@ -175,7 +175,7 @@ function Set-PesterGitHubOutput {
             $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
             $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
-            $testReference = '{0}:{1}' -f $testFile, $testLine
+            $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
                 $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
@@ -222,7 +222,7 @@ function Set-PesterGitHubOutput {
             $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
             $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](modules[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
-            $testReference = '{0}:{1}' -f $testFile, $testLine
+            $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
                 $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"


### PR DESCRIPTION
# Description

- Removed hardcoded test file path and replace it with actual reference from inside test. This also allows the reference of alternate test files (e.g., for AVM)

![image](https://github.com/Azure/ResourceModules/assets/5365358/5d6d7c9c-ba9b-45b2-9214-9528f358069c)


### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![KeyVault - Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Falsehr%2FtestFileIdent)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
