### PR TITLE
Added MOVED-TO-AVM for `management/management-group`

### DIFF
--- a/modules/management/management-group/MOVED-TO-AVM.md
+++ b/modules/management/management-group/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/management/management-group/README.md
+++ b/modules/management/management-group/README.md
@@ -1,5 +1,7 @@
 # Management Groups `[Microsoft.Management/managementGroups]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This template will prepare the management group structure based on the provided parameter.
 
 This module has some known **limitations**:


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `management/management-group`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1002
  - resolves #4496 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

