### PR TITLE
Added securestring and secure() to several arm templates and biceps

### DIFF
--- a/modules/network/connection/README.md
+++ b/modules/network/connection/README.md
@@ -49,7 +49,7 @@ This module deploys a Virtual Network Gateway Connection.
 | `useLocalAzureIpAddress` | bool | `False` |  | Use private local Azure IP for the connection. Only available for IPSec Virtual Network Gateways that use the Azure Private IP Property. |
 | `usePolicyBasedTrafficSelectors` | bool | `False` |  | Enable policy-based traffic selectors. |
 | `virtualNetworkGateway2` | object | `{object}` |  | The remote Virtual Network Gateway. Used for connection connectionType [Vnet2Vnet]. |
-| `vpnSharedKey` | string | `''` |  | Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways. |
+| `vpnSharedKey` | securestring | `''` |  | Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways. |
 
 
 ### Parameter Usage: `virtualNetworkGateway1`

--- a/modules/network/connection/main.bicep
+++ b/modules/network/connection/main.bicep
@@ -6,6 +6,7 @@ metadata owner = 'Azure/module-maintainers'
 param name string
 
 @description('Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways.')
+@secure()
 param vpnSharedKey string = ''
 
 @description('Optional. Location for all resources.')

--- a/modules/network/connection/main.json
+++ b/modules/network/connection/main.json
@@ -19,7 +19,7 @@
       }
     },
     "vpnSharedKey": {
-      "type": "string",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Optional. Specifies a VPN shared key. The same value has to be specified on both Virtual Network Gateways."

--- a/modules/network/connection/main.json
+++ b/modules/network/connection/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "1999281498995353652"
+      "version": "0.20.4.51522",
+      "templateHash": "11270738369217177363"
     },
     "name": "Virtual Network Gateway Connections",
     "description": "This module deploys a Virtual Network Gateway Connection.",

--- a/modules/network/connection/main.json
+++ b/modules/network/connection/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.20.4.51522",
-      "templateHash": "11270738369217177363"
+      "version": "0.21.1.54444",
+      "templateHash": "16230225022830179202"
     },
     "name": "Virtual Network Gateway Connections",
     "description": "This module deploys a Virtual Network Gateway Connection.",

--- a/modules/network/vpn-gateway/main.json
+++ b/modules/network/vpn-gateway/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "4559859502222142579"
+      "templateHash": "7609266096220214410"
     },
     "name": "VPN Gateways",
     "description": "This module deploys a VPN Gateway.",
@@ -358,7 +358,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.21.1.54444",
-              "templateHash": "4097303452564048264"
+              "templateHash": "9210756491180563718"
             },
             "name": "VPN Gateway VPN Connections",
             "description": "This module deploys a VPN Gateway VPN Connection.",
@@ -466,7 +466,7 @@
               }
             },
             "sharedKey": {
-              "type": "string",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "Optional. SharedKey for the VPN connection."

--- a/modules/network/vpn-gateway/vpn-connection/README.md
+++ b/modules/network/vpn-gateway/vpn-connection/README.md
@@ -42,7 +42,7 @@ This module deploys a VPN Gateway VPN Connection.
 | `remoteVpnSiteResourceId` | string | `''` |  | Reference to a VPN site to link to. |
 | `routingConfiguration` | object | `{object}` |  | Routing configuration indicating the associated and propagated route tables for this connection. |
 | `routingWeight` | int | `0` |  | Routing weight for VPN connection. |
-| `sharedKey` | string | `''` |  | SharedKey for the VPN connection. |
+| `sharedKey` | securestring | `''` |  | SharedKey for the VPN connection. |
 | `trafficSelectorPolicies` | array | `[]` |  | The traffic selector policies to be considered by this connection. |
 | `useLocalAzureIpAddress` | bool | `False` |  | Use local Azure IP to initiate connection. |
 | `usePolicyBasedTrafficSelectors` | bool | `False` |  | Enable policy-based traffic selectors. |

--- a/modules/network/vpn-gateway/vpn-connection/main.bicep
+++ b/modules/network/vpn-gateway/vpn-connection/main.bicep
@@ -49,6 +49,7 @@ param connectionBandwidth int = 10
 param vpnConnectionProtocolType string = 'IKEv2'
 
 @description('Optional. SharedKey for the VPN connection.')
+@secure()
 param sharedKey string = ''
 
 @description('Optional. Reference to a VPN site to link to.')

--- a/modules/network/vpn-gateway/vpn-connection/main.json
+++ b/modules/network/vpn-gateway/vpn-connection/main.json
@@ -113,7 +113,7 @@
       }
     },
     "sharedKey": {
-      "type": "string",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Optional. SharedKey for the VPN connection."

--- a/modules/network/vpn-gateway/vpn-connection/main.json
+++ b/modules/network/vpn-gateway/vpn-connection/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.20.4.51522",
-      "templateHash": "14522307155183796972"
+      "version": "0.21.1.54444",
+      "templateHash": "9210756491180563718"
     },
     "name": "VPN Gateway VPN Connections",
     "description": "This module deploys a VPN Gateway VPN Connection.",

--- a/modules/network/vpn-gateway/vpn-connection/main.json
+++ b/modules/network/vpn-gateway/vpn-connection/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.20.4.51522",
-      "templateHash": "16568762636851429677"
+      "templateHash": "14522307155183796972"
     },
     "name": "VPN Gateway VPN Connections",
     "description": "This module deploys a VPN Gateway VPN Connection.",


### PR DESCRIPTION
# Description

In this PR I have added securestring and secure() to the sharedKey parameter for VPN connection to hide the value of the secret during deployments.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
