### PR TITLE
[CI environment] Add nameprefix to rg test names 

### DIFF
--- a/modules/aad/domain-service/.test/common/main.test.bicep
+++ b/modules/aad/domain-service/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.aad.domainservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-aad.domainservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/analysis-services/server/.test/common/main.test.bicep
+++ b/modules/analysis-services/server/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.analysisservices.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-analysisservices.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -74,7 +74,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -89,4 +90,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/analysis-services/server/.test/max/main.test.bicep
+++ b/modules/analysis-services/server/.test/max/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.analysisservices.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-analysisservices.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -82,7 +82,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -99,4 +100,3 @@ module testDeployment '../../main.bicep' = {
     ]
   }
 }
-

--- a/modules/analysis-services/server/.test/min/main.test.bicep
+++ b/modules/analysis-services/server/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.analysisservices.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-analysisservices.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/api-management/service/.test/common/main.test.bicep
+++ b/modules/api-management/service/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.apimanagement.service-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-apimanagement.service-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -85,7 +85,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -96,4 +97,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/api-management/service/.test/max/main.test.bicep
+++ b/modules/api-management/service/.test/max/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.apimanagement.service-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-apimanagement.service-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -181,7 +181,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -202,4 +203,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/api-management/service/.test/min/main.test.bicep
+++ b/modules/api-management/service/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.apimanagement.service-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-apimanagement.service-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app-configuration/configuration-store/.test/common/main.test.bicep
+++ b/modules/app-configuration/configuration-store/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.appconfiguration.configurationstores-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-appconfiguration.configurationstores-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -80,7 +80,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -94,7 +95,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -110,4 +112,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/app-configuration/configuration-store/.test/min/main.test.bicep
+++ b/modules/app-configuration/configuration-store/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.appconfiguration.configurationstores-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-appconfiguration.configurationstores-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app-configuration/configuration-store/.test/pe/main.test.bicep
+++ b/modules/app-configuration/configuration-store/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.appconfiguration.configurationstores-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-appconfiguration.configurationstores-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app/container-app/.test/common/main.test.bicep
+++ b/modules/app/container-app/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.app.containerApps-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-app.containerApps-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app/container-app/.test/min/main.test.bicep
+++ b/modules/app/container-app/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.app.containerApps-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-app.containerApps-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app/managed-environment/.test/common/main.test.bicep
+++ b/modules/app/managed-environment/.test/common/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with most of its featur
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.app.managedenvironments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-app.managedenvironments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/app/managed-environment/.test/min/main.test.bicep
+++ b/modules/app/managed-environment/.test/min/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.app.managedenvironments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-app.managedenvironments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/lock/.test/common/main.test.bicep
+++ b/modules/authorization/lock/.test/common/main.test.bicep
@@ -20,6 +20,9 @@ param serviceShort string = 'alcom'
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
+@description('Optional. A token to inject into the name of each resource.')
+param namePrefix string = '[[namePrefix]]'
+
 // ============ //
 // Dependencies //
 // ============ //

--- a/modules/authorization/lock/.test/common/main.test.bicep
+++ b/modules/authorization/lock/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.locks-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.locks-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/policy-assignment/.test/rg.common/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/rg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.policyassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.policyassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/policy-assignment/.test/rg.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/rg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.policyassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.policyassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/policy-assignment/.test/sub.common/main.test.bicep
+++ b/modules/authorization/policy-assignment/.test/sub.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.policyassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.policyassignments-${serviceShort}-rg'
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'apasubcom'

--- a/modules/authorization/policy-exemption/.test/rg.common/main.test.bicep
+++ b/modules/authorization/policy-exemption/.test/rg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.policyexemptions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.policyexemptions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/policy-exemption/.test/rg.min/main.test.bicep
+++ b/modules/authorization/policy-exemption/.test/rg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.policyexemptions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.policyexemptions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/mg.common/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/mg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'managementGroup'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/mg.min/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/mg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'managementGroup'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/rg.common/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/rg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/rg.min/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/rg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/sub.common/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/sub.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-assignment/.test/sub.min/main.test.bicep
+++ b/modules/authorization/role-assignment/.test/sub.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roleassignments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roleassignments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-definition/.test/rg.common/main.test.bicep
+++ b/modules/authorization/role-definition/.test/rg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roledefinitions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roledefinitions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/authorization/role-definition/.test/rg.min/main.test.bicep
+++ b/modules/authorization/role-definition/.test/rg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.authorization.roledefinitions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-authorization.roledefinitions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/automation/automation-account/.test/common/main.test.bicep
+++ b/modules/automation/automation-account/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.automation.account-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-automation.account-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -127,7 +127,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -247,4 +248,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/automation/automation-account/.test/encr/main.test.bicep
+++ b/modules/automation/automation-account/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.automation.account-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-automation.account-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/automation/automation-account/.test/min/main.test.bicep
+++ b/modules/automation/automation-account/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.automation.account-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-automation.account-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/batch/batch-account/.test/common/main.test.bicep
+++ b/modules/batch/batch-account/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.batch.batchaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-batch.batchaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/batch/batch-account/.test/encr/main.test.bicep
+++ b/modules/batch/batch-account/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.batch.batchaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-batch.batchaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/batch/batch-account/.test/min/main.test.bicep
+++ b/modules/batch/batch-account/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.batch.batchaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-batch.batchaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cache/redis-enterprise/.test/common/main.test.bicep
+++ b/modules/cache/redis-enterprise/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cache.redisenterprise-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cache.redisenterprise-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -80,7 +80,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]

--- a/modules/cache/redis-enterprise/.test/geo/main.test.bicep
+++ b/modules/cache/redis-enterprise/.test/geo/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cache.redisenterprise-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cache.redisenterprise-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cache/redis-enterprise/.test/min/main.test.bicep
+++ b/modules/cache/redis-enterprise/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cache.redisenterprise-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cache.redisenterprise-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cache/redis/.test/common/main.test.bicep
+++ b/modules/cache/redis/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cache.redis-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cache.redis-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cache/redis/.test/min/main.test.bicep
+++ b/modules/cache/redis/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cache.redis-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cache.redis-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cdn/profile/.test/afd/main.test.bicep
+++ b/modules/cdn/profile/.test/afd/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cdn.profiles-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cdn.profiles-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -60,7 +60,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -129,4 +130,3 @@ module testDeployment '../../main.bicep' = {
     ]
   }
 }
-

--- a/modules/cdn/profile/.test/common/main.test.bicep
+++ b/modules/cdn/profile/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cdn.profiles-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cdn.profiles-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -93,10 +93,10 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
   }
 }
-

