### PR TITLE
[Fixes] Event Hub Namespace : Updated behavior of NetworkRuleSet

### DIFF
--- a/modules/event-hub/namespace/README.md
+++ b/modules/event-hub/namespace/README.md
@@ -319,6 +319,7 @@ module namespace 'br:bicep/modules/event-hub.namespace:1.0.0' = {
           ipMask: '10.10.10.10'
         }
       ]
+      publicNetworkAccess: 'Disabled'
       trustedServiceAccessEnabled: false
       virtualNetworkRules: [
         {
@@ -530,6 +531,7 @@ module namespace 'br:bicep/modules/event-hub.namespace:1.0.0' = {
             "ipMask": "10.10.10.10"
           }
         ],
+        "publicNetworkAccess": "Disabled",
         "trustedServiceAccessEnabled": false,
         "virtualNetworkRules": [
           {

--- a/modules/event-hub/namespace/authorization-rule/main.json
+++ b/modules/event-hub/namespace/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "7668723234672576868"
+      "version": "0.24.24.22086",
+      "templateHash": "3454130656900257881"
     },
     "name": "Event Hub Namespace Authorization Rule",
     "description": "This module deploys an Event Hub Namespace Authorization Rule.",

--- a/modules/event-hub/namespace/disaster-recovery-config/main.json
+++ b/modules/event-hub/namespace/disaster-recovery-config/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "7231520764645220131"
+      "version": "0.24.24.22086",
+      "templateHash": "16561098614039073875"
     },
     "name": "Event Hub Namespace Disaster Recovery Configs",
     "description": "This module deploys an Event Hub Namespace Disaster Recovery Config.",

--- a/modules/event-hub/namespace/eventhub/authorization-rule/main.json
+++ b/modules/event-hub/namespace/eventhub/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "4935957739850887741"
+      "version": "0.24.24.22086",
+      "templateHash": "14602222687176746114"
     },
     "name": "Event Hub Namespace Event Hub Authorization Rules",
     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",

--- a/modules/event-hub/namespace/eventhub/consumergroup/main.json
+++ b/modules/event-hub/namespace/eventhub/consumergroup/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "7142673381100704232"
+      "version": "0.24.24.22086",
+      "templateHash": "1238713274798294217"
     },
     "name": "Event Hub Namespace Event Hub Consumer Groups",
     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",

--- a/modules/event-hub/namespace/eventhub/main.json
+++ b/modules/event-hub/namespace/eventhub/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "8940174354642715236"
+      "version": "0.24.24.22086",
+      "templateHash": "3029831252290713160"
     },
     "name": "Event Hub Namespace Event Hubs",
     "description": "This module deploys an Event Hub Namespace Event Hub.",
@@ -441,8 +441,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7142673381100704232"
+              "version": "0.24.24.22086",
+              "templateHash": "1238713274798294217"
             },
             "name": "Event Hub Namespace Event Hub Consumer Groups",
             "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",
@@ -569,8 +569,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "4935957739850887741"
+              "version": "0.24.24.22086",
+              "templateHash": "14602222687176746114"
             },
             "name": "Event Hub Namespace Event Hub Authorization Rules",
             "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",

--- a/modules/event-hub/namespace/main.bicep
+++ b/modules/event-hub/namespace/main.bicep
@@ -250,7 +250,7 @@ module eventHubNamespace_networkRuleSet 'network-rule-set/main.bicep' = if (!emp
     namespaceName: eventHubNamespace.name
     publicNetworkAccess: contains(networkRuleSets, 'publicNetworkAccess') ? networkRuleSets.publicNetworkAccess : (!empty(privateEndpoints) && empty(networkRuleSets) ? 'Disabled' : 'Enabled')
     defaultAction: contains(networkRuleSets, 'defaultAction') ? networkRuleSets.defaultAction : 'Allow'
-    trustedServiceAccessEnabled: contains(networkRuleSets, 'trustedServiceAccessEnabled') ? networkRuleSets.trustedServiceAccessEnabled : true
+    trustedServiceAccessEnabled: networkRuleSets.?trustedServiceAccessEnabled
     ipRules: contains(networkRuleSets, 'ipRules') ? networkRuleSets.ipRules : []
     virtualNetworkRules: contains(networkRuleSets, 'virtualNetworkRules') ? networkRuleSets.virtualNetworkRules : []
     enableDefaultTelemetry: enableReferencedModulesTelemetry

--- a/modules/event-hub/namespace/main.json
+++ b/modules/event-hub/namespace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "16593644436338874715"
+      "version": "0.24.24.22086",
+      "templateHash": "16520792819194375091"
     },
     "name": "Event Hub Namespaces",
     "description": "This module deploys an Event Hub Namespace.",
