### PR TITLE
[Modules] Added azureMonitorProfile to allow us to enable the Prometheus collector

### DIFF
--- a/modules/container-service/managed-cluster/README.md
+++ b/modules/container-service/managed-cluster/README.md
@@ -145,6 +145,7 @@ module managedCluster 'br:bicep/modules/container-service.managed-cluster:1.0.0'
     ]
     diskEncryptionSetID: '<diskEncryptionSetID>'
     enableAzureDefender: true
+    enableAzureMonitorProfileMetrics: true
     enableDefaultTelemetry: '<enableDefaultTelemetry>'
     enableKeyvaultSecretsProvider: true
     enableOidcIssuerProfile: true
@@ -381,6 +382,9 @@ module managedCluster 'br:bicep/modules/container-service.managed-cluster:1.0.0'
       "value": "<diskEncryptionSetID>"
     },
     "enableAzureDefender": {
+      "value": true
+    },
+    "enableAzureMonitorProfileMetrics": {
       "value": true
     },
     "enableDefaultTelemetry": {
@@ -1228,6 +1232,7 @@ module managedCluster 'br:bicep/modules/container-service.managed-cluster:1.0.0'
 | [`dnsServiceIP`](#parameter-dnsserviceip) | string | Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr. |
 | [`dnsZoneResourceId`](#parameter-dnszoneresourceid) | string | Specifies the resource ID of connected DNS zone. It will be ignored if `webApplicationRoutingEnabled` is set to `false`. |
 | [`enableAzureDefender`](#parameter-enableazuredefender) | bool | Whether to enable Azure Defender. |
+| [`enableAzureMonitorProfileMetrics`](#parameter-enableazuremonitorprofilemetrics) | bool | Whether the metrics profile for the Azure Monitor managed service for Prometheus addon is enabled. |
 | [`enableDefaultTelemetry`](#parameter-enabledefaulttelemetry) | bool | Enable telemetry via a Globally Unique Identifier (GUID). |
 | [`enableDnsZoneContributorRoleAssignment`](#parameter-enablednszonecontributorroleassignment) | bool | Specifies whether assing the DNS zone contributor role to the cluster service principal. It will be ignored if `webApplicationRoutingEnabled` is set to `false` or `dnsZoneResourceId` not provided. |
 | [`enableKeyvaultSecretsProvider`](#parameter-enablekeyvaultsecretsprovider) | bool | Specifies whether the KeyvaultSecretsProvider add-on is enabled or not. |
@@ -1255,6 +1260,8 @@ module managedCluster 'br:bicep/modules/container-service.managed-cluster:1.0.0'
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. Only one type of identity is supported: system-assigned or user-assigned, but not both. |
 | [`managedOutboundIPCount`](#parameter-managedoutboundipcount) | int | Outbound IP Count for the Load balancer. |
+| [`metricAnnotationsAllowList`](#parameter-metricannotationsallowlist) | string | A comma-separated list of Kubernetes annotation keys. |
+| [`metricLabelsAllowlist`](#parameter-metriclabelsallowlist) | string | A comma-separated list of additional Kubernetes label keys. |
 | [`monitoringWorkspaceId`](#parameter-monitoringworkspaceid) | string | Resource ID of the monitoring log analytics workspace. |
 | [`networkDataplane`](#parameter-networkdataplane) | string | Network dataplane used in the Kubernetes cluster. Not compatible with kubenet network plugin. |
 | [`networkPlugin`](#parameter-networkplugin) | string | Specifies the network plugin used for building Kubernetes network. |
@@ -1800,6 +1807,14 @@ Whether to enable Azure Defender.
 - Type: bool
 - Default: `False`
 
+### Parameter: `enableAzureMonitorProfileMetrics`
+
+Whether the metrics profile for the Azure Monitor managed service for Prometheus addon is enabled.
+
+- Required: No
+- Type: bool
+- Default: `False`
+
 ### Parameter: `enableDefaultTelemetry`
 
 Enable telemetry via a Globally Unique Identifier (GUID).
@@ -2077,6 +2092,22 @@ Outbound IP Count for the Load balancer.
 - Required: No
 - Type: int
 - Default: `0`
+
+### Parameter: `metricAnnotationsAllowList`
+
+A comma-separated list of Kubernetes annotation keys.
+
+- Required: No
+- Type: string
+- Default: `''`
+
+### Parameter: `metricLabelsAllowlist`
+
+A comma-separated list of additional Kubernetes label keys.
+
+- Required: No
+- Type: string
+- Default: `''`
 
 ### Parameter: `monitoringWorkspaceId`
 

--- a/modules/container-service/managed-cluster/main.bicep
+++ b/modules/container-service/managed-cluster/main.bicep
@@ -351,6 +351,15 @@ param identityProfile object = {}
 @description('Optional. The customer managed key definition.')
 param customerManagedKey customerManagedKeyType
 
+@description('Optional. Whether the metrics profile for the Azure Monitor managed service for Prometheus addon is enabled.')
+param enableAzureMonitorProfileMetrics bool = false
+
+@description('Optional. A comma-separated list of additional Kubernetes label keys.')
+param metricLabelsAllowlist string = ''
+
+@description('Optional. A comma-separated list of Kubernetes annotation keys.')
+param metricAnnotationsAllowList string = ''
+
 resource cMKKeyVault 'Microsoft.KeyVault/vaults@2023-02-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
   name: last(split((customerManagedKey.?keyVaultResourceId ?? 'dummyVault'), '/'))
   scope: resourceGroup(split((customerManagedKey.?keyVaultResourceId ?? '//'), '/')[2], split((customerManagedKey.?keyVaultResourceId ?? '////'), '/')[4])
@@ -543,6 +552,15 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2023-07-02-p
       enablePrivateCluster: enablePrivateCluster
       enablePrivateClusterPublicFQDN: enablePrivateClusterPublicFQDN
       privateDNSZone: privateDNSZone
+    }
+    azureMonitorProfile: {
+      metrics: enableAzureMonitorProfileMetrics ? {
+        enabled: true
+        kubeStateMetrics: {
+          metricAnnotationsAllowList: metricAnnotationsAllowList
+          metricLabelsAllowlist: metricLabelsAllowlist
+        }
+      } : null
     }
     podIdentityProfile: {
       allowNetworkPluginKubenet: podIdentityProfileAllowNetworkPluginKubenet

--- a/modules/container-service/managed-cluster/main.json
+++ b/modules/container-service/managed-cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "8572950365871080651"
+      "templateHash": "609013537229775592"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Clusters",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster.",
@@ -979,6 +979,27 @@
       "metadata": {
         "description": "Optional. The customer managed key definition."
       }
+    },
+    "enableAzureMonitorProfileMetrics": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Whether the metrics profile for the Azure Monitor managed service for Prometheus addon is enabled."
+      }
+    },
+    "metricLabelsAllowlist": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. A comma-separated list of additional Kubernetes label keys."
+      }
+    },
+    "metricAnnotationsAllowList": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. A comma-separated list of Kubernetes annotation keys."
+      }
     }
   },
   "variables": {
@@ -1170,6 +1191,9 @@
           "enablePrivateCluster": "[parameters('enablePrivateCluster')]",
           "enablePrivateClusterPublicFQDN": "[parameters('enablePrivateClusterPublicFQDN')]",
           "privateDNSZone": "[parameters('privateDNSZone')]"
+        },
+        "azureMonitorProfile": {
+          "metrics": "[if(parameters('enableAzureMonitorProfileMetrics'), createObject('enabled', true(), 'kubeStateMetrics', createObject('metricAnnotationsAllowList', parameters('metricAnnotationsAllowList'), 'metricLabelsAllowlist', parameters('metricLabelsAllowlist'))), null())]"
         },
         "podIdentityProfile": {
           "allowNetworkPluginKubenet": "[parameters('podIdentityProfileAllowNetworkPluginKubenet')]",

--- a/modules/container-service/managed-cluster/tests/e2e/azure/main.test.bicep
+++ b/modules/container-service/managed-cluster/tests/e2e/azure/main.test.bicep
@@ -189,6 +189,7 @@ module testDeployment '../../../main.bicep' = {
     enableAzureDefender: true
     enableKeyvaultSecretsProvider: true
     enablePodSecurityPolicy: false
+    enableAzureMonitorProfileMetrics: true
     customerManagedKey: {
       keyName: nestedDependencies.outputs.keyVaultEncryptionKeyName
       keyVaultNetworkAccess: 'Public'


### PR DESCRIPTION
Based on #4329 
cc: @aadev1, @JPEasier

AVM ref: https://github.com/Azure/bicep-registry-modules/pull/665

# Description
Added azureMonitorProfile to allow us to enable the Prometheus collector and kube state metrics for prometheus addon profile for the container service cluster

Update azure/main.test.bicep and example in readme to test enabling Prometheus collector

This change will allow enabling the Prometheus collector and kube state metrics for prometheus addon profile for the container service cluster by adding the settings required to theazureMonitorProfile as per the 'Microsoft.ContainerService/managedClusters' documentation. See link below:

https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/2023-07-02-preview/managedclusters?pivots=deployment-language-bicep#managedclusterazuremonitorprofilemetrics

| Pipeline |
| - |
| [![ContainerService - ManagedClusters](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml/badge.svg?branch=users%2Falsehr%2FmanagedClusterMetricProfile)](https://github.com/Azure/ResourceModules/actions/workflows/ms.containerservice.managedclusters.yml) |

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