--- a/modules/cognitive-services/account/.test/common/main.test.bicep
+++ b/modules/cognitive-services/account/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cognitiveservices.accounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cognitiveservices.accounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -94,7 +94,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -124,4 +125,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/cognitive-services/account/.test/encr/main.test.bicep
+++ b/modules/cognitive-services/account/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cognitiveservices.accounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cognitiveservices.accounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cognitive-services/account/.test/min/main.test.bicep
+++ b/modules/cognitive-services/account/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cognitiveservices.accounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cognitiveservices.accounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/cognitive-services/account/.test/speech/main.test.bicep
+++ b/modules/cognitive-services/account/.test/speech/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.cognitiveservices.accounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-cognitiveservices.accounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/availability-set/.test/common/main.test.bicep
+++ b/modules/compute/availability-set/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.availabilitysets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.availabilitysets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -61,7 +61,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -72,4 +73,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/availability-set/.test/min/main.test.bicep
+++ b/modules/compute/availability-set/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.availabilitysets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.availabilitysets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/disk-encryption-set/.test/accessPolicies/main.test.bicep
+++ b/modules/compute/disk-encryption-set/.test/accessPolicies/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.diskencryptionsets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.diskencryptionsets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -59,7 +59,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -74,4 +75,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/disk-encryption-set/.test/common/main.test.bicep
+++ b/modules/compute/disk-encryption-set/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.diskencryptionsets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.diskencryptionsets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -66,7 +66,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -81,4 +82,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/disk/.test/common/main.test.bicep
+++ b/modules/compute/disk/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.images-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.images-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -65,7 +65,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -76,4 +77,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/disk/.test/image/main.test.bicep
+++ b/modules/compute/disk/.test/image/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.images-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.images-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -54,7 +54,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -65,4 +66,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/disk/.test/import/main.test.bicep
+++ b/modules/compute/disk/.test/import/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.images-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.images-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -57,7 +57,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -70,4 +71,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/disk/.test/min/main.test.bicep
+++ b/modules/compute/disk/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.images-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.images-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/gallery/.test/common/main.test.bicep
+++ b/modules/compute/gallery/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.galleries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.galleries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -66,7 +66,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -90,7 +91,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -111,7 +113,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -132,7 +135,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -153,7 +157,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -176,7 +181,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -187,4 +193,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/gallery/.test/min/main.test.bicep
+++ b/modules/compute/gallery/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.galleries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.galleries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/image/.test/common/main.test.bicep
+++ b/modules/compute/image/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.images-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.images-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -69,7 +69,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -84,4 +85,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/proximity-placement-group/.test/common/main.test.bicep
+++ b/modules/compute/proximity-placement-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.proximityplacementgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.proximityplacementgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -59,7 +59,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -86,4 +87,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/proximity-placement-group/.test/min/main.test.bicep
+++ b/modules/compute/proximity-placement-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.proximityplacementgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.proximityplacementgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/ssh-public-key/.test/common/main.test.bicep
+++ b/modules/compute/ssh-public-key/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.sshPublicKeys-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.sshPublicKeys-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/ssh-public-key/.test/min/main.test.bicep
+++ b/modules/compute/ssh-public-key/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.sshPublicKeys-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.sshPublicKeys-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine-scale-set/.test/linux.min/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/.test/linux.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualmachinescalesets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualmachinescalesets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine-scale-set/.test/linux.ssecmk/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/.test/linux.ssecmk/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualmachinescalesets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualmachinescalesets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine-scale-set/.test/linux/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/.test/linux/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualmachinescalesets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualmachinescalesets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -174,7 +174,8 @@ module testDeployment '../../main.bicep' = {
     ]
     roleAssignments: [
       {
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -194,4 +195,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/virtual-machine-scale-set/.test/windows.min/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/.test/windows.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualmachinescalesets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualmachinescalesets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine-scale-set/.test/windows/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/.test/windows/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualmachinescalesets-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualmachinescalesets-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -171,7 +171,8 @@ module testDeployment '../../main.bicep' = {
     proximityPlacementGroupResourceId: nestedDependencies.outputs.proximityPlacementGroupResourceId
     roleAssignments: [
       {
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         roleDefinitionIdOrName: 'Reader'
       }
     ]
@@ -190,4 +191,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/compute/virtual-machine/.test/linux.atmg/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/linux.atmg/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/linux.min/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/linux.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/linux/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/linux/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/windows.atmg/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/windows.atmg/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/windows.min/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/windows.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/windows.ssecmk/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/windows.ssecmk/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/compute/virtual-machine/.test/windows/main.test.bicep
+++ b/modules/compute/virtual-machine/.test/windows/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.compute.virtualMachines-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-compute.virtualMachines-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -106,7 +106,8 @@ module testDeployment '../../main.bicep' = {
               roleAssignments: [
                 {
                   roleDefinitionIdOrName: 'Reader'
-                  principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+                  principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
                   principalType: 'ServicePrincipal'
                 }
               ]
@@ -123,7 +124,8 @@ module testDeployment '../../main.bicep' = {
         roleAssignments: [
           {
             roleDefinitionIdOrName: 'Reader'
-            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+            principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
             principalType: 'ServicePrincipal'
           }
         ]
@@ -279,7 +281,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -294,4 +297,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/container-instance/container-group/.test/common/main.test.bicep
+++ b/modules/container-instance/container-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerinstance.containergroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerinstance.containergroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-instance/container-group/.test/encr/main.test.bicep
+++ b/modules/container-instance/container-group/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerinstance.containergroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerinstance.containergroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-instance/container-group/.test/min/main.test.bicep
+++ b/modules/container-instance/container-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerinstance.containergroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerinstance.containergroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-instance/container-group/.test/private/main.test.bicep
+++ b/modules/container-instance/container-group/.test/private/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerinstance.containergroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerinstance.containergroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-registry/registry/.test/common/main.test.bicep
+++ b/modules/container-registry/registry/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerregistry.registries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerregistry.registries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -114,7 +114,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -146,4 +147,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/container-registry/registry/.test/encr/main.test.bicep
+++ b/modules/container-registry/registry/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerregistry.registries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerregistry.registries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-registry/registry/.test/min/main.test.bicep
+++ b/modules/container-registry/registry/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerregistry.registries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerregistry.registries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-registry/registry/.test/pe/main.test.bicep
+++ b/modules/container-registry/registry/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerregistry.registries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerregistry.registries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-service/managed-cluster/.test/azure/main.test.bicep
+++ b/modules/container-service/managed-cluster/.test/azure/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerservice.managedclusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerservice.managedclusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -184,7 +184,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -253,4 +254,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/container-service/managed-cluster/.test/kubenet/main.test.bicep
+++ b/modules/container-service/managed-cluster/.test/kubenet/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerservice.managedclusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerservice.managedclusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -142,7 +142,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -156,4 +157,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/container-service/managed-cluster/.test/min/main.test.bicep
+++ b/modules/container-service/managed-cluster/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerservice.managedclusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerservice.managedclusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/container-service/managed-cluster/.test/priv/main.test.bicep
+++ b/modules/container-service/managed-cluster/.test/priv/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.containerservice.managedclusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-containerservice.managedclusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/data-factory/factory/.test/common/main.test.bicep
+++ b/modules/data-factory/factory/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.datafactory.factories-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-datafactory.factories-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -133,7 +133,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -148,4 +149,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/data-factory/factory/.test/min/main.test.bicep
+++ b/modules/data-factory/factory/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.datafactory.factories-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-datafactory.factories-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/data-protection/backup-vault/.test/common/main.test.bicep
+++ b/modules/data-protection/backup-vault/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dataprotection.backupvaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dataprotection.backupvaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -55,7 +55,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -134,4 +135,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/data-protection/backup-vault/.test/min/main.test.bicep
+++ b/modules/data-protection/backup-vault/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dataprotection.backupvaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dataprotection.backupvaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/databricks/access-connector/.test/common/main.test.bicep
+++ b/modules/databricks/access-connector/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.databricks.accessconnectors-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-databricks.accessconnectors-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -63,7 +63,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -75,4 +76,3 @@ module testDeployment '../../main.bicep' = {
     location: resourceGroup.location
   }
 }
-

--- a/modules/databricks/access-connector/.test/min/main.test.bicep
+++ b/modules/databricks/access-connector/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.databricks.accessconnectors-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-databricks.accessconnectors-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/databricks/workspace/.test/common/main.test.bicep
+++ b/modules/databricks/workspace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.databricks.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-databricks.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -89,7 +89,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -144,4 +145,3 @@ module testDeployment '../../main.bicep' = {
     location: resourceGroup.location
   }
 }
-

--- a/modules/databricks/workspace/.test/min/main.test.bicep
+++ b/modules/databricks/workspace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.databricks.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-databricks.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/db-for-my-sql/flexible-server/.test/min/main.test.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbformysql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbformysql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/private/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbformysql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbformysql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -76,7 +76,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -119,4 +120,3 @@ module testDeployment '../../main.bicep' = {
     ]
   }
 }
-

--- a/modules/db-for-my-sql/flexible-server/.test/public/main.test.bicep
+++ b/modules/db-for-my-sql/flexible-server/.test/public/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbformysql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbformysql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -94,7 +94,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies2.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies2.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -160,4 +161,3 @@ module testDeployment '../../main.bicep' = {
     diagnosticEventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
   }
 }
