### PR TITLE
[Fixes] Ported fixed implemented in AVM to reenabled static test issues

### DIFF
--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1155,7 +1155,7 @@ function Set-UsageExamplesSection {
     $buildTestFileMap = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
     $testFilePaths | ForEach-Object -Parallel {
         $folderName = Split-Path (Split-Path -Path $_) -Leaf
-        $buildTemplate = bicep build $_ --stdout | ConvertFrom-Json -AsHashtable
+        $buildTemplate = (bicep build $_ --stdout 2>$null) | ConvertFrom-Json -AsHashtable
 
         $dict = $using:buildTestFileMap
         $null = $dict.TryAdd($folderName, $buildTemplate)

--- a/utilities/pipelines/staticValidation/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/module.tests.ps1
@@ -48,7 +48,7 @@ foreach ($moduleFolderPath in $moduleFolderPaths) {
 $builtTestFileMap = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
 $pathsToBuild | ForEach-Object -Parallel {
     $dict = $using:builtTestFileMap
-    $builtTemplate = bicep build $_ --stdout | ConvertFrom-Json -AsHashtable
+    $builtTemplate = (bicep build $_ --stdout 2>$null) | ConvertFrom-Json -AsHashtable
     $null = $dict.TryAdd($_, $builtTemplate)
 }
 


### PR DESCRIPTION
## Description

Fixed issue where Bicep build output would cause Foreach-Parallel to fail. This unblocks
- `operational-insights/workspace`
- `compute/virtual-machine`

Ref: https://github.com/Azure/bicep/issues/12653

| Pipeline |
| - |
| [![avm.res.operational-insights.workspace](https://github.com/AlexanderSehr/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Falsehr%2FthreadingTest_2)](https://github.com/AlexanderSehr/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |