### PR TITLE
Migrate container-service/managed-cluster to AVM specs

### DIFF
--- a/modules/container-service/managed-cluster/MOVED-TO-AVM.md
+++ b/modules/container-service/managed-cluster/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/container-service/managed-cluster/README.md
+++ b/modules/container-service/managed-cluster/README.md
@@ -1,5 +1,7 @@
 # Azure Kubernetes Service (AKS) Managed Clusters `[Microsoft.ContainerService/managedClusters]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Azure Kubernetes Service (AKS) Managed Cluster.
 
 ## Navigation

--- a/modules/container-service/managed-cluster/main.json
+++ b/modules/container-service/managed-cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "1414107545361983559"
+      "version": "0.24.24.22086",
+      "templateHash": "17801986788893514191"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Clusters",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster.",
@@ -1375,8 +1375,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "13811832596066396545"
+              "version": "0.24.24.22086",
+              "templateHash": "13894804167062746913"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
             "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool.",
@@ -1827,8 +1827,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "548642834195454661"
+              "version": "0.24.24.22086",
+              "templateHash": "3622584380025042085"
             },
             "name": "Kubernetes Configuration Extensions",
             "description": "This module deploys a Kubernetes Configuration Extension.",
@@ -1990,8 +1990,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "10031296768791737313"
+                      "version": "0.24.24.22086",
+                      "templateHash": "8976867865582545635"
                     },
                     "name": "Kubernetes Configuration Flux Configurations",
                     "description": "This module deploys a Kubernetes Configuration Flux Configuration.",


### PR DESCRIPTION
# Description

Issue: #4194
PR on bicep regestry: https://github.com/Azure/bicep-registry-modules/pull/665

This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