-

--- a/modules/db-for-postgre-sql/flexible-server/.test/min/main.test.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbforpostgresql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbforpostgresql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/db-for-postgre-sql/flexible-server/.test/private/main.test.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/.test/private/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbforpostgresql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbforpostgresql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/db-for-postgre-sql/flexible-server/.test/public/main.test.bicep
+++ b/modules/db-for-postgre-sql/flexible-server/.test/public/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.dbforpostgresql.flexibleservers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-dbforpostgresql.flexibleservers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/desktop-virtualization/application-group/.test/common/main.test.bicep
+++ b/modules/desktop-virtualization/application-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.applicationgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.applicationgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -101,7 +101,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -112,4 +113,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/desktop-virtualization/application-group/.test/min/main.test.bicep
+++ b/modules/desktop-virtualization/application-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.applicationgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.applicationgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/desktop-virtualization/host-pool/.test/common/main.test.bicep
+++ b/modules/desktop-virtualization/host-pool/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.hostpools-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.hostpools-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -85,7 +85,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -128,4 +129,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/desktop-virtualization/host-pool/.test/min/main.test.bicep
+++ b/modules/desktop-virtualization/host-pool/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.hostpools-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.hostpools-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/desktop-virtualization/scaling-plan/.test/common/main.test.bicep
+++ b/modules/desktop-virtualization/scaling-plan/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.scalingplans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.scalingplans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -69,7 +69,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -126,4 +127,3 @@ module testDeployment '../../main.bicep' = {
     ]
   }
 }
-

--- a/modules/desktop-virtualization/scaling-plan/.test/min/main.test.bicep
+++ b/modules/desktop-virtualization/scaling-plan/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.scalingplans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.scalingplans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/desktop-virtualization/workspace/.test/common/main.test.bicep
+++ b/modules/desktop-virtualization/workspace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -83,7 +83,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -96,4 +97,3 @@ module testDeployment '../../main.bicep' = {
     friendlyName: 'My first AVD Workspace'
   }
 }
-

--- a/modules/desktop-virtualization/workspace/.test/min/main.test.bicep
+++ b/modules/desktop-virtualization/workspace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.desktopvirtualization.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-desktopvirtualization.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/dev-test-lab/lab/.test/common/main.test.bicep
+++ b/modules/dev-test-lab/lab/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.devtestlab.labs-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-devtestlab.labs-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -68,7 +68,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -282,4 +283,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/dev-test-lab/lab/.test/min/main.test.bicep
+++ b/modules/dev-test-lab/lab/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.devtestlab.labs-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-devtestlab.labs-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/digital-twins/digital-twins-instance/.test/common/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.digitaltwins.digitaltwinsinstances-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-digitaltwins.digitaltwinsinstances-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -112,7 +112,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalResourceId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalResourceId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -123,4 +124,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/digital-twins/digital-twins-instance/.test/min/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.digitaltwins.digitaltwinsinstances-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-digitaltwins.digitaltwinsinstances-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/document-db/database-account/.test/gremlindb/main.test.bicep
+++ b/modules/document-db/database-account/.test/gremlindb/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.documentdb.databaseaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-documentdb.databaseaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -135,7 +135,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -147,4 +148,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/document-db/database-account/.test/mongodb/main.test.bicep
+++ b/modules/document-db/database-account/.test/mongodb/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.documentdb.databaseaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-documentdb.databaseaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -268,7 +268,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -280,4 +281,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/document-db/database-account/.test/plain/main.test.bicep
+++ b/modules/document-db/database-account/.test/plain/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.documentdb.databaseaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-documentdb.databaseaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -87,7 +87,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -98,4 +99,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/document-db/database-account/.test/sqldb/main.test.bicep
+++ b/modules/document-db/database-account/.test/sqldb/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.documentdb.databaseaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-documentdb.databaseaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -101,7 +101,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -191,4 +192,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/event-grid/domain/.test/common/main.test.bicep
+++ b/modules/event-grid/domain/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.domains-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.domains-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/domain/.test/min/main.test.bicep
+++ b/modules/event-grid/domain/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.domains-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.domains-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/domain/.test/pe/main.test.bicep
+++ b/modules/event-grid/domain/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.domains-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.domains-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/system-topic/.test/common/main.test.bicep
+++ b/modules/event-grid/system-topic/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.systemtopics-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.systemtopics-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/system-topic/.test/min/main.test.bicep
+++ b/modules/event-grid/system-topic/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.systemtopics-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.systemtopics-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/topic/.test/common/main.test.bicep
+++ b/modules/event-grid/topic/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.topics-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.topics-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/topic/.test/min/main.test.bicep
+++ b/modules/event-grid/topic/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.topics-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.topics-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-grid/topic/.test/pe/main.test.bicep
+++ b/modules/event-grid/topic/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventgrid.topics-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventgrid.topics-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-hub/namespace/.test/common/main.test.bicep
+++ b/modules/event-hub/namespace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventhub.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventhub.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-hub/namespace/.test/encr/main.test.bicep
+++ b/modules/event-hub/namespace/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventhub.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventhub.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-hub/namespace/.test/min/main.test.bicep
+++ b/modules/event-hub/namespace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventhub.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventhub.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/event-hub/namespace/.test/pe/main.test.bicep
+++ b/modules/event-hub/namespace/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.eventhub.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-eventhub.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/health-bot/health-bot/.test/common/main.test.bicep
+++ b/modules/health-bot/health-bot/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.healthbot.healthbots-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-healthbot.healthbots-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/health-bot/health-bot/.test/min/main.test.bicep
+++ b/modules/health-bot/health-bot/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.healthbot.healthbots-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-healthbot.healthbots-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/healthcare-apis/workspace/.test/common/main.test.bicep
+++ b/modules/healthcare-apis/workspace/.test/common/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with most of its featur
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.healthcareapis.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-healthcareapis.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/healthcare-apis/workspace/.test/min/main.test.bicep
+++ b/modules/healthcare-apis/workspace/.test/min/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.healthcareapis.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-healthcareapis.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/action-group/.test/common/main.test.bicep
+++ b/modules/insights/action-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.actiongroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.actiongroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/action-group/.test/min/main.test.bicep
+++ b/modules/insights/action-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.actiongroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.actiongroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/activity-log-alert/.test/common/main.test.bicep
+++ b/modules/insights/activity-log-alert/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.activityLogAlerts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.activityLogAlerts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/component/.test/common/main.test.bicep
+++ b/modules/insights/component/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.components-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.components-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/component/.test/min/main.test.bicep
+++ b/modules/insights/component/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.components-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.components-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-endpoint/.test/common/main.test.bicep
+++ b/modules/insights/data-collection-endpoint/.test/common/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with most of its featur
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionEndpoints-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionEndpoints-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-endpoint/.test/min/main.test.bicep
+++ b/modules/insights/data-collection-endpoint/.test/min/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionEndpoints-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionEndpoints-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/customadv/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/customadv/main.test.bicep
@@ -5,7 +5,7 @@ targetScope = 'subscription'
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/custombasic/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/custombasic/main.test.bicep
@@ -5,7 +5,7 @@ targetScope = 'subscription'
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/customiis/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/customiis/main.test.bicep
@@ -5,7 +5,7 @@ targetScope = 'subscription'
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/linux/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/linux/main.test.bicep
@@ -5,7 +5,7 @@ targetScope = 'subscription'
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/min/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/min/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/data-collection-rule/.test/windows/main.test.bicep
+++ b/modules/insights/data-collection-rule/.test/windows/main.test.bicep
@@ -5,7 +5,7 @@ targetScope = 'subscription'
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.dataCollectionRules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.dataCollectionRules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/diagnostic-setting/.test/common/main.test.bicep
+++ b/modules/insights/diagnostic-setting/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.diagnosticsettings-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.diagnosticsettings-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/metric-alert/.test/common/main.test.bicep
+++ b/modules/insights/metric-alert/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.metricalerts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.metricalerts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/private-link-scope/.test/common/main.test.bicep
+++ b/modules/insights/private-link-scope/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.privatelinkscopes-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.privatelinkscopes-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/private-link-scope/.test/min/main.test.bicep
+++ b/modules/insights/private-link-scope/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.privatelinkscopes-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.privatelinkscopes-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/scheduled-query-rule/.test/common/main.test.bicep
+++ b/modules/insights/scheduled-query-rule/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.scheduledqueryrules-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.scheduledqueryrules-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/webtest/.test/common/main.test.bicep
+++ b/modules/insights/webtest/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.webtests-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.webtests-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/insights/webtest/.test/min/main.test.bicep
+++ b/modules/insights/webtest/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.insights.webtests-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-insights.webtests-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/key-vault/vault/.test/accesspolicies/main.test.bicep
+++ b/modules/key-vault/vault/.test/accesspolicies/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.keyvault.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-keyvault.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/key-vault/vault/.test/common/main.test.bicep
+++ b/modules/key-vault/vault/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.keyvault.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-keyvault.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/key-vault/vault/.test/min/main.test.bicep
+++ b/modules/key-vault/vault/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.keyvault.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-keyvault.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/key-vault/vault/.test/pe/main.test.bicep
+++ b/modules/key-vault/vault/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.keyvault.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-keyvault.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/kubernetes-configuration/extension/.test/common/main.test.bicep
+++ b/modules/kubernetes-configuration/extension/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.kubernetesconfiguration.extensions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-kubernetesconfiguration.extensions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/kubernetes-configuration/extension/.test/min/main.test.bicep
+++ b/modules/kubernetes-configuration/extension/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.kubernetesconfiguration.extensions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-kubernetesconfiguration.extensions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/kubernetes-configuration/flux-configuration/.test/common/main.test.bicep
+++ b/modules/kubernetes-configuration/flux-configuration/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.kubernetesconfiguration.fluxconfigurations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-kubernetesconfiguration.fluxconfigurations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/kubernetes-configuration/flux-configuration/.test/min/main.test.bicep
+++ b/modules/kubernetes-configuration/flux-configuration/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.kubernetesconfiguration.fluxconfigurations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-kubernetesconfiguration.fluxconfigurations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/logic/workflow/.test/common/main.test.bicep
+++ b/modules/logic/workflow/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.logic.workflows-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-logic.workflows-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/machine-learning-services/workspace/.test/common/main.test.bicep
+++ b/modules/machine-learning-services/workspace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.machinelearningservices.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-machinelearningservices.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/machine-learning-services/workspace/.test/encr/main.test.bicep
+++ b/modules/machine-learning-services/workspace/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.machinelearningservices.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-machinelearningservices.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/machine-learning-services/workspace/.test/min/main.test.bicep
+++ b/modules/machine-learning-services/workspace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.machinelearningservices.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-machinelearningservices.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/maintenance/maintenance-configuration/.test/common/main.test.bicep
+++ b/modules/maintenance/maintenance-configuration/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.maintenance.maintenanceconfigurations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-maintenance.maintenanceconfigurations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/maintenance/maintenance-configuration/.test/min/main.test.bicep
+++ b/modules/maintenance/maintenance-configuration/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.maintenance.maintenanceconfigurations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-maintenance.maintenanceconfigurations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/managed-identity/user-assigned-identity/.test/common/main.test.bicep
+++ b/modules/managed-identity/user-assigned-identity/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.managedidentity.userassignedidentities-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-managedidentity.userassignedidentities-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/managed-identity/user-assigned-identity/.test/min/main.test.bicep
+++ b/modules/managed-identity/user-assigned-identity/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.managedidentity.userassignedidentities-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-managedidentity.userassignedidentities-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/managed-identity/user-assigned-identity/.test/min/main.test.bicep
+++ b/modules/managed-identity/user-assigned-identity/.test/min/main.test.bicep
@@ -20,6 +20,9 @@ param serviceShort string = 'miuaimin'
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
+@description('Optional. A token to inject into the name of each resource.')
+param namePrefix string = '[[namePrefix]]'
+
 // ============ //
 // Dependencies //
 // ============ //

