### PR TITLE
[Fixes] Ensure that VirtualMachineImages are removed before MSIs are removed as there's otherwise a high chance for a lock

### DIFF
--- a/modules/virtual-machine-images/image-template/main.json
+++ b/modules/virtual-machine-images/image-template/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "10277577540639461484"
+      "version": "0.24.24.22086",
+      "templateHash": "3206365221053341077"
     },
     "name": "Virtual Machine Image Templates",
     "description": "This module deploys a Virtual Machine Image Template that can be consumed by Azure Image Builder (AIB).",

--- a/modules/virtual-machine-images/image-template/tests/e2e/max/dependencies.bicep
+++ b/modules/virtual-machine-images/image-template/tests/e2e/max/dependencies.bicep
@@ -18,6 +18,16 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
   location: location
 }
 
+// required for the Azure Image Builder service to assign the list of User Assigned Identities to the Build VM.
+resource msi_managedIdentityOperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'ManagedIdentityContributor', managedIdentity.id)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830') // Managed Identity Operator
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 var addressPrefix = '10.0.0.0/16'
 
 resource gallery 'Microsoft.Compute/galleries@2022-03-03' = {

--- a/modules/virtual-machine-images/image-template/tests/e2e/max/main.test.bicep
+++ b/modules/virtual-machine-images/image-template/tests/e2e/max/main.test.bicep
@@ -51,16 +51,6 @@ module nestedDependencies 'dependencies.bicep' = {
   }
 }
 
-// required for the Azure Image Builder service to assign the list of User Assigned Identities to the Build VM.
-resource msi_managedIdentityOperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, 'ManagedIdentityContributor', '${namePrefix}')
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830') // Managed Identity Operator
-    principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
 // ============== //
 // Test Execution //
 // ============== //

--- a/modules/virtual-machine-images/image-template/tests/e2e/waf-aligned/dependencies.bicep
+++ b/modules/virtual-machine-images/image-template/tests/e2e/waf-aligned/dependencies.bicep
@@ -18,6 +18,16 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
   location: location
 }
 
+// required for the Azure Image Builder service to assign the list of User Assigned Identities to the Build VM.
+resource msi_managedIdentityOperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'ManagedIdentityContributor', managedIdentity.id)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830') // Managed Identity Operator
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 var addressPrefix = '10.0.0.0/16'
 
 resource gallery 'Microsoft.Compute/galleries@2022-03-03' = {
@@ -85,9 +95,6 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityResourceId string = managedIdentity.id
-
-@description('The principal ID of the created Managed Identity.')
-output managedIdentityPrincipalId string = managedIdentity.properties.principalId
 
 @description('The name of the created Managed Identity.')
 output managedIdentityName string = managedIdentity.name

--- a/modules/virtual-machine-images/image-template/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/virtual-machine-images/image-template/tests/e2e/waf-aligned/main.test.bicep
@@ -51,16 +51,6 @@ module nestedDependencies 'dependencies.bicep' = {
   }
 }
 
-// required for the Azure Image Builder service to assign the list of User Assigned Identities to the Build VM.
-resource msi_managedIdentityOperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, 'ManagedIdentityContributor', '${namePrefix}')
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830') // Managed Identity Operator
-    principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
 // ============== //
 // Test Execution //
 // ============== //

--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -78,7 +78,7 @@ function Initialize-DeploymentRemoval {
             'Microsoft.MachineLearningServices/workspaces',
             'Microsoft.Resources/resourceGroups',
             'Microsoft.Compute/virtualMachines',
-            'Microsoft.ManagedIdentity/userAssignedIdentities'
+            'Microsoft.VirtualMachineImages/imageTemplates'
         )
 
         Write-Verbose ('Handling resource removal with deployment names [{0}]' -f ($deploymentNames -join ', ')) -Verbose

--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -77,7 +77,8 @@ function Initialize-DeploymentRemoval {
             'Microsoft.Sql/managedInstances',
             'Microsoft.MachineLearningServices/workspaces',
             'Microsoft.Resources/resourceGroups',
-            'Microsoft.Compute/virtualMachines'
+            'Microsoft.Compute/virtualMachines',
+            'Microsoft.ManagedIdentity/userAssignedIdentities'
         )
 
         Write-Verbose ('Handling resource removal with deployment names [{0}]' -f ($deploymentNames -join ', ')) -Verbose

--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -78,7 +78,8 @@ function Initialize-DeploymentRemoval {
             'Microsoft.MachineLearningServices/workspaces',
             'Microsoft.Resources/resourceGroups',
             'Microsoft.Compute/virtualMachines',
-            'Microsoft.VirtualMachineImages/imageTemplates'
+            'Microsoft.VirtualMachineImages/imageTemplates',
+            'Microsoft.ManagedIdentity/userAssignedIdentities'
         )
 
         Write-Verbose ('Handling resource removal with deployment names [{0}]' -f ($deploymentNames -join ', ')) -Verbose

--- a/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/utilities/pipelines/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -76,10 +76,10 @@ function Initialize-DeploymentRemoval {
             'Microsoft.Authorization/policyDefinitions'
             'Microsoft.Sql/managedInstances',
             'Microsoft.MachineLearningServices/workspaces',
-            'Microsoft.Resources/resourceGroups',
             'Microsoft.Compute/virtualMachines',
-            'Microsoft.VirtualMachineImages/imageTemplates',
-            'Microsoft.ManagedIdentity/userAssignedIdentities'
+            'Microsoft.VirtualMachineImages/imageTemplates', # Must be removed before their MSI
+            'Microsoft.ManagedIdentity/userAssignedIdentities',
+            'Microsoft.Resources/resourceGroups'
         )
 
         Write-Verbose ('Handling resource removal with deployment names [{0}]' -f ($deploymentNames -join ', ')) -Verbose


### PR DESCRIPTION
# Description

Ensure that VirtualMachineImages are removed before MSIs are removed as there's otherwise a high chance for a lock. -> The resource cannot be removed anymore until an MSI is re-assigned.

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![VirtualMachineImages - ImageTemplates](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml/badge.svg?branch=users%2Falsehr%2FimageRemovalFix)](https://github.com/Azure/ResourceModules/actions/workflows/ms.virtualmachineimages.imagetemplates.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
