### PR TITLE
Added MOVED-TO-AVM.md for `db-for-postgre-sql/flexible-server` module

### DIFF
--- a/modules/db-for-postgre-sql/flexible-server/MOVED-TO-AVM.md
+++ b/modules/db-for-postgre-sql/flexible-server/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/db-for-postgre-sql/flexible-server/README.md
+++ b/modules/db-for-postgre-sql/flexible-server/README.md
@@ -1,5 +1,7 @@
 # DBforPostgreSQL Flexible Servers `[Microsoft.DBforPostgreSQL/flexibleServers]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a DBforPostgreSQL Flexible Server.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  `db-for-postgre-sql/flexible-server` module as it has been merged into AVM, see https://github.com/Azure/bicep-registry-modules/pull/664

This PR resolves #4305 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