--- a/modules/managed-services/registration-definition/.test/rg/main.test.bicep
+++ b/modules/managed-services/registration-definition/.test/rg/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.managedservices.registrationdefinitions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-managedservices.registrationdefinitions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/net-app/net-app-account/.test/min/main.test.bicep
+++ b/modules/net-app/net-app-account/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.netapp.netappaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-netapp.netappaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/net-app/net-app-account/.test/nfs3/main.test.bicep
+++ b/modules/net-app/net-app-account/.test/nfs3/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.netapp.netappaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-netapp.netappaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/net-app/net-app-account/.test/nfs41/main.test.bicep
+++ b/modules/net-app/net-app-account/.test/nfs41/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.netapp.netappaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-netapp.netappaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/application-gateway-web-application-firewall-policy/.test/common/main.test.bicep
+++ b/modules/network/application-gateway-web-application-firewall-policy/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.applicationGatewayWebApplicationFirewallPolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.applicationGatewayWebApplicationFirewallPolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/application-gateway/.test/common/main.test.bicep
+++ b/modules/network/application-gateway/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.applicationgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.applicationgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/application-security-group/.test/common/main.test.bicep
+++ b/modules/network/application-security-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.applicationsecuritygroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.applicationsecuritygroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/addpip/main.test.bicep
+++ b/modules/network/azure-firewall/.test/addpip/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/common/main.test.bicep
+++ b/modules/network/azure-firewall/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/custompip/main.test.bicep
+++ b/modules/network/azure-firewall/.test/custompip/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/hubcommon/main.test.bicep
+++ b/modules/network/azure-firewall/.test/hubcommon/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/hubmin/main.test.bicep
+++ b/modules/network/azure-firewall/.test/hubmin/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/azure-firewall/.test/min/main.test.bicep
+++ b/modules/network/azure-firewall/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.azurefirewalls-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.azurefirewalls-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/bastion-host/.test/common/main.test.bicep
+++ b/modules/network/bastion-host/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.bastionhosts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.bastionhosts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/bastion-host/.test/custompip/main.test.bicep
+++ b/modules/network/bastion-host/.test/custompip/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.bastionhosts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.bastionhosts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/bastion-host/.test/min/main.test.bicep
+++ b/modules/network/bastion-host/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.bastionhosts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.bastionhosts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/connection/.test/vnet2vnet/main.test.bicep
+++ b/modules/network/connection/.test/vnet2vnet/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.connections-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.connections-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/ddos-protection-plan/.test/common/main.test.bicep
+++ b/modules/network/ddos-protection-plan/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.ddosprotectionplans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.ddosprotectionplans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/ddos-protection-plan/.test/min/main.test.bicep
+++ b/modules/network/ddos-protection-plan/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.ddosprotectionplans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.ddosprotectionplans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/dns-forwarding-ruleset/.test/common/main.test.bicep
+++ b/modules/network/dns-forwarding-ruleset/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.dnsForwardingRuleset-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.dnsForwardingRuleset-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/dns-forwarding-ruleset/.test/min/main.test.bicep
+++ b/modules/network/dns-forwarding-ruleset/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.dnsForwardingRuleset-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.dnsForwardingRuleset-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/dns-resolver/.test/common/main.test.bicep
+++ b/modules/network/dns-resolver/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.dnsResolvers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.dnsResolvers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/dns-zone/.test/common/main.test.bicep
+++ b/modules/network/dns-zone/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.dnszones-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.dnszones-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/dns-zone/.test/min/main.test.bicep
+++ b/modules/network/dns-zone/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.dnszones-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.dnszones-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/express-route-circuit/.test/common/main.test.bicep
+++ b/modules/network/express-route-circuit/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.expressroutecircuits-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.expressroutecircuits-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/express-route-circuit/.test/min/main.test.bicep
+++ b/modules/network/express-route-circuit/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.expressroutecircuits-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.expressroutecircuits-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/express-route-gateway/.test/common/main.test.bicep
+++ b/modules/network/express-route-gateway/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.expressRouteGateway-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.expressRouteGateway-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/express-route-gateway/.test/min/main.test.bicep
+++ b/modules/network/express-route-gateway/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.expressRouteGateway-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.expressRouteGateway-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/firewall-policy/.test/common/main.test.bicep
+++ b/modules/network/firewall-policy/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.firewallpolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.firewallpolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/firewall-policy/.test/min/main.test.bicep
+++ b/modules/network/firewall-policy/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.firewallpolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.firewallpolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/front-door-web-application-firewall-policy/.test/common/main.test.bicep
+++ b/modules/network/front-door-web-application-firewall-policy/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.frontdoorWebApplicationFirewallPolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.frontdoorWebApplicationFirewallPolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/front-door-web-application-firewall-policy/.test/min/main.test.bicep
+++ b/modules/network/front-door-web-application-firewall-policy/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.frontdoorWebApplicationFirewallPolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.frontdoorWebApplicationFirewallPolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/front-door/.test/common/main.test.bicep
+++ b/modules/network/front-door/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.frontdoors-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.frontdoors-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/front-door/.test/min/main.test.bicep
+++ b/modules/network/front-door/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.frontdoors-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.frontdoors-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/ip-group/.test/common/main.test.bicep
+++ b/modules/network/ip-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.ipgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.ipgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/ip-group/.test/min/main.test.bicep
+++ b/modules/network/ip-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.ipgroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.ipgroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/load-balancer/.test/common/main.test.bicep
+++ b/modules/network/load-balancer/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.loadbalancers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.loadbalancers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/load-balancer/.test/internal/main.test.bicep
+++ b/modules/network/load-balancer/.test/internal/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.loadbalancers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.loadbalancers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/load-balancer/.test/min/main.test.bicep
+++ b/modules/network/load-balancer/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.loadbalancers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.loadbalancers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/local-network-gateway/.test/common/main.test.bicep
+++ b/modules/network/local-network-gateway/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.localnetworkgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.localnetworkgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/local-network-gateway/.test/min/main.test.bicep
+++ b/modules/network/local-network-gateway/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.localnetworkgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.localnetworkgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/nat-gateway/.test/common/main.test.bicep
+++ b/modules/network/nat-gateway/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.natgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.natgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/network-interface/.test/common/main.test.bicep
+++ b/modules/network/network-interface/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.networkinterfaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.networkinterfaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -104,7 +104,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -115,4 +116,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/network/network-interface/.test/min/main.test.bicep
+++ b/modules/network/network-interface/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.networkinterfaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.networkinterfaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/network-manager/.test/common/main.test.bicep
+++ b/modules/network/network-manager/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.networkmanagers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.networkmanagers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/network-security-group/.test/common/main.test.bicep
+++ b/modules/network/network-security-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.networksecuritygroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.networksecuritygroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/network-security-group/.test/min/main.test.bicep
+++ b/modules/network/network-security-group/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.networksecuritygroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.networksecuritygroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-dns-zone/.test/common/main.test.bicep
+++ b/modules/network/private-dns-zone/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privatednszones-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privatednszones-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-dns-zone/.test/min/main.test.bicep
+++ b/modules/network/private-dns-zone/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privatednszones-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privatednszones-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-endpoint/.test/common/main.test.bicep
+++ b/modules/network/private-endpoint/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privateendpoints-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privateendpoints-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-endpoint/.test/min/main.test.bicep
+++ b/modules/network/private-endpoint/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privateendpoints-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privateendpoints-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-link-service/.test/common/main.test.bicep
+++ b/modules/network/private-link-service/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privatelinkservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privatelinkservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/private-link-service/.test/min/main.test.bicep
+++ b/modules/network/private-link-service/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.privatelinkservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.privatelinkservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/public-ip-address/.test/common/main.test.bicep
+++ b/modules/network/public-ip-address/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.publicipaddresses-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.publicipaddresses-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location
@@ -78,7 +78,8 @@ module testDeployment '../../main.bicep' = {
     roleAssignments: [
       {
         roleDefinitionIdOrName: 'Reader'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+
         principalType: 'ServicePrincipal'
       }
     ]
@@ -95,4 +96,3 @@ module testDeployment '../../main.bicep' = {
     }
   }
 }
