### PR TITLE
Added MOVED-TO-AVM.md for the recently migrated modules

### DIFF
--- a/modules/network/firewall-policy/MOVED-TO-AVM.md
+++ b/modules/network/firewall-policy/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/network/firewall-policy/README.md
+++ b/modules/network/firewall-policy/README.md
@@ -1,5 +1,7 @@
 # Firewall Policies `[Microsoft.Network/firewallPolicies]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Firewall Policy.
 
 ## Navigation

--- a/modules/network/front-door-web-application-firewall-policy/MOVED-TO-AVM.md
+++ b/modules/network/front-door-web-application-firewall-policy/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/network/front-door-web-application-firewall-policy/README.md
+++ b/modules/network/front-door-web-application-firewall-policy/README.md
@@ -1,5 +1,7 @@
 # Front Door Web Application Firewall (WAF) Policies `[Microsoft.Network/FrontDoorWebApplicationFirewallPolicies]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Front Door Web Application Firewall (WAF) Policy.
 
 ## Navigation

--- a/modules/network/front-door/MOVED-TO-AVM.md
+++ b/modules/network/front-door/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/network/front-door/README.md
+++ b/modules/network/front-door/README.md
@@ -1,5 +1,7 @@
 # Azure Front Doors `[Microsoft.Network/frontDoors]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Azure Front Door.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `network/firewall-policy`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/767
  - resolves #4432 
- `network/front-door`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/769
  - resolves #4433 
- `network/front-door-web-application-firewall-policy`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/772
  - resolves #4434 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

