### PR TITLE
Added MOVED-TO-AVM.md for `network/public-ip-prefix` module

### DIFF
--- a/modules/network/public-ip-prefix/MOVED-TO-AVM.md
+++ b/modules/network/public-ip-prefix/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/network/public-ip-prefix/README.md
+++ b/modules/network/public-ip-prefix/README.md
@@ -1,5 +1,7 @@
 # Public IP Prefixes `[Microsoft.Network/publicIPPrefixes]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Public IP Prefix.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  `network/public-ip-prefix` module as it has been merged into AVM, see https://github.com/Azure/bicep-registry-modules/pull/690

This PR resolves #4323 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