-

--- a/modules/network/public-ip-address/.test/min/main.test.bicep
+++ b/modules/network/public-ip-address/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.publicipaddresses-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.publicipaddresses-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/public-ip-prefix/.test/common/main.test.bicep
+++ b/modules/network/public-ip-prefix/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.publicipprefixes-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.publicipprefixes-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/public-ip-prefix/.test/min/main.test.bicep
+++ b/modules/network/public-ip-prefix/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.publicipprefixes-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.publicipprefixes-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/route-table/.test/common/main.test.bicep
+++ b/modules/network/route-table/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.routetables-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.routetables-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/route-table/.test/min/main.test.bicep
+++ b/modules/network/route-table/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.routetables-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.routetables-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/service-endpoint-policy/.test/common/main.test.bicep
+++ b/modules/network/service-endpoint-policy/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.serviceendpointpolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.serviceendpointpolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/service-endpoint-policy/.test/min/main.test.bicep
+++ b/modules/network/service-endpoint-policy/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.serviceendpointpolicies-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.serviceendpointpolicies-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/trafficmanagerprofile/.test/common/main.test.bicep
+++ b/modules/network/trafficmanagerprofile/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.trafficmanagerprofiles-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.trafficmanagerprofiles-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/trafficmanagerprofile/.test/min/main.test.bicep
+++ b/modules/network/trafficmanagerprofile/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.trafficmanagerprofiles-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.trafficmanagerprofiles-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-hub/.test/common/main.test.bicep
+++ b/modules/network/virtual-hub/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualHub-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualHub-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-hub/.test/min/main.test.bicep
+++ b/modules/network/virtual-hub/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualHub-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualHub-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network-gateway/.test/aadvpn/main.test.bicep
+++ b/modules/network/virtual-network-gateway/.test/aadvpn/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworkgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworkgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network-gateway/.test/expressRoute/main.test.bicep
+++ b/modules/network/virtual-network-gateway/.test/expressRoute/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworkgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworkgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network-gateway/.test/vpn/main.test.bicep
+++ b/modules/network/virtual-network-gateway/.test/vpn/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworkgateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworkgateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network/.test/common/main.test.bicep
+++ b/modules/network/virtual-network/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworks-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworks-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network/.test/min/main.test.bicep
+++ b/modules/network/virtual-network/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworks-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworks-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-network/.test/vnetPeering/main.test.bicep
+++ b/modules/network/virtual-network/.test/vnetPeering/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualnetworks-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualnetworks-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-wan/.test/common/main.test.bicep
+++ b/modules/network/virtual-wan/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualwans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualwans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/virtual-wan/.test/min/main.test.bicep
+++ b/modules/network/virtual-wan/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.virtualwans-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.virtualwans-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/vpn-gateway/.test/common/main.test.bicep
+++ b/modules/network/vpn-gateway/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.vpngateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.vpngateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/vpn-gateway/.test/min/main.test.bicep
+++ b/modules/network/vpn-gateway/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.vpngateways-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.vpngateways-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/vpn-site/.test/common/main.test.bicep
+++ b/modules/network/vpn-site/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.vpnSites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.vpnSites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/network/vpn-site/.test/min/main.test.bicep
+++ b/modules/network/vpn-site/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.network.vpnSites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-network.vpnSites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operational-insights/workspace/.test/adv/main.test.bicep
+++ b/modules/operational-insights/workspace/.test/adv/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationalinsights.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationalinsights.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operational-insights/workspace/.test/common/main.test.bicep
+++ b/modules/operational-insights/workspace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationalinsights.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationalinsights.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operational-insights/workspace/.test/min/main.test.bicep
+++ b/modules/operational-insights/workspace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationalinsights.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationalinsights.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operations-management/solution/.test/min/main.test.bicep
+++ b/modules/operations-management/solution/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationsmanagement.solutions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationsmanagement.solutions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operations-management/solution/.test/ms/main.test.bicep
+++ b/modules/operations-management/solution/.test/ms/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationsmanagement.solutions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationsmanagement.solutions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/operations-management/solution/.test/nonms/main.test.bicep
+++ b/modules/operations-management/solution/.test/nonms/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.operationsmanagement.solutions-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-operationsmanagement.solutions-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/policy-insights/remediation/.test/rg.common/main.test.bicep
+++ b/modules/policy-insights/remediation/.test/rg.common/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.policyinsights.remediations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-policyinsights.remediations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/policy-insights/remediation/.test/rg.min/main.test.bicep
+++ b/modules/policy-insights/remediation/.test/rg.min/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.policyinsights.remediations-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-policyinsights.remediations-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/power-bi-dedicated/capacity/.test/common/main.test.bicep
+++ b/modules/power-bi-dedicated/capacity/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.powerbidedicated.capacities-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-powerbidedicated.capacities-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/power-bi-dedicated/capacity/.test/min/main.test.bicep
+++ b/modules/power-bi-dedicated/capacity/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.powerbidedicated.capacities-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-powerbidedicated.capacities-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/purview/account/.test/common/main.test.bicep
+++ b/modules/purview/account/.test/common/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with most of its featur
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.purview-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-purview-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = 'eastus' // Only available in selected locations: eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3

