### PR TITLE
Fix `winrm` listeners data type

### DIFF
--- a/constructs/Compute/virtualMachinesMultiple/main.bicep
+++ b/constructs/Compute/virtualMachinesMultiple/main.bicep
@@ -285,7 +285,7 @@ param timeZone string = ''
 param additionalUnattendContent array = []
 
 @description('Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.')
-param winRM object = {}
+param winRM array = {}
 
 @description('Optional. Any VM configuration profile assignments.')
 param configurationProfileAssignments string = ''

--- a/modules/compute/virtual-machine-scale-set/README.md
+++ b/modules/compute/virtual-machine-scale-set/README.md
@@ -1284,7 +1284,7 @@ module virtualMachineScaleSet 'br:bicep/modules/compute.virtual-machine-scale-se
 | [`vmNamePrefix`](#parameter-vmnameprefix) | string | Specifies the computer name prefix for all of the virtual machines in the scale set. |
 | [`vmPriority`](#parameter-vmpriority) | string | Specifies the priority for the virtual machine. |
 | [`vTpmEnabled`](#parameter-vtpmenabled) | bool | Specifies whether vTPM should be enabled on the virtual machine scale set. This parameter is part of the UefiSettings.  SecurityType should be set to TrustedLaunch to enable UefiSettings. |
-| [`winRM`](#parameter-winrm) | object | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object. |
+| [`winRM`](#parameter-winrm) | array | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object. |
 | [`zoneBalance`](#parameter-zonebalance) | bool | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. |
 
 **Generated parameters**
@@ -2102,8 +2102,8 @@ Specifies whether vTPM should be enabled on the virtual machine scale set. This 
 Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.
 
 - Required: No
-- Type: object
-- Default: `{}`
+- Type: array
+- Default: `[]`
 
 ### Parameter: `zoneBalance`
 

--- a/modules/compute/virtual-machine-scale-set/main.bicep
+++ b/modules/compute/virtual-machine-scale-set/main.bicep
@@ -190,7 +190,7 @@ param timeZone string = ''
 param additionalUnattendContent array = []
 
 @description('Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.')
-param winRM object = {}
+param winRM array = []
 
 @description('Optional. Specifies whether password authentication should be disabled.')
 #disable-next-line secure-secrets-in-params // Not a secret

--- a/modules/compute/virtual-machine-scale-set/main.json
+++ b/modules/compute/virtual-machine-scale-set/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "6314533557974797448"
+      "version": "0.24.24.22086",
+      "templateHash": "14263499970126484312"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set.",
@@ -587,8 +587,8 @@
       }
     },
     "winRM": {
-      "type": "object",
-      "defaultValue": {},
+      "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object."
       }
@@ -1030,8 +1030,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -1216,8 +1216,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -1407,8 +1407,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -1589,8 +1589,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -1770,8 +1770,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -1955,8 +1955,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -2146,8 +2146,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",
@@ -2332,8 +2332,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7901509432352717969"
+              "version": "0.24.24.22086",
+              "templateHash": "11750050808770259539"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension.",

--- a/modules/compute/virtual-machine/README.md
+++ b/modules/compute/virtual-machine/README.md
@@ -2031,7 +2031,7 @@ module virtualMachine 'br:bicep/modules/compute.virtual-machine:1.0.0' = {
 | [`timeZone`](#parameter-timezone) | string | Specifies the time zone of the virtual machine. e.g. 'Pacific Standard Time'. Possible values can be `TimeZoneInfo.id` value from time zones returned by `TimeZoneInfo.GetSystemTimeZones`. |
 | [`ultraSSDEnabled`](#parameter-ultrassdenabled) | bool | The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled. |
 | [`vTpmEnabled`](#parameter-vtpmenabled) | bool | Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  SecurityType should be set to TrustedLaunch to enable UefiSettings. |
-| [`winRM`](#parameter-winrm) | object | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object. |
+| [`winRM`](#parameter-winrm) | array | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object. |
 
 **Generated parameters**
 
@@ -2757,8 +2757,8 @@ Specifies whether vTPM should be enabled on the virtual machine. This parameter 
 Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.
 
 - Required: No
-- Type: object
-- Default: `{}`
+- Type: array
+- Default: `[]`
 
 ### Parameter: `baseTime`
 

--- a/modules/compute/virtual-machine/main.bicep
+++ b/modules/compute/virtual-machine/main.bicep
@@ -245,7 +245,7 @@ param timeZone string = ''
 param additionalUnattendContent array = []
 
 @description('Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.')
-param winRM object = {}
+param winRM array = []
 
 @description('Required. The configuration profile of automanage.')
 @allowed([

--- a/modules/compute/virtual-machine/main.json
+++ b/modules/compute/virtual-machine/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "89939038941992549"
+      "version": "0.24.24.22086",
+      "templateHash": "7283140726016531733"
     },
     "name": "Virtual Machines",
     "description": "This module deploys a Virtual Machine with one or multiple NICs and optionally one or multiple public IPs.",
@@ -704,8 +704,8 @@
       }
     },
     "winRM": {
-      "type": "object",
-      "defaultValue": {},
+      "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object."
       }
@@ -1000,8 +1000,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "11123708724712871468"
+              "version": "0.24.24.22086",
+              "templateHash": "8409177324826913650"
             }
           },
           "definitions": {
@@ -1304,8 +1304,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15536304828480480757"
+                      "version": "0.24.24.22086",
+                      "templateHash": "11463500650113068679"
                     },
                     "name": "Public IP Addresses",
                     "description": "This module deploys a Public IP Address.",
@@ -1849,8 +1849,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "2750011165297287068"
+                      "version": "0.24.24.22086",
+                      "templateHash": "2212030554483009866"
                     },
                     "name": "Network Interface",
                     "description": "This module deploys a Network Interface.",
@@ -2344,8 +2344,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -2571,8 +2571,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -2793,8 +2793,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -3020,8 +3020,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -3238,8 +3238,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -3455,8 +3455,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -3676,8 +3676,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -3905,8 +3905,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -4127,8 +4127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "5421737065579119324"
+              "version": "0.24.24.22086",
+              "templateHash": "3950506887759942356"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension.",
@@ -4348,8 +4348,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "9921011786088905122"
+              "version": "0.24.24.22086",
+              "templateHash": "9748368160737147237"
             },
             "name": "Recovery Service Vaults Protection Container Protected Item",
             "description": "This module deploys a Recovery Services Vault Protection Container Protected Item.",


### PR DESCRIPTION
# Description

winRM is passed to listeners, which is an array and not an object. I was not able to perform set-module on the virtual machine construct, that template is broken.


### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Update to documentation

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [X] I did format my code
