### PR TITLE
Fix Pester test Bicep test deployment files should invoke test like [`module testDeployment '../.*main.bicep' does not support for loop

### DIFF
--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -1317,14 +1317,13 @@ Describe 'Test file tests' -Tag 'TestTemplate' {
             }
         }
 
-        It "[<moduleFolderName>] Bicep test deployment files should invoke test like [`module testDeployment '../.*main.bicep' = {`]" -TestCases ($deploymentTestFileTestCases | Where-Object { (Split-Path $_.testFilePath -Extension) -eq '.bicep' }) {
+        It "[<moduleFolderName>] Bicep test deployment files should invoke test like [`module testDeployment '../.*main.bicep' = `]" -TestCases ($deploymentTestFileTestCases | Where-Object { (Split-Path $_.testFilePath -Extension) -eq '.bicep' }) {
 
             param(
                 [object[]] $testFileContent
             )
 
-            $testIndex = ($testFileContent | Select-String ("^module testDeployment '..\/.*main.bicep' = {$") | ForEach-Object { $_.LineNumber - 1 })[0]
-
+            $testIndex = ($testFileContent | Select-String ("^module testDeployment '..\/.*main.bicep' = (\[for .+: )?{$") | ForEach-Object { $_.LineNumber - 1 })[0]
             $testIndex -ne -1 | Should -Be $true -Because 'the module test invocation should be in the expected format to allow identification.'
         }
 


### PR DESCRIPTION
# Description

the Pester test [Bicep test deployment files should invoke test like [`module testDeployment '../.*main.bicep'](https://github.com/Azure/ResourceModules/blob/main/utilities/pipelines/staticValidation/module.tests.ps1#L1320C34-L1320C127) does not support for loop in the regex.

Fix #4018 

### Pipeline references
[![Authorization - PolicyDefinitions](https://github.com/TY-Consulting/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml/badge.svg?branch=fix%2Fbicep-test-deployment-pester)](https://github.com/TY-Consulting/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml)

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