@@ -812,8 +812,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7668723234672576868"
+              "version": "0.24.24.22086",
+              "templateHash": "3454130656900257881"
             },
             "name": "Event Hub Namespace Authorization Rule",
             "description": "This module deploys an Event Hub Namespace Authorization Rule.",
@@ -933,8 +933,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7231520764645220131"
+              "version": "0.24.24.22086",
+              "templateHash": "16561098614039073875"
             },
             "name": "Event Hub Namespace Disaster Recovery Configs",
             "description": "This module deploys an Event Hub Namespace Disaster Recovery Config.",
@@ -1073,8 +1073,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "8940174354642715236"
+              "version": "0.24.24.22086",
+              "templateHash": "3029831252290713160"
             },
             "name": "Event Hub Namespace Event Hubs",
             "description": "This module deploys an Event Hub Namespace Event Hub.",
@@ -1509,8 +1509,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "7142673381100704232"
+                      "version": "0.24.24.22086",
+                      "templateHash": "1238713274798294217"
                     },
                     "name": "Event Hub Namespace Event Hub Consumer Groups",
                     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",
@@ -1637,8 +1637,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "4935957739850887741"
+                      "version": "0.24.24.22086",
+                      "templateHash": "14602222687176746114"
                     },
                     "name": "Event Hub Namespace Event Hub Authorization Rules",
                     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",
@@ -1789,7 +1789,9 @@
           },
           "publicNetworkAccess": "[if(contains(parameters('networkRuleSets'), 'publicNetworkAccess'), createObject('value', parameters('networkRuleSets').publicNetworkAccess), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkRuleSets'))), createObject('value', 'Disabled'), createObject('value', 'Enabled')))]",
           "defaultAction": "[if(contains(parameters('networkRuleSets'), 'defaultAction'), createObject('value', parameters('networkRuleSets').defaultAction), createObject('value', 'Allow'))]",
-          "trustedServiceAccessEnabled": "[if(contains(parameters('networkRuleSets'), 'trustedServiceAccessEnabled'), createObject('value', parameters('networkRuleSets').trustedServiceAccessEnabled), createObject('value', true()))]",
+          "trustedServiceAccessEnabled": {
+            "value": "[tryGet(parameters('networkRuleSets'), 'trustedServiceAccessEnabled')]"
+          },
           "ipRules": "[if(contains(parameters('networkRuleSets'), 'ipRules'), createObject('value', parameters('networkRuleSets').ipRules), createObject('value', createArray()))]",
           "virtualNetworkRules": "[if(contains(parameters('networkRuleSets'), 'virtualNetworkRules'), createObject('value', parameters('networkRuleSets').virtualNetworkRules), createObject('value', createArray()))]",
           "enableDefaultTelemetry": {
@@ -1802,8 +1804,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7843391232136950856"
+              "version": "0.24.24.22086",
+              "templateHash": "7604418407731554463"
             },
             "name": "Event Hub Namespace Network Rule Sets",
             "description": "This module deploys an Event Hub Namespace Network Rule Set.",
