### PR TITLE
Updated to set property "publicNetworkAccess" at the higher level

### DIFF
--- a/modules/web/site/main.bicep
+++ b/modules/web/site/main.bicep
@@ -196,6 +196,9 @@ param basicPublishingCredentialsPolicies array = []
 @description('Optional. Names of hybrid connection relays to connect app with.')
 param hybridConnectionRelays array = []
 
+@description('Optional. Property to allow or block all public traffic. Allowed Values: "Enabled", "Disabled" or an empty string.')
+param publicNetworkAccess string = ''
+
 // =========== //
 // Variables   //
 // =========== //
@@ -269,6 +272,7 @@ resource app 'Microsoft.Web/sites@2021-03-01' = {
     hostNameSslStates: hostNameSslStates
     hyperV: hyperV
     redundancyMode: redundancyMode
+    publicNetworkAccess: publicNetworkAccess
   }
 }
 


### PR DESCRIPTION
# Description
Updated to set property "publicNetworkAccess" at the higher level required for Azure Policy checks

This is required as part of the "Azure Landing Zones (ALZ) Policy Initiative (PolicySet) - Public network access should be disabled for PaaS services"

Policy: https://www.azadvertizer.net/azpolicyadvertizer/1b5ef780-c53c-4a64-87f3-bb9c8c8094ba.html
Initative: https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deny-PublicPaaSEndpoints.html

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
