### PR TITLE
Added MOVED-TO-AVM.md for the recently migrated modules

### DIFF
--- a/modules/api-management/service/MOVED-TO-AVM.md
+++ b/modules/api-management/service/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/api-management/service/README.md
+++ b/modules/api-management/service/README.md
@@ -1,5 +1,7 @@
 # API Management Services `[Microsoft.ApiManagement/service]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an API Management Service.
 
 ## Navigation

--- a/modules/data-factory/factory/MOVED-TO-AVM.md
+++ b/modules/data-factory/factory/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/data-factory/factory/README.md
+++ b/modules/data-factory/factory/README.md
@@ -1,5 +1,7 @@
 # Data Factories `[Microsoft.DataFactory/factories]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Data Factory.
 
 ## Navigation

--- a/modules/insights/webtest/MOVED-TO-AVM.md
+++ b/modules/insights/webtest/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/insights/webtest/README.md
+++ b/modules/insights/webtest/README.md
@@ -1,5 +1,7 @@
 # Web Tests `[Microsoft.Insights/webtests]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Web Test.
 
 ## Navigation

--- a/modules/maintenance/maintenance-configuration/MOVED-TO-AVM.md
+++ b/modules/maintenance/maintenance-configuration/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/maintenance/maintenance-configuration/README.md
+++ b/modules/maintenance/maintenance-configuration/README.md
@@ -1,5 +1,7 @@
 # Maintenance Configurations `[Microsoft.Maintenance/maintenanceConfigurations]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Maintenance Configuration.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `api-management/service`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/713
  - resolves #4355 
- `data-factory/factory`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/730
  - resolves #4376 
- `insights/webtest`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/728
  - resolves #4377
- `maintenance/maintenance-configuration`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/729
  - resolves #4378 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