@@ -1842,7 +1844,7 @@
               "type": "bool",
               "defaultValue": true,
               "metadata": {
-                "description": "Optional. Value that indicates whether Trusted Service Access is enabled or not. Default is \"true\". It will not be set if publicNetworkAccess is \"Disabled\"."
+                "description": "Optional. Value that indicates whether Trusted Service Access is enabled or not."
               }
             },
             "virtualNetworkRules": {
@@ -1901,7 +1903,7 @@
               "properties": {
                 "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
                 "defaultAction": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), if(or(not(empty(parameters('ipRules'))), not(empty(parameters('virtualNetworkRules')))), 'Deny', parameters('defaultAction')))]",
-                "trustedServiceAccessEnabled": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), parameters('trustedServiceAccessEnabled'))]",
+                "trustedServiceAccessEnabled": "[parameters('trustedServiceAccessEnabled')]",
                 "ipRules": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), parameters('ipRules'))]",
                 "virtualNetworkRules": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), variables('networkRules'))]"
               }
@@ -2008,8 +2010,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "6873008238043407177"
+              "version": "0.24.24.22086",
+              "templateHash": "11154909986774213690"
             },
             "name": "Private Endpoints",
             "description": "This module deploys a Private Endpoint.",
@@ -2411,8 +2413,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "17578977753131828304"
+                      "version": "0.24.24.22086",
+                      "templateHash": "6129461321051281170"
                     },
                     "name": "Private Endpoint Private DNS Zone Groups",
                     "description": "This module deploys a Private Endpoint Private DNS Zone Group.",

