### PR TITLE
[Fixes] Updated remaining PE references that got not passed down to the actual module

### DIFF
--- a/modules/app-configuration/configuration-store/.test/pe/main.test.bicep
+++ b/modules/app-configuration/configuration-store/.test/pe/main.test.bicep
@@ -54,11 +54,11 @@ module testDeployment '../../main.bicep' = {
     enablePurgeProtection: false
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'configurationStores'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/app-configuration/configuration-store/README.md
+++ b/modules/app-configuration/configuration-store/README.md
@@ -411,11 +411,9 @@ module configurationStore 'br:bicep/modules/app-configuration.configuration-stor
     enablePurgeProtection: false
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'configurationStores'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -467,11 +465,9 @@ module configurationStore 'br:bicep/modules/app-configuration.configuration-stor
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "configurationStores",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/cache/redis-enterprise/.test/common/main.test.bicep
+++ b/modules/cache/redis-enterprise/.test/common/main.test.bicep
@@ -87,11 +87,11 @@ module testDeployment '../../main.bicep' = {
     zoneRedundant: true
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'redisEnterprise'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/cache/redis-enterprise/README.md
+++ b/modules/cache/redis-enterprise/README.md
@@ -80,11 +80,9 @@ module redisEnterprise 'br:bicep/modules/cache.redis-enterprise:1.0.0' = {
     minimumTlsVersion: '1.2'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'redisEnterprise'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -180,11 +178,9 @@ module redisEnterprise 'br:bicep/modules/cache.redis-enterprise:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "redisEnterprise",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/cache/redis/.test/common/main.test.bicep
+++ b/modules/cache/redis/.test/common/main.test.bicep
@@ -79,11 +79,11 @@ module testDeployment '../../main.bicep' = {
     zones: [ 1, 2 ]
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'redisCache'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/cache/redis/README.md
+++ b/modules/cache/redis/README.md
@@ -61,11 +61,9 @@ module redis 'br:bicep/modules/cache.redis:1.0.0' = {
     minimumTlsVersion: '1.2'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'redisCache'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -143,11 +141,9 @@ module redis 'br:bicep/modules/cache.redis:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "redisCache",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/data-factory/factory/.test/common/main.test.bicep
+++ b/modules/data-factory/factory/.test/common/main.test.bicep
@@ -114,11 +114,11 @@ module testDeployment '../../main.bicep' = {
     managedVirtualNetworkName: 'default'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'dataFactory'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/data-factory/factory/README.md
+++ b/modules/data-factory/factory/README.md
@@ -97,11 +97,9 @@ module factory 'br:bicep/modules/data-factory.factory:1.0.0' = {
     managedVirtualNetworkName: 'default'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'dataFactory'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -223,11 +221,9 @@ module factory 'br:bicep/modules/data-factory.factory:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "dataFactory",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/databricks/workspace/.test/common/main.test.bicep
+++ b/modules/databricks/workspace/.test/common/main.test.bicep
@@ -118,11 +118,11 @@ module testDeployment '../../main.bicep' = {
     customVirtualNetworkResourceId: nestedDependencies.outputs.virtualNetworkResourceId
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'databricks_ui_api'
         subnetResourceId: nestedDependencies.outputs.defaultSubnetResourceId
         tags: {

--- a/modules/databricks/workspace/README.md
+++ b/modules/databricks/workspace/README.md
@@ -78,11 +78,9 @@ module workspace 'br:bicep/modules/databricks.workspace:1.0.0' = {
     prepareEncryption: true
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'databricks_ui_api'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -212,11 +210,9 @@ module workspace 'br:bicep/modules/databricks.workspace:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "databricks_ui_api",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/digital-twins/digital-twins-instance/.test/common/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/.test/common/main.test.bicep
@@ -97,11 +97,11 @@ module testDeployment '../../main.bicep' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'API'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
       }

--- a/modules/digital-twins/digital-twins-instance/README.md
+++ b/modules/digital-twins/digital-twins-instance/README.md
@@ -68,11 +68,9 @@ module digitalTwinsInstance 'br:bicep/modules/digital-twins.digital-twins-instan
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'API'
         subnetResourceId: '<subnetResourceId>'
       }
@@ -156,11 +154,9 @@ module digitalTwinsInstance 'br:bicep/modules/digital-twins.digital-twins-instan
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "API",
           "subnetResourceId": "<subnetResourceId>"
         }

--- a/modules/document-db/database-account/.test/sqldb/main.test.bicep
+++ b/modules/document-db/database-account/.test/sqldb/main.test.bicep
@@ -84,11 +84,11 @@ module testDeployment '../../main.bicep' = {
     location: location
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'Sql'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/document-db/database-account/README.md
+++ b/modules/document-db/database-account/README.md
@@ -926,11 +926,9 @@ module databaseAccount 'br:bicep/modules/document-db.database-account:1.0.0' = {
     location: '<location>'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'Sql'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -1089,11 +1087,9 @@ module databaseAccount 'br:bicep/modules/document-db.database-account:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "Sql",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/insights/private-link-scope/.test/common/main.test.bicep
+++ b/modules/insights/private-link-scope/.test/common/main.test.bicep
@@ -62,11 +62,11 @@ module testDeployment '../../main.bicep' = {
     ]
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'azuremonitor'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/insights/private-link-scope/README.md
+++ b/modules/insights/private-link-scope/README.md
@@ -50,11 +50,9 @@ This instance deploys the module with most of its features enabled.
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'azuremonitor'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -111,11 +109,9 @@ This instance deploys the module with most of its features enabled.
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "azuremonitor",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/key-vault/vault/.test/common/main.test.bicep
+++ b/modules/key-vault/vault/.test/common/main.test.bicep
@@ -132,11 +132,11 @@ module testDeployment '../../main.bicep' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'vault'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/key-vault/vault/README.md
+++ b/modules/key-vault/vault/README.md
@@ -290,11 +290,9 @@ module vault 'br:bicep/modules/key-vault.vault:1.0.0' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'vault'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -443,11 +441,9 @@ module vault 'br:bicep/modules/key-vault.vault:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "vault",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/recovery-services/vault/.test/common/main.test.bicep
+++ b/modules/recovery-services/vault/.test/common/main.test.bicep
@@ -319,11 +319,11 @@ module testDeployment '../../main.bicep' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'AzureSiteRecovery'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/recovery-services/vault/README.md
+++ b/modules/recovery-services/vault/README.md
@@ -313,11 +313,9 @@ module vault 'br:bicep/modules/recovery-services.vault:1.0.0' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'AzureSiteRecovery'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -649,11 +647,9 @@ module vault 'br:bicep/modules/recovery-services.vault:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "AzureSiteRecovery",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/signal-r-service/signal-r/.test/common/main.test.bicep
+++ b/modules/signal-r-service/signal-r/.test/common/main.test.bicep
@@ -83,11 +83,11 @@ module testDeployment '../../main.bicep' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'signalr'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/signal-r-service/signal-r/README.md
+++ b/modules/signal-r-service/signal-r/README.md
@@ -77,11 +77,9 @@ module signalR 'br:bicep/modules/signal-r-service.signal-r:1.0.0' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'signalr'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -178,11 +176,9 @@ module signalR 'br:bicep/modules/signal-r-service.signal-r:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "signalr",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/signal-r-service/web-pub-sub/.test/common/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/.test/common/main.test.bicep
@@ -81,11 +81,11 @@ module testDeployment '../../main.bicep' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'webpubsub'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/signal-r-service/web-pub-sub/.test/pe/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/.test/pe/main.test.bicep
@@ -51,11 +51,11 @@ module testDeployment '../../main.bicep' = {
     name: '${namePrefix}-${serviceShort}-001'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'webpubsub'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/signal-r-service/web-pub-sub/README.md
+++ b/modules/signal-r-service/web-pub-sub/README.md
@@ -77,11 +77,9 @@ module webPubSub 'br:bicep/modules/signal-r-service.web-pub-sub:1.0.0' = {
     }
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'webpubsub'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -176,11 +174,9 @@ module webPubSub 'br:bicep/modules/signal-r-service.web-pub-sub:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "webpubsub",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {
@@ -290,11 +286,9 @@ module webPubSub 'br:bicep/modules/signal-r-service.web-pub-sub:1.0.0' = {
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'webpubsub'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -337,11 +331,9 @@ module webPubSub 'br:bicep/modules/signal-r-service.web-pub-sub:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "webpubsub",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/sql/server/.test/common/main.test.bicep
+++ b/modules/sql/server/.test/common/main.test.bicep
@@ -162,11 +162,11 @@ module testDeployment '../../main.bicep' = {
       {
         subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
         service: 'sqlServer'
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         tags: {
           'hidden-title': 'This is visible in the resource name'
           Environment: 'Non-Prod'

--- a/modules/sql/server/.test/pe/main.test.bicep
+++ b/modules/sql/server/.test/pe/main.test.bicep
@@ -58,11 +58,11 @@ module testDeployment '../../main.bicep' = {
     administratorLoginPassword: password
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'sqlServer'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/sql/server/README.md
+++ b/modules/sql/server/README.md
@@ -179,11 +179,9 @@ module server 'br:bicep/modules/sql.server:1.0.0' = {
     primaryUserAssignedIdentityId: '<primaryUserAssignedIdentityId>'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'sqlServer'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -333,11 +331,9 @@ module server 'br:bicep/modules/sql.server:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "sqlServer",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {
@@ -432,11 +428,9 @@ module server 'br:bicep/modules/sql.server:1.0.0' = {
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'sqlServer'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -484,11 +478,9 @@ module server 'br:bicep/modules/sql.server:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "sqlServer",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/synapse/private-link-hub/.test/common/main.test.bicep
+++ b/modules/synapse/private-link-hub/.test/common/main.test.bicep
@@ -57,11 +57,11 @@ module testDeployment '../../main.bicep' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         service: 'Web'
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         tags: {

--- a/modules/synapse/private-link-hub/README.md
+++ b/modules/synapse/private-link-hub/README.md
@@ -51,11 +51,9 @@ module privateLinkHub 'br:bicep/modules/synapse.private-link-hub:1.0.0' = {
     lock: 'CanNotDelete'
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'Web'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -115,11 +113,9 @@ module privateLinkHub 'br:bicep/modules/synapse.private-link-hub:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "Web",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/synapse/workspace/.test/common/main.test.bicep
+++ b/modules/synapse/workspace/.test/common/main.test.bicep
@@ -87,11 +87,11 @@ module testDeployment '../../main.bicep' = {
       {
         subnetResourceId: nestedDependencies.outputs.subnetResourceId
         service: 'SQL'
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            nestedDependencies.outputs.privateDNSZoneResourceId
-          ]
-        }
+        privateDnsZoneResourceIds: [
+
+          nestedDependencies.outputs.privateDNSZoneResourceId
+
+        ]
         tags: {
           'hidden-title': 'This is visible in the resource name'
           Environment: 'Non-Prod'

--- a/modules/synapse/workspace/README.md
+++ b/modules/synapse/workspace/README.md
@@ -82,11 +82,9 @@ module workspace 'br:bicep/modules/synapse.workspace:1.0.0' = {
     managedVirtualNetwork: true
     privateEndpoints: [
       {
-        privateDnsZoneGroup: {
-          privateDNSResourceIds: [
-            '<privateDNSZoneResourceId>'
-          ]
-        }
+        privateDnsZoneResourceIds: [
+          '<privateDNSZoneResourceId>'
+        ]
         service: 'SQL'
         subnetResourceId: '<subnetResourceId>'
         tags: {
@@ -181,11 +179,9 @@ module workspace 'br:bicep/modules/synapse.workspace:1.0.0' = {
     "privateEndpoints": {
       "value": [
         {
-          "privateDnsZoneGroup": {
-            "privateDNSResourceIds": [
-              "<privateDNSZoneResourceId>"
-            ]
-          },
+          "privateDnsZoneResourceIds": [
+            "<privateDNSZoneResourceId>"
+          ],
           "service": "SQL",
           "subnetResourceId": "<subnetResourceId>",
           "tags": {

--- a/modules/web/site/.test/webAppCommon/main.test.bicep
+++ b/modules/web/site/.test/webAppCommon/main.test.bicep
@@ -84,11 +84,11 @@ module testDeployment '../../main.bicep' = {
           {
             service: 'sites'
             subnetResourceId: nestedDependencies.outputs.subnetResourceId
-            privateDnsZoneGroup: {
-              privateDNSResourceIds: [
-                nestedDependencies.outputs.privateDNSZoneResourceId
-              ]
-            }
+            privateDnsZoneResourceIds: [
+
+              nestedDependencies.outputs.privateDNSZoneResourceId
+
+            ]
             tags: {
               'hidden-title': 'This is visible in the resource name'
               Environment: 'Non-Prod'

--- a/modules/web/site/README.md
+++ b/modules/web/site/README.md
@@ -503,11 +503,9 @@ module site 'br:bicep/modules/web.site:1.0.0' = {
         name: 'slot1'
         privateEndpoints: [
           {
-            privateDnsZoneGroup: {
-              privateDNSResourceIds: [
-                '<privateDNSZoneResourceId>'
-              ]
-            }
+            privateDnsZoneResourceIds: [
+              '<privateDNSZoneResourceId>'
+            ]
             service: 'sites'
             subnetResourceId: '<subnetResourceId>'
             tags: {
@@ -670,11 +668,9 @@ module site 'br:bicep/modules/web.site:1.0.0' = {
           "name": "slot1",
           "privateEndpoints": [
             {
-              "privateDnsZoneGroup": {
-                "privateDNSResourceIds": [
-                  "<privateDNSZoneResourceId>"
-                ]
-              },
+              "privateDnsZoneResourceIds": [
+                "<privateDNSZoneResourceId>"
+              ],
               "service": "sites",
               "subnetResourceId": "<subnetResourceId>",
               "tags": {


### PR DESCRIPTION
# Description

- Updated remaining PE references that got not passed down to the actual module
- Regenerated all docs

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![AppConfiguration - ConfigurationStores](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml) |
| [![Cache - Redis](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml) |
| [![Cache - Redis Enterprise](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redisenterprise.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redisenterprise.yml) (unrelated) |
| [![DataFactory - Factories](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml) |
| [![Databricks - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.workspaces.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.workspaces.yml) |
| [![DigitalTwins - DigitalTwinsInstances](https://github.com/Azure/ResourceModules/actions/workflows/ms.digitaltwins.digitaltwinsinstances.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.digitaltwins.digitaltwinsinstances.yml) |
| [![DocumentDB - DatabaseAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml) |
| [![Insights - PrivateLinkScopes](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml) |
| [![KeyVault - Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml)  |
| [![SignalRService - SignalR](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml) |
| [![SignalRService - WebPubSub](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml) |
| [![Sql - Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml) |
| [![Synapse - PrivateLinkHubs](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.privatelinkhubs.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.privatelinkhubs.yml) |
| [![Synapse - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml) |
| [![Web - Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg?branch=users%2Falsehr%2Fpe_Update_avm)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
