### PR TITLE
Added MOVED-TO-AVM.md for the recently migrated modules

### DIFF
--- a/modules/compute/disk-encryption-set/MOVED-TO-AVM.md
+++ b/modules/compute/disk-encryption-set/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/compute/disk-encryption-set/README.md
+++ b/modules/compute/disk-encryption-set/README.md
@@ -1,5 +1,7 @@
 # Disk Encryption Sets `[Microsoft.Compute/diskEncryptionSets]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Disk Encryption Set.
 
 ## Navigation

--- a/modules/compute/gallery/MOVED-TO-AVM.md
+++ b/modules/compute/gallery/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/compute/gallery/README.md
+++ b/modules/compute/gallery/README.md
@@ -1,5 +1,7 @@
 # Azure Compute Galleries `[Microsoft.Compute/galleries]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `compute/disk-encryption-set`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/749
  - resolves #4425  
- `compute/gallery`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/752
  - resolves #4422 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

