### PR TITLE
Added MOVED-TO-AVM.md for three modules

### DIFF
--- a/modules/insights/activity-log-alert/MOVED-TO-AVM.md
+++ b/modules/insights/activity-log-alert/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/insights/activity-log-alert/README.md
+++ b/modules/insights/activity-log-alert/README.md
@@ -1,5 +1,7 @@
 # Activity Log Alerts `[Microsoft.Insights/activityLogAlerts]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Activity Log Alert.
 
 ## Navigation

--- a/modules/insights/metric-alert/MOVED-TO-AVM.md
+++ b/modules/insights/metric-alert/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/insights/metric-alert/README.md
+++ b/modules/insights/metric-alert/README.md
@@ -1,5 +1,7 @@
 # Metric Alerts `[Microsoft.Insights/metricAlerts]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Metric Alert.
 
 ## Navigation

--- a/modules/insights/scheduled-query-rule/MOVED-TO-AVM.md
+++ b/modules/insights/scheduled-query-rule/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/insights/scheduled-query-rule/README.md
+++ b/modules/insights/scheduled-query-rule/README.md
@@ -1,5 +1,7 @@
 # Scheduled Query Rules `[Microsoft.Insights/scheduledQueryRules]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Scheduled Query Rule.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  three modules:
- `insights/activity-log-alert`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/708
  - resolves #4344 
- `insights/metric-alert`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/711
  - resolves #4343 
- `insights/scheduled-query-rule`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/712
  - resolves #4345 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