--- a/modules/purview/account/.test/min/main.test.bicep
+++ b/modules/purview/account/.test/min/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 // ========== //
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.purview-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-purview-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = 'eastus' // Only available in selected locations: eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3

--- a/modules/recovery-services/vault/.test/common/main.test.bicep
+++ b/modules/recovery-services/vault/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.recoveryservices.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-recoveryservices.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/recovery-services/vault/.test/dr/main.test.bicep
+++ b/modules/recovery-services/vault/.test/dr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.recoveryservices.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-recoveryservices.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/recovery-services/vault/.test/min/main.test.bicep
+++ b/modules/recovery-services/vault/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.recoveryservices.vaults-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-recoveryservices.vaults-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/relay/namespace/.test/common/main.test.bicep
+++ b/modules/relay/namespace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-relay.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/relay/namespace/.test/min/main.test.bicep
+++ b/modules/relay/namespace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-relay.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/relay/namespace/.test/pe/main.test.bicep
+++ b/modules/relay/namespace/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.relay.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-relay.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resource-graph/query/.test/common/main.test.bicep
+++ b/modules/resource-graph/query/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resourcegraph.queries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resourcegraph.queries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resource-graph/query/.test/min/main.test.bicep
+++ b/modules/resource-graph/query/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resourcegraph.queries-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resourcegraph.queries-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resources/deployment-script/.test/cli/main.test.bicep
+++ b/modules/resources/deployment-script/.test/cli/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resources.deploymentscripts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resources.deploymentscripts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resources/deployment-script/.test/ps/main.test.bicep
+++ b/modules/resources/deployment-script/.test/ps/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resources.deploymentscripts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resources.deploymentscripts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resources/resource-group/.test/common/main.test.bicep
+++ b/modules/resources/resource-group/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resources.resourcegroups-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resources.resourcegroups-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resources/tags/.test/rg/main.test.bicep
+++ b/modules/resources/tags/.test/rg/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.resources.tags-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-resources.tags-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/resources/tags/.test/rg/main.test.bicep
+++ b/modules/resources/tags/.test/rg/main.test.bicep
@@ -17,6 +17,9 @@ param serviceShort string = 'rtrg'
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
+@description('Optional. A token to inject into the name of each resource.')
+param namePrefix string = '[[namePrefix]]'
+
 // ============ //
 // Dependencies //
 // ============ //

--- a/modules/search/search-service/.test/common/main.test.bicep
+++ b/modules/search/search-service/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.search.searchservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-search.searchservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/search/search-service/.test/min/main.test.bicep
+++ b/modules/search/search-service/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.search.searchservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-search.searchservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/search/search-service/.test/pe/main.test.bicep
+++ b/modules/search/search-service/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.search.searchservices-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-search.searchservices-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/security/azure-security-center/.test/common/main.test.bicep
+++ b/modules/security/azure-security-center/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.security.azureSecurityCenter-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-security.azureSecurityCenter-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-bus/namespace/.test/common/main.test.bicep
+++ b/modules/service-bus/namespace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicebus.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicebus.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-bus/namespace/.test/encr/main.test.bicep
+++ b/modules/service-bus/namespace/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicebus.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicebus.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-bus/namespace/.test/min/main.test.bicep
+++ b/modules/service-bus/namespace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicebus.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicebus.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-bus/namespace/.test/pe/main.test.bicep
+++ b/modules/service-bus/namespace/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicebus.namespaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicebus.namespaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-fabric/cluster/.test/cert/main.test.bicep
+++ b/modules/service-fabric/cluster/.test/cert/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicefabric.clusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicefabric.clusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-fabric/cluster/.test/common/main.test.bicep
+++ b/modules/service-fabric/cluster/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicefabric.clusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicefabric.clusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/service-fabric/cluster/.test/min/main.test.bicep
+++ b/modules/service-fabric/cluster/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.servicefabric.clusters-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-servicefabric.clusters-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/signal-r-service/signal-r/.test/common/main.test.bicep
+++ b/modules/signal-r-service/signal-r/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.signalrservice.signalr-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-signalrservice.signalr-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/signal-r-service/signal-r/.test/min/main.test.bicep
+++ b/modules/signal-r-service/signal-r/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.signalrservice.signalr-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-signalrservice.signalr-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/signal-r-service/web-pub-sub/.test/common/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.signalrservice.webpubsub-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-signalrservice.webpubsub-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/signal-r-service/web-pub-sub/.test/min/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.signalrservice.webpubsub-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-signalrservice.webpubsub-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/signal-r-service/web-pub-sub/.test/pe/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.signalrservice.webpubsub-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-signalrservice.webpubsub-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/managed-instance/.test/common/main.test.bicep
+++ b/modules/sql/managed-instance/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.managedinstances-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.managedinstances-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/managed-instance/.test/min/main.test.bicep
+++ b/modules/sql/managed-instance/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.managedinstances-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.managedinstances-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/managed-instance/.test/vulnAssm/main.test.bicep
+++ b/modules/sql/managed-instance/.test/vulnAssm/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.managedinstances-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.managedinstances-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/server/.test/admin/main.test.bicep
+++ b/modules/sql/server/.test/admin/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/server/.test/common/main.test.bicep
+++ b/modules/sql/server/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/server/.test/pe/main.test.bicep
+++ b/modules/sql/server/.test/pe/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/sql/server/.test/secondary/main.test.bicep
+++ b/modules/sql/server/.test/secondary/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.sql.servers-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/storage/storage-account/.test/common/main.test.bicep
+++ b/modules/storage/storage-account/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.storage.storageaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/storage/storage-account/.test/encr/main.test.bicep
+++ b/modules/storage/storage-account/.test/encr/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.storage.storageaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/storage/storage-account/.test/min/main.test.bicep
+++ b/modules/storage/storage-account/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.storage.storageaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/storage/storage-account/.test/nfs/main.test.bicep
+++ b/modules/storage/storage-account/.test/nfs/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.storage.storageaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/storage/storage-account/.test/v1/main.test.bicep
+++ b/modules/storage/storage-account/.test/v1/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.storage.storageaccounts-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/private-link-hub/.test/common/main.test.bicep
+++ b/modules/synapse/private-link-hub/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.privatelinkhubs-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.privatelinkhubs-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/private-link-hub/.test/min/main.test.bicep
+++ b/modules/synapse/private-link-hub/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.privatelinkhubs-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.privatelinkhubs-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/workspace/.test/common/main.test.bicep
+++ b/modules/synapse/workspace/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/workspace/.test/encrwsai/main.test.bicep
+++ b/modules/synapse/workspace/.test/encrwsai/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/workspace/.test/encrwuai/main.test.bicep
+++ b/modules/synapse/workspace/.test/encrwuai/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/workspace/.test/managedvnet/main.test.bicep
+++ b/modules/synapse/workspace/.test/managedvnet/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/synapse/workspace/.test/min/main.test.bicep
+++ b/modules/synapse/workspace/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.synapse.workspaces-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-synapse.workspaces-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/virtual-machine-images/image-template/.test/common/main.test.bicep
+++ b/modules/virtual-machine-images/image-template/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.virtualmachineimages.imagetemplates-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-virtualmachineimages.imagetemplates-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/virtual-machine-images/image-template/.test/min/main.test.bicep
+++ b/modules/virtual-machine-images/image-template/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.virtualmachineimages.imagetemplates-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-virtualmachineimages.imagetemplates-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/connection/.test/common/main.test.bicep
+++ b/modules/web/connection/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.connections-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.connections-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/hosting-environment/.test/asev2/main.test.bicep
+++ b/modules/web/hosting-environment/.test/asev2/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.hostingenvironments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.hostingenvironments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/hosting-environment/.test/asev3/main.test.bicep
+++ b/modules/web/hosting-environment/.test/asev3/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.hostingenvironments-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.hostingenvironments-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/serverfarm/.test/common/main.test.bicep
+++ b/modules/web/serverfarm/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.serverfarms-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.serverfarms-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/site/.test/functionAppCommon/main.test.bicep
+++ b/modules/web/site/.test/functionAppCommon/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.sites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.sites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/site/.test/functionAppMin/main.test.bicep
+++ b/modules/web/site/.test/functionAppMin/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.sites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.sites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/site/.test/webAppCommon/main.test.bicep
+++ b/modules/web/site/.test/webAppCommon/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.sites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.sites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/site/.test/webAppMin/main.test.bicep
+++ b/modules/web/site/.test/webAppMin/main.test.bicep
@@ -6,7 +6,7 @@ targetScope = 'subscription'
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.sites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.sites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/static-site/.test/common/main.test.bicep
+++ b/modules/web/static-site/.test/common/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with most of its featur
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.staticsites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.staticsites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location