--- a/modules/event-hub/namespace/network-rule-set/README.md
+++ b/modules/event-hub/namespace/network-rule-set/README.md
@@ -31,7 +31,7 @@ This module deploys an Event Hub Namespace Network Rule Set.
 | [`enableDefaultTelemetry`](#parameter-enabledefaulttelemetry) | bool | Enable telemetry via a Globally Unique Identifier (GUID). |
 | [`ipRules`](#parameter-iprules) | array | An array of objects for the public IP ranges you want to allow via the Event Hub Namespace firewall. Supports IPv4 address or CIDR. It will not be set if publicNetworkAccess is "Disabled". Otherwise, when used, defaultAction will be set to "Deny". |
 | [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | This determines if traffic is allowed over public network. Default is "Enabled". If set to "Disabled", traffic to this namespace will be restricted over Private Endpoints only and network rules will not be applied. |
-| [`trustedServiceAccessEnabled`](#parameter-trustedserviceaccessenabled) | bool | Value that indicates whether Trusted Service Access is enabled or not. Default is "true". It will not be set if publicNetworkAccess is "Disabled". |
+| [`trustedServiceAccessEnabled`](#parameter-trustedserviceaccessenabled) | bool | Value that indicates whether Trusted Service Access is enabled or not. |
 | [`virtualNetworkRules`](#parameter-virtualnetworkrules) | array | An array of subnet resource ID objects that this Event Hub Namespace is exposed to via Service Endpoints. You can enable the `ignoreMissingVnetServiceEndpoint` if you wish to add this virtual network to Event Hub Namespace but do not have an existing service endpoint. It will not be set if publicNetworkAccess is "Disabled". Otherwise, when used, defaultAction will be set to "Deny". |
 
 ### Parameter: `namespaceName`
@@ -89,7 +89,7 @@ This determines if traffic is allowed over public network. Default is "Enabled".
 
 ### Parameter: `trustedServiceAccessEnabled`
 
-Value that indicates whether Trusted Service Access is enabled or not. Default is "true". It will not be set if publicNetworkAccess is "Disabled".
+Value that indicates whether Trusted Service Access is enabled or not.
 
 - Required: No
 - Type: bool

--- a/modules/event-hub/namespace/network-rule-set/main.bicep
+++ b/modules/event-hub/namespace/network-rule-set/main.bicep
@@ -19,7 +19,7 @@ param publicNetworkAccess string = 'Enabled'
 @description('Optional. Default Action for Network Rule Set. Default is "Allow". It will not be set if publicNetworkAccess is "Disabled". Otherwise, it will be set to "Deny" if ipRules or virtualNetworkRules are being used.')
 param defaultAction string = 'Allow'
 
-@description('Optional. Value that indicates whether Trusted Service Access is enabled or not. Default is "true". It will not be set if publicNetworkAccess is "Disabled".')
+@description('Optional. Value that indicates whether Trusted Service Access is enabled or not.')
 param trustedServiceAccessEnabled bool = true
 
 @description('Optional. An array of subnet resource ID objects that this Event Hub Namespace is exposed to via Service Endpoints. You can enable the `ignoreMissingVnetServiceEndpoint` if you wish to add this virtual network to Event Hub Namespace but do not have an existing service endpoint. It will not be set if publicNetworkAccess is "Disabled". Otherwise, when used, defaultAction will be set to "Deny".')
@@ -60,7 +60,7 @@ resource networkRuleSet 'Microsoft.EventHub/namespaces/networkRuleSets@2022-10-0
   properties: {
     publicNetworkAccess: publicNetworkAccess
     defaultAction: publicNetworkAccess == 'Disabled' ? null : (!empty(ipRules) || !empty(virtualNetworkRules) ? 'Deny' : defaultAction)
-    trustedServiceAccessEnabled: publicNetworkAccess == 'Disabled' ? null : trustedServiceAccessEnabled
+    trustedServiceAccessEnabled: trustedServiceAccessEnabled
     ipRules: publicNetworkAccess == 'Disabled' ? null : ipRules
     virtualNetworkRules: publicNetworkAccess == 'Disabled' ? null : networkRules
   }

--- a/modules/event-hub/namespace/network-rule-set/main.json
+++ b/modules/event-hub/namespace/network-rule-set/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "7843391232136950856"
+      "version": "0.24.24.22086",
+      "templateHash": "7604418407731554463"
     },
     "name": "Event Hub Namespace Network Rule Sets",
     "description": "This module deploys an Event Hub Namespace Network Rule Set.",
@@ -44,7 +44,7 @@
       "type": "bool",
       "defaultValue": true,
       "metadata": {
-        "description": "Optional. Value that indicates whether Trusted Service Access is enabled or not. Default is \"true\". It will not be set if publicNetworkAccess is \"Disabled\"."
+        "description": "Optional. Value that indicates whether Trusted Service Access is enabled or not."
       }
     },
     "virtualNetworkRules": {
@@ -103,7 +103,7 @@
       "properties": {
         "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
         "defaultAction": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), if(or(not(empty(parameters('ipRules'))), not(empty(parameters('virtualNetworkRules')))), 'Deny', parameters('defaultAction')))]",
-        "trustedServiceAccessEnabled": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), parameters('trustedServiceAccessEnabled'))]",
+        "trustedServiceAccessEnabled": "[parameters('trustedServiceAccessEnabled')]",
         "ipRules": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), parameters('ipRules'))]",
         "virtualNetworkRules": "[if(equals(parameters('publicNetworkAccess'), 'Disabled'), null(), variables('networkRules'))]"
       }

--- a/modules/event-hub/namespace/tests/e2e/max/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/max/main.test.bicep
@@ -179,6 +179,7 @@ module testDeployment '../../../main.bicep' = {
         }
       ]
       trustedServiceAccessEnabled: false
+      publicNetworkAccess: 'Disabled'
       virtualNetworkRules: [
         {
           ignoreMissingVnetServiceEndpoint: true


### PR DESCRIPTION
# Description

- As per linked issue, updated behavior of NetworkRuleSet
- Instead of making any assumptions on behalf of the user, the value now simply defaults to true (which is the expected behavior (unless explicitely specified differently)

### Pipeline references
<!-- For module/pipeline changes, please create and attach the status badge of your successful run. -->

| Pipeline |
| - |
| [![EventHub - Namespaces](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml/badge.svg?branch=users%2Falsehr%2F4452_networkRuleSet&event=workflow_dispatch)](https://github.com/Azure/ResourceModules/actions/workflows/ms.eventhub.namespaces.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
