### PR TITLE
[Bug Fix] Remove kind parameter from App Service Plan `web/serverfarm` module

### DIFF
--- a/modules/web/serverfarm/README.md
+++ b/modules/web/serverfarm/README.md
@@ -435,10 +435,11 @@ Enable telemetry via a Globally Unique Identifier (GUID).
 Kind of server OS.
 - Required: No
 - Type: string
-- Default: `'Windows'`
+- Default: `''`
 - Allowed:
   ```Bicep
   [
+    ''
     'App'
     'Elastic'
     'FunctionApp'

--- a/modules/web/serverfarm/README.md
+++ b/modules/web/serverfarm/README.md
@@ -317,7 +317,6 @@ module serverfarm 'br:bicep/modules/web.serverfarm:1.0.0' = {
 | [`appServiceEnvironmentId`](#parameter-appserviceenvironmentid) | string | The Resource ID of the App Service Environment to use for the App Service Plan. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`enableDefaultTelemetry`](#parameter-enabledefaulttelemetry) | bool | Enable telemetry via a Globally Unique Identifier (GUID). |
-| [`kind`](#parameter-kind) | string | Kind of server OS. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`maximumElasticWorkerCount`](#parameter-maximumelasticworkercount) | int | Maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan. |
@@ -429,24 +428,6 @@ Enable telemetry via a Globally Unique Identifier (GUID).
 - Required: No
 - Type: bool
 - Default: `True`
-
-### Parameter: `kind`
-
-Kind of server OS.
-- Required: No
-- Type: string
-- Default: `''`
-- Allowed:
-  ```Bicep
-  [
-    ''
-    'App'
-    'Elastic'
-    'FunctionApp'
-    'Linux'
-    'Windows'
-  ]
-  ```
 
 ### Parameter: `location`
 

--- a/modules/web/serverfarm/main.bicep
+++ b/modules/web/serverfarm/main.bicep
@@ -15,7 +15,7 @@ param sku object
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
-
+/*
 @description('Optional. Kind of server OS.')
 @allowed([
   'App'
@@ -26,7 +26,7 @@ param location string = resourceGroup().location
   ''
 ])
 param kind string = ''
-
+*/
 @description('Conditional. Defaults to false when creating Windows/app App Service Plan. Required if creating a Linux App Service Plan and must be set to true.')
 param reserved bool = false
 
@@ -98,7 +98,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: name
-  kind: !empty(kind) ? kind : null
+  //kind: !empty(kind) ? kind : null
   location: location
   tags: tags
   sku: sku

--- a/modules/web/serverfarm/main.bicep
+++ b/modules/web/serverfarm/main.bicep
@@ -23,8 +23,9 @@ param location string = resourceGroup().location
   'FunctionApp'
   'Windows'
   'Linux'
+  ''
 ])
-param kind string = 'Windows'
+param kind string = ''
 
 @description('Conditional. Defaults to false when creating Windows/app App Service Plan. Required if creating a Linux App Service Plan and must be set to true.')
 param reserved bool = false
@@ -97,7 +98,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: name
-  kind: kind
+  kind: !empty(kind) ? kind : null
   location: location
   tags: tags
   sku: sku

--- a/modules/web/serverfarm/main.bicep
+++ b/modules/web/serverfarm/main.bicep
@@ -15,18 +15,7 @@ param sku object
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
-/*
-@description('Optional. Kind of server OS.')
-@allowed([
-  'App'
-  'Elastic'
-  'FunctionApp'
-  'Windows'
-  'Linux'
-  ''
-])
-param kind string = ''
-*/
+
 @description('Conditional. Defaults to false when creating Windows/app App Service Plan. Required if creating a Linux App Service Plan and must be set to true.')
 param reserved bool = false
 
@@ -98,7 +87,6 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: name
-  //kind: !empty(kind) ? kind : null
   location: location
   tags: tags
   sku: sku

--- a/modules/web/serverfarm/main.json
+++ b/modules/web/serverfarm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "8298394894981665863"
+      "templateHash": "10832175948195959384"
     },
     "name": "App Service Plans",
     "description": "This module deploys an App Service Plan.",
@@ -207,21 +207,6 @@
         "description": "Optional. Location for all resources."
       }
     },
-    "kind": {
-      "type": "string",
-      "defaultValue": "",
-      "allowedValues": [
-        "App",
-        "Elastic",
-        "FunctionApp",
-        "Windows",
-        "Linux",
-        ""
-      ],
-      "metadata": {
-        "description": "Optional. Kind of server OS."
-      }
-    },
     "reserved": {
       "type": "bool",
       "defaultValue": false,
@@ -346,7 +331,6 @@
       "type": "Microsoft.Web/serverfarms",
       "apiVersion": "2022-09-01",
       "name": "[parameters('name')]",
-      "kind": "[if(not(empty(parameters('kind'))), parameters('kind'), null())]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "sku": "[parameters('sku')]",

--- a/modules/web/serverfarm/main.json
+++ b/modules/web/serverfarm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.22.6.54827",
-      "templateHash": "14824797980620937555"
+      "version": "0.23.1.45101",
+      "templateHash": "8298394894981665863"
     },
     "name": "App Service Plans",
     "description": "This module deploys an App Service Plan.",
@@ -209,13 +209,14 @@
     },
     "kind": {
       "type": "string",
-      "defaultValue": "Windows",
+      "defaultValue": "",
       "allowedValues": [
         "App",
         "Elastic",
         "FunctionApp",
         "Windows",
-        "Linux"
+        "Linux",
+        ""
       ],
       "metadata": {
         "description": "Optional. Kind of server OS."
@@ -345,7 +346,7 @@
       "type": "Microsoft.Web/serverfarms",
       "apiVersion": "2022-09-01",
       "name": "[parameters('name')]",
-      "kind": "[parameters('kind')]",
+      "kind": "[if(not(empty(parameters('kind'))), parameters('kind'), null())]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "sku": "[parameters('sku')]",


### PR DESCRIPTION
# Description

The `kind` parameter for `web/serverfarm` (app service plan) is obsolete according to this article [Overview of the ‘kind’ property for App Service](https://azure.github.io/AppService/2021/08/31/Kind-property-overview.html)

The RP sets the value based on the `sku`, regardless what you have specified. To repro, assign a value to the `kind` parameter:

![image](https://github.com/Azure/ResourceModules/assets/11845994/58d1d373-f9e0-476f-b677-670e3129f937)

after the resource is created, the `GET` request shows a different value that aligned with the `sku`:

![image](https://github.com/Azure/ResourceModules/assets/11845994/3911b198-e77d-4131-b473-b477b0721b97)

I have tried to make it conditional such as `kind: !empty(kind) ? kind : null`, but it didn't work (error as shown below):

![image](https://github.com/Azure/ResourceModules/assets/11845994/330b7d0f-e242-42ff-b3dd-d6bb675c7a11)

The only option is removing it completely and let RP to set it at creation time.


### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![Web - Serverfarms](https://github.com/TY-Consulting/ResourceModules/actions/workflows/ms.web.serverfarms.yml/badge.svg?branch=fix%2Fweb-asp-kind)](https://github.com/TY-Consulting/ResourceModules/actions/workflows/ms.web.serverfarms.yml)|

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