--- a/modules/web/static-site/.test/min/main.test.bicep
+++ b/modules/web/static-site/.test/min/main.test.bicep
@@ -9,7 +9,7 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-param resourceGroupName string = 'ms.web.staticsites-${serviceShort}-rg'
+param resourceGroupName string = 'dep-${namePrefix}-web.staticsites-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param location string = deployment().location


### PR DESCRIPTION
# Description

Closes #4020 
Add nameprefix to rg test names, aligning with avm pbr names
Add nameprefix to tests where it was missing:
- resources\tags\.test\rg\main.test.bicep
- managed-identity\user-assigned-identity\.test\min\main.test.bicep
- authorization\lock\.test\common\main.test.bicep

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
[![AAD - DomainServices](https://github.com/Azure/ResourceModules/actions/workflows/ms.aad.domainservices.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.aad.domainservices.yml)
[![AnalysisServices - Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.analysisservices.servers.yml)
[![ApiManagement - Service](https://github.com/Azure/ResourceModules/actions/workflows/ms.apimanagement.service.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.apimanagement.service.yml)
[![App - ContainerApps](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.containerapps.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.containerapps.yml)
[![App - Managed Environments](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.managedenvironments.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.app.managedenvironments.yml)
[![AppConfiguration - ConfigurationStores](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.appconfiguration.configurationstores.yml)
[![Authorization - Locks](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.locks.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.locks.yml)
[![Authorization - PolicyAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyassignments.yml)
[![Authorization - PolicyDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policydefinitions.yml)
[![Authorization - PolicyExemptions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policyexemptions.yml)
[![Authorization - PolicySetDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policysetdefinitions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.policysetdefinitions.yml)
[![Authorization - RoleAssignments](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roleassignments.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roleassignments.yml) - unrelated
[![Authorization - RoleDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roledefinitions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.authorization.roledefinitions.yml)
[![Automation - AutomationAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.automation.automationaccounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.automation.automationaccounts.yml)
[![Batch - BatchAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.batch.batchaccounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.batch.batchaccounts.yml)
[![Cache - Redis Enterprise](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redisenterprise.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redisenterprise.yml)
[![Cache - Redis](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cache.redis.yml)
[![CDN - Profiles](https://github.com/Azure/ResourceModules/actions/workflows/ms.cdn.profiles.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cdn.profiles.yml)
[![CognitiveServices - Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.cognitiveservices.accounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.cognitiveservices.accounts.yml)
[![Compute - AvailabilitySets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.availabilitysets.yml)
[![Compute - DiskEncryptionSets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.diskencryptionsets.yml)
[![Compute - Disks](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.disks.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.disks.yml)        
[![Compute - Galleries](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.galleries.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.galleries.yml)
[![Compute - Images](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.images.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.images.yml)     
[![Compute - ProximityPlacementGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.proximityplacementgroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.proximityplacementgroups.yml)
[![Compute - SshPublicKeys](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.sshpublickeys.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.sshpublickeys.yml)
[![Compute - VirtualMachines](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachines.yml)
[![Compute - VirtualMachineScaleSets](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachinescalesets.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.compute.virtualmachinescalesets.yml)
[![Consumption - Budgets](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.consumption.budgets.yml)
[![ContainerInstance - ContainerGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerinstance.containergroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerinstance.containergroups.yml)
[![ContainerRegistry - Registries](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerregistry.registries.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerregistry.registries.yml)
[![ContainerService - ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml)
[![Databricks - Access Connectors](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.accessconnectors.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.accessconnectors.yml)
[![Databricks - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.databricks.workspaces.yml)
[![DataFactory - Factories](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.datafactory.factories.yml)
[![DataProtection - BackupVaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.dataprotection.backupvaults.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dataprotection.backupvaults.yml)
[![DbForMySQL - FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbformysql.flexibleservers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbformysql.flexibleservers.yml)
[![DbForPostgreSQL - FlexibleServers](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.dbforpostgresql.flexibleservers.yml)
[![DesktopVirtualization - ApplicationGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.applicationgroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.applicationgroups.yml)
[![DesktopVirtualization - HostPools](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.hostpools.yml)
[![DesktopVirtualization - Scalingplans](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.scalingplans.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.scalingplans.yml)
[![DesktopVirtualization - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.desktopvirtualization.workspaces.yml)
[![DevTestLab - Labs](https://github.com/Azure/ResourceModules/actions/workflows/ms.devtestlab.labs.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.devtestlab.labs.yml)  
[![DigitalTwins - DigitalTwinsInstances](https://github.com/Azure/ResourceModules/actions/workflows/ms.digitaltwins.digitaltwinsinstances.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.digitaltwins.digitaltwinsinstances.yml)
[![DocumentDB - DatabaseAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.documentdb.databaseaccounts.yml)
[![EventGrid - Domains](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.domains.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.domains.yml)
[![EventGrid - System Topics](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.systemtopics.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.systemtopics.yml)
[![EventGrid - Topics](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.topics.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventgrid.topics.yml)
[![EventHub - Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml)
[![HealthBot - HealthBots](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthbot.healthbots.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthbot.healthbots.yml)
[![HealthcareApis - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthcareapis.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.healthcareapis.workspaces.yml)
[![Insights - ActionGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.actiongroups.yml)
[![Insights - ActivityLogAlerts](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.activitylogalerts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.activitylogalerts.yml)
[![Insights - Components](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.components.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.components.yml)
[![Insights - DataCollectionEndpoints](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.datacollectionendpoints.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.datacollectionendpoints.yml)
[![Insights - DataCollectionRules](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.datacollectionrules.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.datacollectionrules.yml)
[![Insights - DiagnosticSettings](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.diagnosticsettings.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.diagnosticsettings.yml)
[![Insights - MetricAlerts](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.metricalerts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.metricalerts.yml)
[![Insights - PrivateLinkScopes](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.privatelinkscopes.yml)
[![Insights - ScheduledQueryRules](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.scheduledqueryrules.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.scheduledqueryrules.yml)
[![Insights - Web Tests](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.webtests.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.insights.webtests.yml)
[![KeyVault - Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.keyvault.vaults.yml)  
[![KubernetesConfiguration - Extensions](https://github.com/Azure/ResourceModules/actions/workflows/ms.kubernetesconfiguration.extensions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.kubernetesconfiguration.extensions.yml)
[![KubernetesConfiguration - FluxConfigurations](https://github.com/Azure/ResourceModules/actions/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.kubernetesconfiguration.fluxconfigurations.yml)
[![Logic - Workflows](https://github.com/Azure/ResourceModules/actions/workflows/ms.logic.workflows.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.logic.workflows.yml)  
[![MachineLearningServices - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.machinelearningservices.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.machinelearningservices.workspaces.yml)
[![Maintenance - MaintenanceConfigurations](https://github.com/Azure/ResourceModules/actions/workflows/ms.maintenance.maintenanceconfigurations.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.maintenance.maintenanceconfigurations.yml)
[![ManagedIdentity - UserAssignedIdentities](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedidentity.userassignedidentities.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedidentity.userassignedidentities.yml)
[![ManagedServices - RegistrationDefinitions](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedservices.registrationdefinitions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.managedservices.registrationdefinitions.yml)
[![Management - ManagementGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.management.managementgroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.management.managementgroups.yml)
[![NetApp - NetAppAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.netapp.netappaccounts.yml)
[![Network - ApplicationGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationgateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationgateways.yml)
[![Network - ApplicationGatewayWebApplicationFirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationgatewaywebapplicationfirewallpolicies.yml)
[![Network - ApplicationSecurityGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationsecuritygroups.yml)
[![Network - AzureFirewalls](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.azurefirewalls.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.azurefirewalls.yml)  - unrelated
[![Network - BastionHosts](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.bastionhosts.yml) - unrelated
[![Network - Connections](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.connections.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.connections.yml)
[![Network - DdosProtectionPlans](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.ddosprotectionplans.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.ddosprotectionplans.yml)
[![Network - DNS Forwarding Rulesets](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsforwardingrulesets.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsforwardingrulesets.yml)
[![Network - DNS Resolvers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsresolvers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnsresolvers.yml)
[![Network - ExpressRouteCircuits](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.expressroutecircuits.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.expressroutecircuits.yml)
[![Network - ExpressRouteGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.expressroutegateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.expressroutegateways.yml)
[![Network - FirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.firewallpolicies.yml)
[![Network - Frontdoors](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.frontdoors.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.frontdoors.yml)
[![Network - FrontDoorWebApplicationFirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.frontdoorwebapplicationfirewallpolicies.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.frontdoorwebapplicationfirewallpolicies.yml)
[![Network - IpGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.ipgroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.ipgroups.yml)
[![Network - LoadBalancers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.loadbalancers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.loadbalancers.yml)
[![Network - LocalNetworkGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.localnetworkgateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.localnetworkgateways.yml)
[![Network - NatGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.natgateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.natgateways.yml) - unrelated
[![Network - Network Managers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkmanagers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkmanagers.yml)
[![Network - NetworkInterfaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkinterfaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkinterfaces.yml)
[![Network - NetworkSecurityGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networksecuritygroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networksecuritygroups.yml)
[![Network - NetworkWatchers](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkwatchers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.networkwatchers.yml)
[![Network - PrivateDnsZones](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatednszones.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatednszones.yml)
[![Network - PrivateEndpoints](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privateendpoints.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privateendpoints.yml)
[![Network - PrivateLinkServices](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatelinkservices.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.privatelinkservices.yml)
[![Network - Public DnsZones](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnszones.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.dnszones.yml)
[![Network - PublicIpAddresses](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.publicipaddresses.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.publicipaddresses.yml)
[![Network - PublicIpPrefixes](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.publicipprefixes.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.publicipprefixes.yml)
[![Network - RouteTables](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.routetables.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.routetables.yml)
[![Network - ServiceEndpointPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.serviceendpointpolicies.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.serviceendpointpolicies.yml)
[![Network - TrafficManagerProfiles](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.trafficmanagerprofiles.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.trafficmanagerprofiles.yml)
[![Network - VirtualHubs](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualhubs.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualhubs.yml)
[![Network - VirtualNetworkGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworkgateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworkgateways.yml) - unrelated
[![Network - VirtualNetworks](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualnetworks.yml) - unrelated
[![Network - VirtualWans](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualwans.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.virtualwans.yml)
[![Network - VPN Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.vpnsites.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.vpnsites.yml)
[![Network - VPNGateways](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.vpngateways.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.vpngateways.yml)
[![Network: ApplicationGatewayWebApplicationFirewallPolicies](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationGatewayWebApplicationFirewallPolicies.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.network.applicationGatewayWebApplicationFirewallPolicies.yml)
[![OperationalInsights - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationalinsights.workspaces.yml)
[![OperationsManagement - Solutions](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationsmanagement.solutions.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.operationsmanagement.solutions.yml)
[![PolicyInsights - Remediations](https://github.com/Azure/ResourceModules/actions/workflows/ms.policyinsights.remediations.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.policyinsights.remediations.yml)
[![PowerBiDedicated - Capacities](https://github.com/Azure/ResourceModules/actions/workflows/ms.powerbidedicated.capacities.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.powerbidedicated.capacities.yml)
[![Purview - Accounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.purview.accounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.purview.accounts.yml)
[![RecoveryServices - Vaults](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.recoveryservices.vaults.yml)
[![Relay - Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.relay.namespaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.relay.namespaces.yml)
[![ResourceGraph - Queries](https://github.com/Azure/ResourceModules/actions/workflows/ms.resourcegraph.queries.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resourcegraph.queries.yml)
[![Resources - DeploymentScripts](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.deploymentscripts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.deploymentscripts.yml)
[![Resources - ResourceGroups](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.resourcegroups.yml)
[![Resources - Tags](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.resources.tags.yml)     
[![Search - SearchServices](https://github.com/Azure/ResourceModules/actions/workflows/ms.search.searchservices.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.search.searchservices.yml)
[![Security - AzureSecurityCenter](https://github.com/Azure/ResourceModules/actions/workflows/ms.security.azuresecuritycenter.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.security.azuresecuritycenter.yml)
[![ServiceBus - Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicebus.namespaces.yml)
[![ServiceFabric - Clusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicefabric.clusters.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.servicefabric.clusters.yml)
[![SignalRService - SignalR](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.signalr.yml)
[![SignalRService - WebPubSub](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.signalrservice.webpubsub.yml)
[![Sql - ManagedInstances](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.managedinstances.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.managedinstances.yml)
[![Sql - Servers](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.sql.servers.yml)
[![Storage - StorageAccounts](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.storage.storageaccounts.yml)
[![Synapse - PrivateLinkHubs](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.privatelinkhubs.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.privatelinkhubs.yml)
[![Synapse - Workspaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.synapse.workspaces.yml)
[![VirtualMachineImages - ImageTemplates](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml)
[![Web - Connections](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.connections.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.connections.yml)  
[![Web - HostingEnvironments](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.hostingenvironments.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.hostingenvironments.yml)
[![Web - Serverfarms](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.serverfarms.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.serverfarms.yml)  
[![Web - Sites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.sites.yml)
[![Web - StaticSites](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.staticsites.yml/badge.svg?branch=users%2Feriqua%2Frg-test-name-02)](https://github.com/Azure/ResourceModules/actions/workflows/ms.web.staticsites.yml)

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
