### PR TITLE
[Utilities] Ported updated reference resolution from AVM

### DIFF
--- a/modules/analysis-services/server/README.md
+++ b/modules/analysis-services/server/README.md
@@ -1,8 +1,8 @@
 # Analysis Services Servers `[Microsoft.AnalysisServices/servers]`
 
-This module deploys an Analysis Services Server.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys an Analysis Services Server.
 
 ## Navigation
 

--- a/modules/cache/redis/README.md
+++ b/modules/cache/redis/README.md
@@ -1,8 +1,8 @@
 # Redis Cache `[Microsoft.Cache/redis]`
 
-This module deploys a Redis Cache.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a Redis Cache.
 
 ## Navigation
 

--- a/modules/compute/disk/README.md
+++ b/modules/compute/disk/README.md
@@ -1,8 +1,8 @@
 # Compute Disks `[Microsoft.Compute/disks]`
 
-This module deploys a Compute Disk.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a Compute Disk
 
 ## Navigation
 

--- a/modules/compute/image/README.md
+++ b/modules/compute/image/README.md
@@ -1,8 +1,8 @@
 # Images `[Microsoft.Compute/images]`
 
-This module deploys a Compute Image.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a Compute Image.
 
 ## Navigation
 

--- a/modules/consumption/budget/README.md
+++ b/modules/consumption/budget/README.md
@@ -1,8 +1,8 @@
 # Consumption Budgets `[Microsoft.Consumption/budgets]`
 
-This module deploys a Consumption Budget for Subscriptions.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a Consumption Budget for Subscriptions.
 
 ## Navigation
 

--- a/modules/data-protection/backup-vault/README.md
+++ b/modules/data-protection/backup-vault/README.md
@@ -1,8 +1,8 @@
 # Data Protection Backup Vaults `[Microsoft.DataProtection/backupVaults]`
 
-This module deploys a Data Protection Backup Vault.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a Data Protection Backup Vault.
 
 ## Navigation
 

--- a/modules/databricks/access-connector/README.md
+++ b/modules/databricks/access-connector/README.md
@@ -1,8 +1,8 @@
 # Azure Databricks Access Connectors `[Microsoft.Databricks/accessConnectors]`
 
-This module deploys an Azure Databricks Access Connector.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys an Azure Databricks Access Connector.
 
 ## Navigation
 

--- a/modules/databricks/workspace/README.md
+++ b/modules/databricks/workspace/README.md
@@ -1,8 +1,8 @@
 # Azure Databricks Workspaces `[Microsoft.Databricks/workspaces]`
 
-This module deploys an Azure Databricks Workspace.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys an Azure Databricks Workspace.
 
 ## Navigation
 

--- a/modules/db-for-my-sql/flexible-server/README.md
+++ b/modules/db-for-my-sql/flexible-server/README.md
@@ -1,8 +1,8 @@
 # DBforMySQL Flexible Servers `[Microsoft.DBforMySQL/flexibleServers]`
 
-This module deploys a DBforMySQL Flexible Server.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys a DBforMySQL Flexible Server.
 
 ## Navigation
 

--- a/modules/health-bot/health-bot/README.md
+++ b/modules/health-bot/health-bot/README.md
@@ -1,8 +1,8 @@
 # Azure Health Bots `[Microsoft.HealthBot/healthBots]`
 
-This module deploys an Azure Health Bot.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys an Azure Health Bot.
 
 ## Navigation
 

--- a/modules/net-app/net-app-account/README.md
+++ b/modules/net-app/net-app-account/README.md
@@ -1,8 +1,8 @@
 # Azure NetApp Files `[Microsoft.NetApp/netAppAccounts]`
 
-This module deploys an Azure NetApp File.
-
 > This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
+This module deploys an Azure NetApp File.
 
 ## Navigation
 

--- a/utilities/tools/Get-CrossReferencedModuleList.ps1
+++ b/utilities/tools/Get-CrossReferencedModuleList.ps1
@@ -156,7 +156,11 @@ function Get-CrossReferencedModuleList {
     $resultSet = [ordered]@{}
 
     # Collect data
-    $moduleTemplatePaths = (Get-ChildItem -Path $path -Recurse -File -Filter 'main.bicep').FullName
+    $moduleTemplatePaths = (Get-ChildItem -Path $path -Recurse -File -Filter '*.bicep').FullName | Where-Object {
+        # No files in the [/utilities/tools/] folder and none in the [/tests/] folder
+        $_ -notmatch '.*[\\|\/]tools[\\|\/].*|.*[\\|\/]tests[\\|\/].*'
+    } | Sort-Object
+
     $templateMap = @{}
     foreach ($moduleTemplatePath in $moduleTemplatePaths) {
         $templateMap[$moduleTemplatePath] = Get-Content -Path $moduleTemplatePath


### PR DESCRIPTION
# Description

- Ported updated reference resolution from AVM: Fixed resolution of local file references ignoring files not named `main.bicep`
- Updated READMEs 
> **Note:** Led to no direct updates as the issue did not occur in CARML through local references. However, some readme's got fixed

Original PR: https://github.com/Azure/bicep-registry-modules/pull/766