### PR TITLE
[Utilities] Ported 2 AVM Updates back to CARML

### DIFF
--- a/modules/key-vault/vault/README.md
+++ b/modules/key-vault/vault/README.md
@@ -1113,9 +1113,17 @@ module vault 'br:bicep/modules/key-vault.vault:1.0.0' = {
 | [`tags`](#parameter-tags) | object | Resource tags. |
 | [`vaultSku`](#parameter-vaultsku) | string | Specifies the SKU for the vault. |
 
+### Parameter: `name`
+
+Name of the Key Vault. Must be globally unique.
+
+- Required: Yes
+- Type: string
+
 ### Parameter: `accessPolicies`
 
 All access policies to create.
+
 - Required: No
 - Type: array
 - Default: `[]`
@@ -1123,6 +1131,7 @@ All access policies to create.
 ### Parameter: `createMode`
 
 The vault's create mode to indicate whether the vault need to be recovered or not. - recover or default.
+
 - Required: No
 - Type: string
 - Default: `'default'`
@@ -1130,114 +1139,90 @@ The vault's create mode to indicate whether the vault need to be recovered or no
 ### Parameter: `diagnosticSettings`
 
 The diagnostic settings of the service.
+
 - Required: No
 - Type: array
 
+**Optional parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`eventHubAuthorizationRuleResourceId`](#parameter-diagnosticsettingseventhubauthorizationruleresourceid) | No | string | Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
-| [`eventHubName`](#parameter-diagnosticsettingseventhubname) | No | string | Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
-| [`logAnalyticsDestinationType`](#parameter-diagnosticsettingsloganalyticsdestinationtype) | No | string | Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type. |
-| [`logCategoriesAndGroups`](#parameter-diagnosticsettingslogcategoriesandgroups) | No | array | Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection. |
-| [`marketplacePartnerResourceId`](#parameter-diagnosticsettingsmarketplacepartnerresourceid) | No | string | Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs. |
-| [`metricCategories`](#parameter-diagnosticsettingsmetriccategories) | No | array | Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection. |
-| [`name`](#parameter-diagnosticsettingsname) | No | string | Optional. The name of diagnostic setting. |
-| [`storageAccountResourceId`](#parameter-diagnosticsettingsstorageaccountresourceid) | No | string | Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
-| [`workspaceResourceId`](#parameter-diagnosticsettingsworkspaceresourceid) | No | string | Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`eventHubAuthorizationRuleResourceId`](#parameter-diagnosticsettingseventhubauthorizationruleresourceid) | string | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
+| [`eventHubName`](#parameter-diagnosticsettingseventhubname) | string | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| [`logAnalyticsDestinationType`](#parameter-diagnosticsettingsloganalyticsdestinationtype) | string | A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type. |
+| [`logCategoriesAndGroups`](#parameter-diagnosticsettingslogcategoriesandgroups) | array | The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection. |
+| [`marketplacePartnerResourceId`](#parameter-diagnosticsettingsmarketplacepartnerresourceid) | string | The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs. |
+| [`metricCategories`](#parameter-diagnosticsettingsmetriccategories) | array | The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection. |
+| [`name`](#parameter-diagnosticsettingsname) | string | The name of diagnostic setting. |
+| [`storageAccountResourceId`](#parameter-diagnosticsettingsstorageaccountresourceid) | string | Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| [`workspaceResourceId`](#parameter-diagnosticsettingsworkspaceresourceid) | string | Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
 
 ### Parameter: `diagnosticSettings.eventHubAuthorizationRuleResourceId`
 
-Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.
+Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `diagnosticSettings.eventHubName`
 
-Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
 
 - Required: No
 - Type: string
 
 ### Parameter: `diagnosticSettings.logAnalyticsDestinationType`
 
-Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type.
+A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type.
 
 - Required: No
 - Type: string
-- Allowed: `[AzureDiagnostics, Dedicated]`
+- Allowed:
+  ```Bicep
+  [
+    'AzureDiagnostics'
+    'Dedicated'
+  ]
+  ```
 
 ### Parameter: `diagnosticSettings.logCategoriesAndGroups`
 
-Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection.
+The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection.
 
 - Required: No
 - Type: array
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`category`](#parameter-diagnosticsettingslogcategoriesandgroupscategory) | No | string | Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here. |
-| [`categoryGroup`](#parameter-diagnosticsettingslogcategoriesandgroupscategorygroup) | No | string | Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to 'AllLogs' to collect all logs. |
-
-### Parameter: `diagnosticSettings.logCategoriesAndGroups.category`
-
-Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here.
-
-- Required: No
-- Type: string
-
-### Parameter: `diagnosticSettings.logCategoriesAndGroups.categoryGroup`
-
-Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to 'AllLogs' to collect all logs.
-
-- Required: No
-- Type: string
-
-
 ### Parameter: `diagnosticSettings.marketplacePartnerResourceId`
 
-Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.
+The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.
 
 - Required: No
 - Type: string
 
 ### Parameter: `diagnosticSettings.metricCategories`
 
-Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection.
+The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to '' to disable log collection.
 
 - Required: No
 - Type: array
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`category`](#parameter-diagnosticsettingsmetriccategoriescategory) | Yes | string | Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to 'AllMetrics' to collect all metrics. |
-
-### Parameter: `diagnosticSettings.metricCategories.category`
-
-Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to 'AllMetrics' to collect all metrics.
-
-- Required: Yes
-- Type: string
-
-
 ### Parameter: `diagnosticSettings.name`
 
-Optional. The name of diagnostic setting.
+The name of diagnostic setting.
 
 - Required: No
 - Type: string
 
 ### Parameter: `diagnosticSettings.storageAccountResourceId`
 
-Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
 
 - Required: No
 - Type: string
 
 ### Parameter: `diagnosticSettings.workspaceResourceId`
 
-Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
 
 - Required: No
 - Type: string
@@ -1245,6 +1230,7 @@ Optional. Resource ID of the diagnostic log analytics workspace. For security re
 ### Parameter: `enableDefaultTelemetry`
 
 Enable telemetry via a Globally Unique Identifier (GUID).
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1252,6 +1238,7 @@ Enable telemetry via a Globally Unique Identifier (GUID).
 ### Parameter: `enablePurgeProtection`
 
 Provide 'true' to enable Key Vault's purge protection feature.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1259,6 +1246,7 @@ Provide 'true' to enable Key Vault's purge protection feature.
 ### Parameter: `enableRbacAuthorization`
 
 Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be ignored. When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. Note that management actions are always authorized with RBAC.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1266,6 +1254,7 @@ Property that controls how data actions are authorized. When true, the key vault
 ### Parameter: `enableSoftDelete`
 
 Switch to enable/disable Key Vault's soft delete feature.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1273,6 +1262,7 @@ Switch to enable/disable Key Vault's soft delete feature.
 ### Parameter: `enableVaultForDeployment`
 
 Specifies if the vault is enabled for deployment by script or compute.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1280,6 +1270,7 @@ Specifies if the vault is enabled for deployment by script or compute.
 ### Parameter: `enableVaultForDiskEncryption`
 
 Specifies if the azure platform has access to the vault for enabling disk encryption scenarios.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1287,6 +1278,7 @@ Specifies if the azure platform has access to the vault for enabling disk encryp
 ### Parameter: `enableVaultForTemplateDeployment`
 
 Specifies if the vault is enabled for a template deployment.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -1294,6 +1286,7 @@ Specifies if the vault is enabled for a template deployment.
 ### Parameter: `keys`
 
 All keys to create.
+
 - Required: No
 - Type: array
 - Default: `[]`
@@ -1301,6 +1294,7 @@ All keys to create.
 ### Parameter: `location`
 
 Location for all resources.
+
 - Required: No
 - Type: string
 - Default: `[resourceGroup().location]`
@@ -1308,39 +1302,43 @@ Location for all resources.
 ### Parameter: `lock`
 
 The lock settings of the service.
+
 - Required: No
 - Type: object
 
+**Optional parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`kind`](#parameter-lockkind) | No | string | Optional. Specify the type of lock. |
-| [`name`](#parameter-lockname) | No | string | Optional. Specify the name of lock. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-lockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-lockname) | string | Specify the name of lock. |
 
 ### Parameter: `lock.kind`
 
-Optional. Specify the type of lock.
+Specify the type of lock.
 
 - Required: No
 - Type: string
-- Allowed: `[CanNotDelete, None, ReadOnly]`
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
 
 ### Parameter: `lock.name`
 
-Optional. Specify the name of lock.
+Specify the name of lock.
 
 - Required: No
-- Type: string
-
-### Parameter: `name`
-
-Name of the Key Vault. Must be globally unique.
-- Required: Yes
 - Type: string
 
 ### Parameter: `networkAcls`
 
 Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny.
+
 - Required: No
 - Type: object
 - Default: `{}`
@@ -1348,197 +1346,247 @@ Service endpoint object information. For security reasons, it is recommended to 
 ### Parameter: `privateEndpoints`
 
 Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.
+
 - Required: No
 - Type: array
 
+**Required parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`applicationSecurityGroupResourceIds`](#parameter-privateendpointsapplicationsecuritygroupresourceids) | No | array | Optional. Application security groups in which the private endpoint IP configuration is included. |
-| [`customDnsConfigs`](#parameter-privateendpointscustomdnsconfigs) | No | array | Optional. Custom DNS configurations. |
-| [`customNetworkInterfaceName`](#parameter-privateendpointscustomnetworkinterfacename) | No | string | Optional. The custom name of the network interface attached to the private endpoint. |
-| [`enableTelemetry`](#parameter-privateendpointsenabletelemetry) | No | bool | Optional. Enable/Disable usage telemetry for module. |
-| [`ipConfigurations`](#parameter-privateendpointsipconfigurations) | No | array | Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints. |
-| [`location`](#parameter-privateendpointslocation) | No | string | Optional. The location to deploy the private endpoint to. |
-| [`lock`](#parameter-privateendpointslock) | No | object | Optional. Specify the type of lock. |
-| [`manualPrivateLinkServiceConnections`](#parameter-privateendpointsmanualprivatelinkserviceconnections) | No | array | Optional. Manual PrivateLink Service Connections. |
-| [`name`](#parameter-privateendpointsname) | No | string | Optional. The name of the private endpoint. |
-| [`privateDnsZoneGroupName`](#parameter-privateendpointsprivatednszonegroupname) | No | string | Optional. The name of the private DNS zone group to create if privateDnsZoneResourceIds were provided. |
-| [`privateDnsZoneResourceIds`](#parameter-privateendpointsprivatednszoneresourceids) | No | array | Optional. The private DNS zone groups to associate the private endpoint with. A DNS zone group can support up to 5 DNS zones. |
-| [`roleAssignments`](#parameter-privateendpointsroleassignments) | No | array | Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
-| [`service`](#parameter-privateendpointsservice) | No | string | Optional. The service (sub-) type to deploy the private endpoint for. For example "vault" or "blob". |
-| [`subnetResourceId`](#parameter-privateendpointssubnetresourceid) | Yes | string | Required. Resource ID of the subnet where the endpoint needs to be created. |
-| [`tags`](#parameter-privateendpointstags) | No | object | Optional. Tags to be applied on all resources/resource groups in this deployment. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`subnetResourceId`](#parameter-privateendpointssubnetresourceid) | string | Resource ID of the subnet where the endpoint needs to be created. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`applicationSecurityGroupResourceIds`](#parameter-privateendpointsapplicationsecuritygroupresourceids) | array | Application security groups in which the private endpoint IP configuration is included. |
+| [`customDnsConfigs`](#parameter-privateendpointscustomdnsconfigs) | array | Custom DNS configurations. |
+| [`customNetworkInterfaceName`](#parameter-privateendpointscustomnetworkinterfacename) | string | The custom name of the network interface attached to the private endpoint. |
+| [`enableTelemetry`](#parameter-privateendpointsenabletelemetry) | bool | Enable/Disable usage telemetry for module. |
+| [`ipConfigurations`](#parameter-privateendpointsipconfigurations) | array | A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints. |
+| [`location`](#parameter-privateendpointslocation) | string | The location to deploy the private endpoint to. |
+| [`lock`](#parameter-privateendpointslock) | object | Specify the type of lock. |
+| [`manualPrivateLinkServiceConnections`](#parameter-privateendpointsmanualprivatelinkserviceconnections) | array | Manual PrivateLink Service Connections. |
+| [`name`](#parameter-privateendpointsname) | string | The name of the private endpoint. |
+| [`privateDnsZoneGroupName`](#parameter-privateendpointsprivatednszonegroupname) | string | The name of the private DNS zone group to create if privateDnsZoneResourceIds were provided. |
+| [`privateDnsZoneResourceIds`](#parameter-privateendpointsprivatednszoneresourceids) | array | The private DNS zone groups to associate the private endpoint with. A DNS zone group can support up to 5 DNS zones. |
+| [`roleAssignments`](#parameter-privateendpointsroleassignments) | array | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+| [`service`](#parameter-privateendpointsservice) | string | The service (sub-) type to deploy the private endpoint for. For example "vault" or "blob". |
+| [`tags`](#parameter-privateendpointstags) | object | Tags to be applied on all resources/resource groups in this deployment. |
+
+### Parameter: `privateEndpoints.subnetResourceId`
+
+Resource ID of the subnet where the endpoint needs to be created.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `privateEndpoints.applicationSecurityGroupResourceIds`
 
-Optional. Application security groups in which the private endpoint IP configuration is included.
+Application security groups in which the private endpoint IP configuration is included.
 
 - Required: No
 - Type: array
 
 ### Parameter: `privateEndpoints.customDnsConfigs`
 
-Optional. Custom DNS configurations.
+Custom DNS configurations.
 
 - Required: No
 - Type: array
-
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | No | string | Required. Fqdn that resolves to private endpoint ip address. |
-| [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | Yes | array | Required. A list of private ip addresses of the private endpoint. |
-
-### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
-
-Required. Fqdn that resolves to private endpoint ip address.
-
-- Required: No
-- Type: string
-
-### Parameter: `privateEndpoints.customDnsConfigs.ipAddresses`
-
-Required. A list of private ip addresses of the private endpoint.
-
-- Required: Yes
-- Type: array
-
 
 ### Parameter: `privateEndpoints.customNetworkInterfaceName`
 
-Optional. The custom name of the network interface attached to the private endpoint.
+The custom name of the network interface attached to the private endpoint.
 
 - Required: No
 - Type: string
 
 ### Parameter: `privateEndpoints.enableTelemetry`
 
-Optional. Enable/Disable usage telemetry for module.
+Enable/Disable usage telemetry for module.
 
 - Required: No
 - Type: bool
 
 ### Parameter: `privateEndpoints.ipConfigurations`
 
-Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.
+A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.
 
 - Required: No
 - Type: array
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`name`](#parameter-privateendpointsipconfigurationsname) | Yes | string | Required. The name of the resource that is unique within a resource group. |
-| [`properties`](#parameter-privateendpointsipconfigurationsproperties) | Yes | object | Required. Properties of private endpoint IP configurations. |
-
-### Parameter: `privateEndpoints.ipConfigurations.name`
-
-Required. The name of the resource that is unique within a resource group.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `privateEndpoints.ipConfigurations.properties`
-
-Required. Properties of private endpoint IP configurations.
-
-- Required: Yes
-- Type: object
-
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`groupId`](#parameter-privateendpointsipconfigurationspropertiesgroupid) | Yes | string | Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. |
-| [`memberName`](#parameter-privateendpointsipconfigurationspropertiesmembername) | Yes | string | Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. |
-| [`privateIPAddress`](#parameter-privateendpointsipconfigurationspropertiesprivateipaddress) | Yes | string | Required. A private ip address obtained from the private endpoint's subnet. |
-
-### Parameter: `privateEndpoints.ipConfigurations.properties.groupId`
-
-Required. The ID of a group obtained from the remote resource that this private endpoint should connect to.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `privateEndpoints.ipConfigurations.properties.memberName`
-
-Required. The member name of a group obtained from the remote resource that this private endpoint should connect to.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `privateEndpoints.ipConfigurations.properties.privateIPAddress`
-
-Required. A private ip address obtained from the private endpoint's subnet.
-
-- Required: Yes
-- Type: string
-
-
-
 ### Parameter: `privateEndpoints.location`
 
-Optional. The location to deploy the private endpoint to.
+The location to deploy the private endpoint to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `privateEndpoints.lock`
 
-Optional. Specify the type of lock.
+Specify the type of lock.
 
 - Required: No
 - Type: object
 
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-privateendpointslockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-privateendpointslockname) | string | Specify the name of lock. |
+
+### Parameter: `privateEndpoints.lock.kind`
+
+Specify the type of lock.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
+
+### Parameter: `privateEndpoints.lock.name`
+
+Specify the name of lock.
+
+- Required: No
+- Type: string
+
 ### Parameter: `privateEndpoints.manualPrivateLinkServiceConnections`
 
-Optional. Manual PrivateLink Service Connections.
+Manual PrivateLink Service Connections.
 
 - Required: No
 - Type: array
 
 ### Parameter: `privateEndpoints.name`
 
-Optional. The name of the private endpoint.
+The name of the private endpoint.
 
 - Required: No
 - Type: string
 
 ### Parameter: `privateEndpoints.privateDnsZoneGroupName`
 
-Optional. The name of the private DNS zone group to create if privateDnsZoneResourceIds were provided.
+The name of the private DNS zone group to create if privateDnsZoneResourceIds were provided.
 
 - Required: No
 - Type: string
 
 ### Parameter: `privateEndpoints.privateDnsZoneResourceIds`
 
-Optional. The private DNS zone groups to associate the private endpoint with. A DNS zone group can support up to 5 DNS zones.
+The private DNS zone groups to associate the private endpoint with. A DNS zone group can support up to 5 DNS zones.
 
 - Required: No
 - Type: array
 
 ### Parameter: `privateEndpoints.roleAssignments`
 
-Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
+Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
 
 - Required: No
 - Type: array
 
-### Parameter: `privateEndpoints.service`
+**Required parameters**
 
-Optional. The service (sub-) type to deploy the private endpoint for. For example "vault" or "blob".
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalId`](#parameter-privateendpointsroleassignmentsprincipalid) | string | The principal ID of the principal (user/group/identity) to assign the role to. |
+| [`roleDefinitionIdOrName`](#parameter-privateendpointsroleassignmentsroledefinitionidorname) | string | The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
 
-- Required: No
-- Type: string
+**Optional parameters**
 
-### Parameter: `privateEndpoints.subnetResourceId`
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`condition`](#parameter-privateendpointsroleassignmentscondition) | string | The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
+| [`conditionVersion`](#parameter-privateendpointsroleassignmentsconditionversion) | string | Version of the condition. |
+| [`delegatedManagedIdentityResourceId`](#parameter-privateendpointsroleassignmentsdelegatedmanagedidentityresourceid) | string | The Resource Id of the delegated managed identity resource. |
+| [`description`](#parameter-privateendpointsroleassignmentsdescription) | string | The description of the role assignment. |
+| [`principalType`](#parameter-privateendpointsroleassignmentsprincipaltype) | string | The principal type of the assigned principal ID. |
 
-Required. Resource ID of the subnet where the endpoint needs to be created.
+### Parameter: `privateEndpoints.roleAssignments.principalId`
+
+The principal ID of the principal (user/group/identity) to assign the role to.
 
 - Required: Yes
 - Type: string
 
+### Parameter: `privateEndpoints.roleAssignments.roleDefinitionIdOrName`
+
+The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `privateEndpoints.roleAssignments.condition`
+
+The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
+
+- Required: No
+- Type: string
+
+### Parameter: `privateEndpoints.roleAssignments.conditionVersion`
+
+Version of the condition.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
+
+### Parameter: `privateEndpoints.roleAssignments.delegatedManagedIdentityResourceId`
+
+The Resource Id of the delegated managed identity resource.
+
+- Required: No
+- Type: string
+
+### Parameter: `privateEndpoints.roleAssignments.description`
+
+The description of the role assignment.
+
+- Required: No
+- Type: string
+
+### Parameter: `privateEndpoints.roleAssignments.principalType`
+
+The principal type of the assigned principal ID.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Device'
+    'ForeignGroup'
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
+
+### Parameter: `privateEndpoints.service`
+
+The service (sub-) type to deploy the private endpoint for. For example "vault" or "blob".
+
+- Required: No
+- Type: string
+
 ### Parameter: `privateEndpoints.tags`
 
-Optional. Tags to be applied on all resources/resource groups in this deployment.
+Tags to be applied on all resources/resource groups in this deployment.
 
 - Required: No
 - Type: object
@@ -1546,6 +1594,7 @@ Optional. Tags to be applied on all resources/resource groups in this deployment
 ### Parameter: `publicNetworkAccess`
 
 Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.
+
 - Required: No
 - Type: string
 - Default: `''`
@@ -1561,74 +1610,96 @@ Whether or not public network access is allowed for this resource. For security 
 ### Parameter: `roleAssignments`
 
 Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
+
 - Required: No
 - Type: array
 
+**Required parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`condition`](#parameter-roleassignmentscondition) | No | string | Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
-| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | No | string | Optional. Version of the condition. |
-| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | No | string | Optional. The Resource Id of the delegated managed identity resource. |
-| [`description`](#parameter-roleassignmentsdescription) | No | string | Optional. The description of the role assignment. |
-| [`principalId`](#parameter-roleassignmentsprincipalid) | Yes | string | Required. The principal ID of the principal (user/group/identity) to assign the role to. |
-| [`principalType`](#parameter-roleassignmentsprincipaltype) | No | string | Optional. The principal type of the assigned principal ID. |
-| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | Yes | string | Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalId`](#parameter-roleassignmentsprincipalid) | string | The principal ID of the principal (user/group/identity) to assign the role to. |
+| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | string | The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`condition`](#parameter-roleassignmentscondition) | string | The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
+| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | string | Version of the condition. |
+| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | string | The Resource Id of the delegated managed identity resource. |
+| [`description`](#parameter-roleassignmentsdescription) | string | The description of the role assignment. |
+| [`principalType`](#parameter-roleassignmentsprincipaltype) | string | The principal type of the assigned principal ID. |
+
+### Parameter: `roleAssignments.principalId`
+
+The principal ID of the principal (user/group/identity) to assign the role to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `roleAssignments.roleDefinitionIdOrName`
+
+The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `roleAssignments.condition`
 
-Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
+The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.conditionVersion`
 
-Optional. Version of the condition.
+Version of the condition.
 
 - Required: No
 - Type: string
-- Allowed: `[2.0]`
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
 
 ### Parameter: `roleAssignments.delegatedManagedIdentityResourceId`
 
-Optional. The Resource Id of the delegated managed identity resource.
+The Resource Id of the delegated managed identity resource.
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.description`
 
-Optional. The description of the role assignment.
+The description of the role assignment.
 
 - Required: No
-- Type: string
-
-### Parameter: `roleAssignments.principalId`
-
-Required. The principal ID of the principal (user/group/identity) to assign the role to.
-
-- Required: Yes
 - Type: string
 
 ### Parameter: `roleAssignments.principalType`
 
-Optional. The principal type of the assigned principal ID.
+The principal type of the assigned principal ID.
 
 - Required: No
 - Type: string
-- Allowed: `[Device, ForeignGroup, Group, ServicePrincipal, User]`
-
-### Parameter: `roleAssignments.roleDefinitionIdOrName`
-
-Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
-
-- Required: Yes
-- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Device'
+    'ForeignGroup'
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
 
 ### Parameter: `secrets`
 
 All secrets to create.
+
 - Required: No
 - Type: secureObject
 - Default: `{}`
@@ -1636,6 +1707,7 @@ All secrets to create.
 ### Parameter: `softDeleteRetentionInDays`
 
 softDelete data retention days. It accepts >=7 and <=90.
+
 - Required: No
 - Type: int
 - Default: `90`
@@ -1643,12 +1715,14 @@ softDelete data retention days. It accepts >=7 and <=90.
 ### Parameter: `tags`
 
 Resource tags.
+
 - Required: No
 - Type: object
 
 ### Parameter: `vaultSku`
 
 Specifies the SKU for the vault.
+
 - Required: No
 - Type: string
 - Default: `'premium'`

--- a/modules/key-vault/vault/access-policy/README.md
+++ b/modules/key-vault/vault/access-policy/README.md
@@ -30,9 +30,17 @@ This module deploys a Key Vault Access Policy.
 | [`accessPolicies`](#parameter-accesspolicies) | array | An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID. |
 | [`enableDefaultTelemetry`](#parameter-enabledefaulttelemetry) | bool | Enable telemetry via a Globally Unique Identifier (GUID). |
 
+### Parameter: `keyVaultName`
+
+The name of the parent key vault. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
 ### Parameter: `accessPolicies`
 
 An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
+
 - Required: No
 - Type: array
 - Default: `[]`
@@ -40,15 +48,10 @@ An array of 0 to 16 identities that have access to the key vault. All identities
 ### Parameter: `enableDefaultTelemetry`
 
 Enable telemetry via a Globally Unique Identifier (GUID).
+
 - Required: No
 - Type: bool
 - Default: `True`
-
-### Parameter: `keyVaultName`
-
-The name of the parent key vault. Required if the template is used in a standalone deployment.
-- Required: Yes
-- Type: string
 
 
 ## Outputs

--- a/modules/key-vault/vault/key/README.md
+++ b/modules/key-vault/vault/key/README.md
@@ -47,9 +47,24 @@ This module deploys a Key Vault Key.
 | [`rotationPolicy`](#parameter-rotationpolicy) | object | Key rotation policy properties object. |
 | [`tags`](#parameter-tags) | object | Resource tags. |
 
+### Parameter: `name`
+
+The name of the key.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `keyVaultName`
+
+The name of the parent key vault. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
 ### Parameter: `attributesEnabled`
 
 Determines whether the object is enabled.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -57,6 +72,7 @@ Determines whether the object is enabled.
 ### Parameter: `attributesExp`
 
 Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible.
+
 - Required: No
 - Type: int
 - Default: `-1`
@@ -64,6 +80,7 @@ Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is r
 ### Parameter: `attributesNbf`
 
 Not before date in seconds since 1970-01-01T00:00:00Z.
+
 - Required: No
 - Type: int
 - Default: `-1`
@@ -71,6 +88,7 @@ Not before date in seconds since 1970-01-01T00:00:00Z.
 ### Parameter: `curveName`
 
 The elliptic curve name.
+
 - Required: No
 - Type: string
 - Default: `'P-256'`
@@ -87,6 +105,7 @@ The elliptic curve name.
 ### Parameter: `enableDefaultTelemetry`
 
 Enable telemetry via a Globally Unique Identifier (GUID).
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -94,6 +113,7 @@ Enable telemetry via a Globally Unique Identifier (GUID).
 ### Parameter: `keyOps`
 
 Array of JsonWebKeyOperation.
+
 - Required: No
 - Type: array
 - Default: `[]`
@@ -113,19 +133,15 @@ Array of JsonWebKeyOperation.
 ### Parameter: `keySize`
 
 The key size in bits. For example: 2048, 3072, or 4096 for RSA.
+
 - Required: No
 - Type: int
 - Default: `-1`
 
-### Parameter: `keyVaultName`
-
-The name of the parent key vault. Required if the template is used in a standalone deployment.
-- Required: Yes
-- Type: string
-
 ### Parameter: `kty`
 
 The type of the key.
+
 - Required: No
 - Type: string
 - Default: `'EC'`
@@ -139,83 +155,99 @@ The type of the key.
   ]
   ```
 
-### Parameter: `name`
-
-The name of the key.
-- Required: Yes
-- Type: string
-
 ### Parameter: `roleAssignments`
 
 Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
+
 - Required: No
 - Type: array
 
+**Required parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`condition`](#parameter-roleassignmentscondition) | No | string | Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
-| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | No | string | Optional. Version of the condition. |
-| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | No | string | Optional. The Resource Id of the delegated managed identity resource. |
-| [`description`](#parameter-roleassignmentsdescription) | No | string | Optional. The description of the role assignment. |
-| [`principalId`](#parameter-roleassignmentsprincipalid) | Yes | string | Required. The principal ID of the principal (user/group/identity) to assign the role to. |
-| [`principalType`](#parameter-roleassignmentsprincipaltype) | No | string | Optional. The principal type of the assigned principal ID. |
-| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | Yes | string | Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalId`](#parameter-roleassignmentsprincipalid) | string | The principal ID of the principal (user/group/identity) to assign the role to. |
+| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | string | The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`condition`](#parameter-roleassignmentscondition) | string | The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
+| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | string | Version of the condition. |
+| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | string | The Resource Id of the delegated managed identity resource. |
+| [`description`](#parameter-roleassignmentsdescription) | string | The description of the role assignment. |
+| [`principalType`](#parameter-roleassignmentsprincipaltype) | string | The principal type of the assigned principal ID. |
+
+### Parameter: `roleAssignments.principalId`
+
+The principal ID of the principal (user/group/identity) to assign the role to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `roleAssignments.roleDefinitionIdOrName`
+
+The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `roleAssignments.condition`
 
-Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
+The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.conditionVersion`
 
-Optional. Version of the condition.
+Version of the condition.
 
 - Required: No
 - Type: string
-- Allowed: `[2.0]`
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
 
 ### Parameter: `roleAssignments.delegatedManagedIdentityResourceId`
 
-Optional. The Resource Id of the delegated managed identity resource.
+The Resource Id of the delegated managed identity resource.
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.description`
 
-Optional. The description of the role assignment.
+The description of the role assignment.
 
 - Required: No
-- Type: string
-
-### Parameter: `roleAssignments.principalId`
-
-Required. The principal ID of the principal (user/group/identity) to assign the role to.
-
-- Required: Yes
 - Type: string
 
 ### Parameter: `roleAssignments.principalType`
 
-Optional. The principal type of the assigned principal ID.
+The principal type of the assigned principal ID.
 
 - Required: No
 - Type: string
-- Allowed: `[Device, ForeignGroup, Group, ServicePrincipal, User]`
-
-### Parameter: `roleAssignments.roleDefinitionIdOrName`
-
-Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
-
-- Required: Yes
-- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Device'
+    'ForeignGroup'
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
 
 ### Parameter: `rotationPolicy`
 
 Key rotation policy properties object.
+
 - Required: No
 - Type: object
 - Default: `{}`
@@ -223,6 +255,7 @@ Key rotation policy properties object.
 ### Parameter: `tags`
 
 Resource tags.
+
 - Required: No
 - Type: object
 

--- a/modules/key-vault/vault/secret/README.md
+++ b/modules/key-vault/vault/secret/README.md
@@ -43,9 +43,31 @@ This module deploys a Key Vault Secret.
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | [`tags`](#parameter-tags) | object | Resource tags. |
 
+### Parameter: `name`
+
+The name of the secret.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `value`
+
+The value of the secret. NOTE: "value" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.
+
+- Required: Yes
+- Type: securestring
+
+### Parameter: `keyVaultName`
+
+The name of the parent key vault. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
 ### Parameter: `attributesEnabled`
 
 Determines whether the object is enabled.
+
 - Required: No
 - Type: bool
 - Default: `True`
@@ -53,6 +75,7 @@ Determines whether the object is enabled.
 ### Parameter: `attributesExp`
 
 Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible.
+
 - Required: No
 - Type: int
 - Default: `-1`
@@ -60,6 +83,7 @@ Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is r
 ### Parameter: `attributesNbf`
 
 Not before date in seconds since 1970-01-01T00:00:00Z.
+
 - Required: No
 - Type: int
 - Default: `-1`
@@ -67,6 +91,7 @@ Not before date in seconds since 1970-01-01T00:00:00Z.
 ### Parameter: `contentType`
 
 The content type of the secret.
+
 - Required: No
 - Type: securestring
 - Default: `''`
@@ -74,101 +99,106 @@ The content type of the secret.
 ### Parameter: `enableDefaultTelemetry`
 
 Enable telemetry via a Globally Unique Identifier (GUID).
+
 - Required: No
 - Type: bool
 - Default: `True`
 
-### Parameter: `keyVaultName`
-
-The name of the parent key vault. Required if the template is used in a standalone deployment.
-- Required: Yes
-- Type: string
-
-### Parameter: `name`
-
-The name of the secret.
-- Required: Yes
-- Type: string
-
 ### Parameter: `roleAssignments`
 
 Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
+
 - Required: No
 - Type: array
 
+**Required parameters**
 
-| Name | Required | Type | Description |
-| :-- | :-- | :--| :-- |
-| [`condition`](#parameter-roleassignmentscondition) | No | string | Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
-| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | No | string | Optional. Version of the condition. |
-| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | No | string | Optional. The Resource Id of the delegated managed identity resource. |
-| [`description`](#parameter-roleassignmentsdescription) | No | string | Optional. The description of the role assignment. |
-| [`principalId`](#parameter-roleassignmentsprincipalid) | Yes | string | Required. The principal ID of the principal (user/group/identity) to assign the role to. |
-| [`principalType`](#parameter-roleassignmentsprincipaltype) | No | string | Optional. The principal type of the assigned principal ID. |
-| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | Yes | string | Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalId`](#parameter-roleassignmentsprincipalid) | string | The principal ID of the principal (user/group/identity) to assign the role to. |
+| [`roleDefinitionIdOrName`](#parameter-roleassignmentsroledefinitionidorname) | string | The name of the role to assign. If it cannot be found you can specify the role definition ID instead. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`condition`](#parameter-roleassignmentscondition) | string | The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container" |
+| [`conditionVersion`](#parameter-roleassignmentsconditionversion) | string | Version of the condition. |
+| [`delegatedManagedIdentityResourceId`](#parameter-roleassignmentsdelegatedmanagedidentityresourceid) | string | The Resource Id of the delegated managed identity resource. |
+| [`description`](#parameter-roleassignmentsdescription) | string | The description of the role assignment. |
+| [`principalType`](#parameter-roleassignmentsprincipaltype) | string | The principal type of the assigned principal ID. |
+
+### Parameter: `roleAssignments.principalId`
+
+The principal ID of the principal (user/group/identity) to assign the role to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `roleAssignments.roleDefinitionIdOrName`
+
+The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `roleAssignments.condition`
 
-Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
+The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container"
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.conditionVersion`
 
-Optional. Version of the condition.
+Version of the condition.
 
 - Required: No
 - Type: string
-- Allowed: `[2.0]`
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
 
 ### Parameter: `roleAssignments.delegatedManagedIdentityResourceId`
 
-Optional. The Resource Id of the delegated managed identity resource.
+The Resource Id of the delegated managed identity resource.
 
 - Required: No
 - Type: string
 
 ### Parameter: `roleAssignments.description`
 
-Optional. The description of the role assignment.
+The description of the role assignment.
 
 - Required: No
-- Type: string
-
-### Parameter: `roleAssignments.principalId`
-
-Required. The principal ID of the principal (user/group/identity) to assign the role to.
-
-- Required: Yes
 - Type: string
 
 ### Parameter: `roleAssignments.principalType`
 
-Optional. The principal type of the assigned principal ID.
+The principal type of the assigned principal ID.
 
 - Required: No
 - Type: string
-- Allowed: `[Device, ForeignGroup, Group, ServicePrincipal, User]`
-
-### Parameter: `roleAssignments.roleDefinitionIdOrName`
-
-Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead.
-
-- Required: Yes
-- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Device'
+    'ForeignGroup'
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
 
 ### Parameter: `tags`
 
 Resource tags.
+
 - Required: No
 - Type: object
-
-### Parameter: `value`
-
-The value of the secret. NOTE: "value" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.
-- Required: Yes
-- Type: securestring
 
 
 ## Outputs

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1181,6 +1181,17 @@ function Set-UsageExamplesSection {
     ############################
     ##   Process test files   ##
     ############################
+
+    # Prepare data (using thread-safe multithreading) to consume later
+    $buildTestFileMap = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
+    $testFilePaths | ForEach-Object -Parallel {
+        $folderName = Split-Path (Split-Path -Path $_) -Leaf
+        $buildTemplate = bicep build $_ --stdout | ConvertFrom-Json -AsHashtable
+
+        $dict = $using:buildTestFileMap
+        $null = $dict.TryAdd($folderName, $buildTemplate)
+    }
+
     $pathIndex = 1
     $usageExampleSectionHeaders = @()
     $testFilesContent = @()
@@ -1188,7 +1199,8 @@ function Set-UsageExamplesSection {
 
         # Read content
         $rawContentArray = Get-Content -Path $testFilePath
-        $compiledTestFileContent = bicep build $testFilePath --stdout | ConvertFrom-Json -AsHashtable
+        $folderName = Split-Path (Split-Path -Path $testFilePath) -Leaf
+        $compiledTestFileContent = $buildTestFileMap[$folderName]
         $rawContent = Get-Content -Path $testFilePath -Encoding 'utf8' | Out-String
 
         # Format example header

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -180,20 +180,79 @@ function Set-ParametersSection {
         [string[]] $ColumnsInOrder = @('Required', 'Conditional', 'Optional', 'Generated')
     )
 
-    # Collect sources for parameter usage section
-    $parameterUsageContentMap = @{}
-    if (Test-Path (Join-Path $PSScriptRoot 'moduleReadMeSource')) {
-        if ($resourceUsageSourceFiles = Get-ChildItem (Join-Path $PSScriptRoot 'moduleReadMeSource') -Recurse -Filter 'resourceUsage-*') {
-            foreach ($sourceFile in $resourceUsageSourceFiles.FullName) {
-                $parameterName = (Split-Path $sourceFile -LeafBase).Replace('resourceUsage-', '')
+    # Invoking recursive function to resolve parameters
+    $newSectionContent = Set-DefinitionSection -TemplateFileContent $TemplateFileContent -ColumnsInOrder $ColumnsInOrder
 
-                $parameterUsageContentMap[$parameterName] = Get-Content $sourceFile -Raw
-            }
-        }
+    # Build result
+    if ($PSCmdlet.ShouldProcess('Original file with new parameters content', 'Merge')) {
+        $updatedFileContent = Merge-FileWithNewContent -oldContent $ReadMeFileContent -newContent $newSectionContent -SectionStartIdentifier $SectionStartIdentifier -contentType 'nextH2'
     }
 
-    # Get all descriptions
-    $descriptions = $TemplateFileContent.parameters.Values.metadata.description
+    return $updatedFileContent
+}
+
+<#
+.SYNOPSIS
+Update parts of the 'parameters' section of the given readme file, if user defined types are used
+
+.DESCRIPTION
+Adds user defined types to the 'parameters' section of the given readme file
+
+.PARAMETER TemplateFileContent
+Mandatory. The template file content object to crawl data from
+
+.PARAMETER Properties
+Optional. Hashtable of the user defined properties
+
+.PARAMETER ParentName
+Optional. Name of the parameter, that has the user defined types
+
+.PARAMETER ParentIdentifierLink
+Optional. Link of the parameter, that has the user defined types
+
+.PARAMETER ColumnsInOrder
+Optional. The order of parameter categories to show in the readme parameters section.
+
+.EXAMPLE
+Set-DefinitionSection -TemplateFileContent @{ resource = @{}; ... } -ColumnsInOrder @('Required', 'Optional')
+
+Top-level invocation. Will start from the TemplateFile's parameters object and recursively crawl through all children. Tables will be ordered by 'Required' first and 'Optional' after.
+
+.EXAMPLE
+Set-DefinitionSection -TemplateFileContent @{ resource = @{}; ... } -Properties @{ @{ name = @{ type = 'string'; 'allowedValues' = @('A1','A2','A3','A4','A5','A6'); 'nullable' = $true; (...) } -ParentName 'diagnosticSettings' -ParentIdentifierLink '#parameter-diagnosticsettings'
+
+.NOTES
+The function is recursive and will also output grand, great grand children, ... .
+#>
+function Set-DefinitionSection {
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable] $TemplateFileContent,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable] $Properties,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ParentName,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ParentIdentifierLink,
+
+        [Parameter(Mandatory = $false)]
+        [string[]] $ColumnsInOrder = @('Required', 'Conditional', 'Optional', 'Generated')
+    )
+
+    if (-not $Properties) {
+        # Top-level invocation
+        # Get all descriptions
+        $descriptions = $TemplateFileContent.parameters.Values.metadata.description
+        # Add name as property for later reference
+        $TemplateFileContent.parameters.Keys | ForEach-Object { $TemplateFileContent.parameters[$_]['name'] = $_ }
+    } else {
+        $descriptions = $Properties.Values.metadata.description
+        # Add name as property for later reference
+        $Properties.Keys | ForEach-Object { $Properties[$_]['name'] = $_ }
+    }
 
     # Get the module parameter categories
     $paramCategories = $descriptions | ForEach-Object { $_.Split('.')[0] } | Select-Object -Unique
@@ -202,34 +261,66 @@ function Set-ParametersSection {
     $sortedParamCategories = $ColumnsInOrder | Where-Object { $paramCategories -contains $_ }
     # Add all others that exist but are not specified in the columnsInOrder parameter
     $sortedParamCategories += $paramCategories | Where-Object { $ColumnsInOrder -notcontains $_ }
-
-    # Add name as property for later reference
-    $TemplateFileContent.parameters.Keys | ForEach-Object { $TemplateFileContent.parameters[$_]['name'] = $_ }
-
     $newSectionContent = [System.Collections.ArrayList]@()
-    $parameterList = @{}
+    $tableSectionContent = [System.Collections.ArrayList]@()
+    $listSectionContent = [System.Collections.ArrayList]@()
 
-    # Create parameter blocks
     foreach ($category in $sortedParamCategories) {
 
         # 1. Prepare
         # Filter to relevant items
-        [array] $categoryParameters = $TemplateFileContent.parameters.Values | Where-Object { $_.metadata.description -like "$category. *" } | Sort-Object -Property 'Name' -Culture 'en-US'
+        if (-not $Properties) {
+            # Top-level invocation
+            [array] $categoryParameters = $TemplateFileContent.parameters.Values | Where-Object { $_.metadata.description -like "$category. *" } | Sort-Object -Property 'Name' -Culture 'en-US'
+        } else {
+            $categoryParameters = $Properties.Values | Where-Object { $_.metadata.description -like "$category. *" } | Sort-Object -Property 'Name' -Culture 'en-US'
+        }
 
-        # 2. Create header including optional columns & initiate the parameter list
-        $newSectionContent += @(
+        $tableSectionContent += @(
             ('**{0} parameters**' -f $category),
             '',
             '| Parameter | Type | Description |',
             '| :-- | :-- | :-- |'
         )
 
-        # 3. Add individual parameters
         foreach ($parameter in $categoryParameters) {
 
-            $isRequired = Get-IsParameterRequired -TemplateFileContent $TemplateFileContent -Parameter $parameter
+            ######################
+            #   Gather details   #
+            ######################
 
-            # Default values
+            $paramIdentifier = (-not [String]::IsNullOrEmpty($ParentName)) ? '{0}.{1}' -f $ParentName, $parameter.name : $parameter.name
+            $paramHeader = '### Parameter: `{0}`' -f $paramIdentifier
+            $paramIdentifierLink = (-not [String]::IsNullOrEmpty($ParentIdentifierLink)) ? ('{0}{1}' -f $ParentIdentifierLink, $parameter.name).ToLower() :  ('#{0}' -f $paramHeader.TrimStart('#').Trim().ToLower()) -replace '[:|`]' -replace ' ', '-'
+
+            # definition type (if any)
+            if ($parameter.Keys -contains '$ref') {
+                $identifier = Split-Path $parameter.'$ref' -Leaf
+                $definition = $TemplateFileContent.definitions[$identifier]
+                $type = $definition['type']
+                $rawAllowedValues = $definition['allowedValues']
+            } else {
+                $definition = $null
+                $type = $parameter.type
+                $rawAllowedValues = $parameter.allowedValues
+            }
+
+            $isRequired = (Get-IsParameterRequired -TemplateFileContent $TemplateFileContent -Parameter $parameter) ? 'Yes' : 'No'
+            $description = $parameter.ContainsKey('metadata') ? $parameter['metadata']['description'] : $null
+
+            #####################
+            #   Table content   #
+            #####################
+
+            # build table for definition properties
+            $tableSectionContent += ('| [`{0}`]({1}) | {2} | {3} |' -f $parameter.name, $paramIdentifierLink, $type, $description.substring("$category. ".Length))
+
+            ####################
+            #   List content   #
+            ####################
+
+            # Format default values
+            # =====================
             if ($parameter.defaultValue -is [array]) {
                 if ($parameter.defaultValue.count -eq 0) {
                     $defaultValue = '[]'
@@ -253,18 +344,23 @@ function Set-ParametersSection {
                 $defaultValue = $parameter.defaultValue
             }
 
-            # User defined type
-            if ($null -eq $parameter.type -and $parameter.ContainsKey('$ref')) {
-                $identifier = Split-Path $parameter.'$ref' -Leaf
-                $definition = $TemplateFileContent.definitions[$identifier]
-                $type = $definition['type']
-                $rawAllowedValues = $definition['allowedValues']
+            if (-not [String]::IsNullOrEmpty($defaultValue)) {
+                if (($defaultValue -split '\n').count -eq 1) {
+                    $formattedDefaultValue = '- Default: `{0}`' -f $defaultValue
+                } else {
+                    $formattedDefaultValue = @(
+                        '- Default:',
+                        '  ```Bicep',
+                ($defaultValue -split '\n' | ForEach-Object { "  $_" } | Out-String).TrimEnd(),
+                        '  ```'
+                    )
+                }
             } else {
-                $type = $parameter.type
-                $rawAllowedValues = $parameter.allowedValues
+                $formattedDefaultValue = $null
             }
 
-            # Allowed values
+            # Format allowed values
+            # =====================
             if ($rawAllowedValues -is [array]) {
                 $bicepJSONAllowedParameterObject = @{ $parameter.name = ($rawAllowedValues ?? @()) } # Wrapping on object to work with formatted Bicep script
                 $bicepRawformattedAllowed = ConvertTo-FormattedBicep -JSONParameters $bicepJSONAllowedParameterObject
@@ -278,37 +374,6 @@ function Set-ParametersSection {
                 $allowedValues = $rawAllowedValues
             }
 
-            # Prepare the links to local headers
-            $paramHeader = '### Parameter: `{0}`' -f $parameter.name
-            $paramIdentifier = ('#{0}' -f $paramHeader.TrimStart('#').Trim().ToLower()) -replace '[:|`]' -replace ' ', '-'
-
-            # Add external single quotes to all default values of type string except for those using functions
-            $description = $parameter.metadata.description.Replace("`r`n", '<p>').Replace("`n", '<p>')
-            # Further, replace all "empty string" default values with actual visible quotes
-            if ([regex]::Match($allowedValues, '^(\[\s*,.+)|(\[.+,\s*,)|(.+,\s*\])$').Captures.Count -gt 0) {
-                $allowedValues = $allowedValues -replace '\[\s*,', "[''," -replace ',\s*,', ", ''," -replace ',\s*\]', ", '']"
-            }
-
-            # Update parameter table content based on parameter category
-            ## Remove category from parameter description
-            $description = $description.substring("$category. ".Length)
-            $newSectionContent += ('| [`{0}`]({1}) | {2} | {3} |' -f $parameter.name, $paramIdentifier, $type, $description)
-
-            if (-not [String]::IsNullOrEmpty($defaultValue)) {
-                if (($defaultValue -split '\n').count -eq 1) {
-                    $formattedDefaultValue = '- Default: `{0}`' -f $defaultValue
-                } else {
-                    $formattedDefaultValue = @(
-                        '- Default:',
-                        '  ```Bicep',
-                    ($defaultValue -split '\n' | ForEach-Object { "  $_" } | Out-String).TrimEnd(),
-                        '  ```'
-                    )
-                }
-            } else {
-                $formattedDefaultValue = $null
-            }
-
             if (-not [String]::IsNullOrEmpty($allowedValues)) {
                 if (($allowedValues -split '\n').count -eq 1) {
                     $formattedAllowedValues = '- Default: `{0}`' -f $allowedValues
@@ -316,7 +381,7 @@ function Set-ParametersSection {
                     $formattedAllowedValues = @(
                         '- Allowed:',
                         '  ```Bicep',
-                    ($allowedValues -split '\n' | Where-Object { -not [String]::IsNullOrEmpty($_) } | ForEach-Object { "  $_" } | Out-String).TrimEnd(),
+                ($allowedValues -split '\n' | Where-Object { -not [String]::IsNullOrEmpty($_) } | ForEach-Object { "  $_" } | Out-String).TrimEnd(),
                         '  ```'
                     )
                 }
@@ -324,138 +389,42 @@ function Set-ParametersSection {
                 $formattedAllowedValues = $null
             }
 
-            $parameterList += @{
-                $paramIdentifier = @(
-                    $paramHeader,
-                    '',
-                    $description,
-                ('- Required: {0}' -f ($isRequired ? 'Yes' : 'No')),
-                ('- Type: {0}' -f $type),
-                ((-not [String]::IsNullOrEmpty($formattedDefaultValue)) ? $formattedDefaultValue : $null),
-                ((-not [String]::IsNullOrEmpty($formattedAllowedValues)) ? $formattedAllowedValues : $null),
-                    '',
-                (($parameterUsageContentMap.Keys -contains $parameter.name) ? $parameterUsageContentMap[$parameter.name] : $null)
-                ) | Where-Object { $null -ne $_ }
-            }
-
-            if (($parameter.Keys -contains '$ref') -or ($parameter.Keys -contains 'items' -and $parameter.items.Keys -contains '$ref')) {
-                # Has a user-defined type
-                $identifier = ($parameter.Keys -contains '$ref') ? (Split-Path $parameter.'$ref' -Leaf) : (Split-Path $parameter.items.'$ref' -Leaf)
-                $definition = $TemplateFileContent.definitions[$identifier]
-                $properties = ($definition.Keys -contains 'items' ? $definition['items']['properties'] : $definition['properties'])
-                $parameterList[$paramIdentifier] += Set-DefinitionSection -TemplateFileContent $TemplateFileContent -Properties $properties -ParentName $parameter.name -ParentIdentifierLink $paramIdentifier
-            }
-        }
-        $newSectionContent += ''
-    }
-
-    $sortedFlatParamList = [System.Collections.ArrayList]@()
-    foreach ($key in ($parameterList.Keys | Sort-Object)) {
-        $sortedFlatParamList += $parameterList[$key]
-    }
-    $newSectionContent += $sortedFlatParamList
-
-    # Build result
-    if ($PSCmdlet.ShouldProcess('Original file with new parameters content', 'Merge')) {
-        $updatedFileContent = Merge-FileWithNewContent -oldContent $ReadMeFileContent -newContent $newSectionContent -SectionStartIdentifier $SectionStartIdentifier -contentType 'nextH2'
-    }
-
-    return $updatedFileContent
-}
-
-<#
-.SYNOPSIS
-Update parts of the 'parameters' section of the given readme file, if user defined types are used
-
-.DESCRIPTION
-Adds user defined types to the 'parameters' section of the given readme file
-
-.PARAMETER TemplateFileContent
-Mandatory. The template file content object to crawl data from
-
-.PARAMETER Properties
-Mandatory. Hashtable of the user defined properties
-
-.PARAMETER ParentName
-Mandatory. Name of the parameter, that has the user defined types
-
-.PARAMETER ParentIdentifierLink
-Mandatory. Link of the parameter, that has the user defined types
-
-.EXAMPLE
-Set-DefinitionSection -TemplateFileContent @{ resource = @{}; ... } -Properties @{ resource = @{}; ... } -ParentName 'diagnosticSettings' -ParentIdentifierLink '#parameter-diagnosticsettings'
-
-.NOTES
-The function is recursive and will also output grand, great grand children, ... .
-#>
-function Set-DefinitionSection {
-    param (
-        [Parameter(Mandatory)]
-        [hashtable] $TemplateFileContent,
-
-        [Parameter(Mandatory)]
-        [hashtable] $Properties,
-
-        [Parameter(Mandatory)]
-        [string] $ParentName,
-
-        [Parameter(Mandatory)]
-        [string] $ParentIdentifierLink
-    )
-    $newSectionContent = @(
-        '',
-        '| Name | Required | Type | Description |',
-        '| :-- | :-- | :--| :-- |'
-    )
-    $tableSectionContent = [System.Collections.ArrayList]@()
-    $listSectionContent = [System.Collections.ArrayList]@()
-
-    foreach ($parameterName in $Properties.Keys | Sort-Object) {
-        $parameterValue = $Properties[$parameterName]
-        $paramIdentifier = '{0}.{1}' -f $ParentName, $parameterName
-        $paramIdentifierLink = ('{0}{1}' -f $ParentIdentifierLink, $parameterName).ToLower()
-
-        # definition type (if any)
-        if ($parameterValue.Keys -contains '$ref') {
-            $definition = $TemplateFileContent.definitions[(Split-Path $parameterValue.'$ref' -Leaf)]
-        } else {
-            $definition = $null
-        }
-
-        $isRequired = (Get-IsParameterRequired -TemplateFileContent $TemplateFileContent -Parameter $parameterValue) ? 'Yes' : 'No'
-        $type = ($parameterValue.Keys -contains '$ref') ? $definition.type : $parameterValue['type']
-        $description = $parameterValue.ContainsKey('metadata') ? $parameterValue['metadata']['description'] : $null
-
-        # build table for definition properties
-        $tableSectionContent += ('| [`{0}`]({1}) | {2} | {3} | {4} |' -f $parameterName, $paramIdentifierLink, $isRequired, $type, $description)
-        $allowedValues = ($parameterValue.ContainsKey('allowedValues')) ? (($parameterValue['allowedValues'] -is [array]) ? ('[{0}]' -f (($parameterValue['allowedValues'] | Sort-Object) -join ', ')) : (($parameterValue['allowedValues'] -is [hashtable]) ? '{object}' : $parameterValue['allowedValues'])) : $null
-
-        #build flat list for definition properties
-        $listSectionContent += @(
-            '',
-            ('### Parameter: `{0}`' -f $paramIdentifier),
-            ($parameterValue.ContainsKey('metadata') ? '' : $null),
-            ($parameterValue.ContainsKey('metadata') ? $parameterValue['metadata']['description'] : $null),
-            ($parameterValue.ContainsKey('metadata') ? '' : $null),
+            # Build list item
+            # ===============
+            $listSectionContent += @(
+                $paramHeader,
+            ($parameter.ContainsKey('metadata') ? '' : $null),
+            ($parameter.ContainsKey('metadata') ? $parameter['metadata']['description'].substring("$category. ".Length) : $null),
+            ($parameter.ContainsKey('metadata') ? '' : $null),
             ('- Required: {0}' -f $isRequired),
             ('- Type: {0}' -f $type),
-            (($null -ne $allowedValues) ? ('- Allowed: `{0}`' -f $allowedValues) : $null)
-        ) | Where-Object { $null -ne $_ }
+            ((-not [String]::IsNullOrEmpty($formattedDefaultValue)) ? $formattedDefaultValue : $null),
+            ((-not [String]::IsNullOrEmpty($formattedAllowedValues)) ? $formattedAllowedValues : $null)
+                ''
+            ) | Where-Object { $null -ne $_ }
 
-        #recursive call for children
-        if ($parameterValue.ContainsKey('items') -and $parameterValue['items'].ContainsKey('properties')) {
-            $childProperties = $parameterValue['items']['properties']
-            $listSectionContent += Set-DefinitionSection -TemplateFileContent $TemplateFileContent -Properties $childProperties -ParentName $paramIdentifier -ParentIdentifierLink $paramIdentifierLink
-        } elseif ($parameterValue.type -eq 'object' -and $parameterValue['properties']) {
-            $childProperties = $parameterValue['properties']
-            $listSectionContent += Set-DefinitionSection -TemplateFileContent $TemplateFileContent -Properties $childProperties -ParentName $paramIdentifier -ParentIdentifierLink $paramIdentifierLink
+            #recursive call for children
+            if ($definition) {
+                if ($definition.ContainsKey('items') -and $definition['items'].ContainsKey('properties')) {
+                    $childProperties = $definition['items']['properties']
+                    $sectionContent = Set-DefinitionSection -TemplateFileContent $TemplateFileContent -Properties $childProperties -ParentName $paramIdentifier -ParentIdentifierLink $paramIdentifierLink -ColumnsInOrder $ColumnsInOrder
+
+                    $listSectionContent += $sectionContent
+
+                } elseif ($definition.type -eq 'object' -and $definition['properties']) {
+                    $childProperties = $definition['properties']
+                    $sectionContent = Set-DefinitionSection -TemplateFileContent $TemplateFileContent -Properties $childProperties -ParentName $paramIdentifier -ParentIdentifierLink $paramIdentifierLink -ColumnsInOrder $ColumnsInOrder
+
+                    $listSectionContent += $sectionContent
+                }
+            }
         }
+
+        $tableSectionContent += ''
     }
 
     $newSectionContent += $tableSectionContent
     $newSectionContent += $listSectionContent
-    $newSectionContent += ''
-
     return $newSectionContent
 }
 

--- a/utilities/tools/Test-ModuleLocally.ps1
+++ b/utilities/tools/Test-ModuleLocally.ps1
@@ -34,7 +34,7 @@ Optional. A hashtable parameter that contains custom tokens to be replaced in th
 
 $TestModuleLocallyInput = @{
     TemplateFilePath           = 'C:\network\route-table\main.bicep'
-    ModuleTestFilePath          = 'C:\network\route-table\.test\parameters.json'
+    ModuleTestFilePath         = 'C:\network\route-table\.test\parameters.json'
     PesterTest                 = $false
     DeploymentTest             = $false
     ValidationTest             = $true


### PR DESCRIPTION
# Description

Base PRs
- https://github.com/Azure/bicep-registry-modules/pull/618
- https://github.com/Azure/bicep-registry-modules/pull/638

Changes
- Improved runtime of Set-ModuleReadMe utility by building all test files per modules using a thread each.
- Fixed bug regarding an incorrect formatting for allowed values in UDTs
  - Finally reworked the Parameter Script to be fully recursive
    > It will show several changes as both the top-level table and nested tables follow a common syntax (otherwise the recursion wouldn't work)


### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
