### PR TITLE
[Modules] Aligned NamePrefix with AVM

### DIFF
--- a/docs/wiki/The CI environment - Token replacement.md
+++ b/docs/wiki/The CI environment - Token replacement.md
@@ -52,14 +52,14 @@ Let's say you'd want to use this token inside a Key Vault module test file, to d
 ```json
 "parameters": {
     "name": {
-        "value": "[[tokenA]]-keyVault-[[tokenB]]"
+        "value": "#_tokenA_#-keyVault-#_tokenB_#"
     }
 }
 ```
 
 Once the Key Vault is deployed, you'll notice that the Key Vault name in Azure will be `foo-keyVault-bar`
 
-The token prefix `'[['` and suffix `']]'` in the above example are also configurable in the [settings.yml](https://github.com/Azure/ResourceModules/blob/main/settings.yml) file and are used to identify the tokens in the files.
+The token prefix `'#_'` and suffix `'_#'` in the above example are also configurable in the [settings.yml](https://github.com/Azure/ResourceModules/blob/main/settings.yml) file and are used to identify the tokens in the files.
 
 The solution comes with one predefined local token `namePrefix`. This token is leveraged in most of the parameter & test files for deployments. It allows using a consistent naming prefix that is applied to all resources being tested. There are two ways this token can be set and one will take precedence over the other:
 

--- a/modules/aad/domain-service/tests/e2e/max/main.test.bicep
+++ b/modules/aad/domain-service/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'aaddsmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/aad/domain-service/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/aad/domain-service/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'aaddswaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app-configuration/configuration-store/tests/e2e/defaults/main.test.bicep
+++ b/modules/app-configuration/configuration-store/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'accmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app-configuration/configuration-store/tests/e2e/encr/main.test.bicep
+++ b/modules/app-configuration/configuration-store/tests/e2e/encr/main.test.bicep
@@ -21,7 +21,7 @@ param enableDefaultTelemetry bool = true
 param baseTime string = utcNow('u')
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app-configuration/configuration-store/tests/e2e/max/main.test.bicep
+++ b/modules/app-configuration/configuration-store/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'accmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app-configuration/configuration-store/tests/e2e/pe/main.test.bicep
+++ b/modules/app-configuration/configuration-store/tests/e2e/pe/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'accpe'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app-configuration/configuration-store/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/app-configuration/configuration-store/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'accwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/app/job/tests/e2e/defaults/main.test.bicep
+++ b/modules/app/job/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ajmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/app/job/tests/e2e/max/main.test.bicep
+++ b/modules/app/job/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ajmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/app/job/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/app/job/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ajwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/authorization/lock/tests/e2e/max/main.test.bicep
+++ b/modules/authorization/lock/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'almax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/lock/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/authorization/lock/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'alwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-assignment/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/mg.common/main.test.bicep
@@ -14,7 +14,7 @@ param location string = deployment().location
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-assignment/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/mg.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apamgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-assignment/tests/e2e/rg.common/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/rg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'apargcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-assignment/tests/e2e/rg.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/rg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'apargmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-assignment/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/sub.common/main.test.bicep
@@ -18,7 +18,7 @@ param location string = deployment().location
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-assignment/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/policy-assignment/tests/e2e/sub.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apasubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-definition/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/policy-definition/tests/e2e/mg.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apdmgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-definition/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/policy-definition/tests/e2e/mg.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apdmgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-definition/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/policy-definition/tests/e2e/sub.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apdsubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-definition/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/policy-definition/tests/e2e/sub.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apdsubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-exemption/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/mg.common/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'apemgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-exemption/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/mg.min/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'apemgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-exemption/tests/e2e/rg.common/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/rg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'apergcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-exemption/tests/e2e/rg.min/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/rg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'apergmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-exemption/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/sub.common/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'apesubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-exemption/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/policy-exemption/tests/e2e/sub.min/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'apesubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/policy-set-definition/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/policy-set-definition/tests/e2e/mg.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apsdmgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-set-definition/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/policy-set-definition/tests/e2e/mg.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apsdmgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-set-definition/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/policy-set-definition/tests/e2e/sub.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apsdsubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/policy-set-definition/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/policy-set-definition/tests/e2e/sub.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'apsdsubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/role-assignment/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/mg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'aramgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-assignment/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/mg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'aramgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-assignment/tests/e2e/rg.common/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/rg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'arargcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-assignment/tests/e2e/rg.min/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/rg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'arargmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-assignment/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/sub.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'arasubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-assignment/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/role-assignment/tests/e2e/sub.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'arasubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-definition/tests/e2e/mg.common/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/mg.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'ardmgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/role-definition/tests/e2e/mg.min/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/mg.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'ardmgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/role-definition/tests/e2e/rg.common/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/rg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'ardrgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-definition/tests/e2e/rg.min/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/rg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'ardrgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/authorization/role-definition/tests/e2e/sub.common/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/sub.common/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'ardsubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/authorization/role-definition/tests/e2e/sub.min/main.test.bicep
+++ b/modules/authorization/role-definition/tests/e2e/sub.min/main.test.bicep
@@ -11,7 +11,7 @@ param serviceShort string = 'ardsubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/cache/redis-enterprise/tests/e2e/defaults/main.test.bicep
+++ b/modules/cache/redis-enterprise/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cremin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cache/redis-enterprise/tests/e2e/geo/main.test.bicep
+++ b/modules/cache/redis-enterprise/tests/e2e/geo/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'cregeo'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cache/redis-enterprise/tests/e2e/max/main.test.bicep
+++ b/modules/cache/redis-enterprise/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cremax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cache/redis-enterprise/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/cache/redis-enterprise/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'crewaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cdn/profile/tests/e2e/afd/main.test.bicep
+++ b/modules/cdn/profile/tests/e2e/afd/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'cdnpafd'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/modules/cdn/profile/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cdnpmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/cdn/profile/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/cdn/profile/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cdnpwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/compute/virtual-machine-scale-set/tests/e2e/linux.min/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/tests/e2e/linux.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'cvmsslinmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/compute/virtual-machine-scale-set/tests/e2e/linux/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/tests/e2e/linux/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'cvmsslin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/compute/virtual-machine-scale-set/tests/e2e/windows.min/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/tests/e2e/windows.min/main.test.bicep
@@ -22,7 +22,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/compute/virtual-machine-scale-set/tests/e2e/windows/main.test.bicep
+++ b/modules/compute/virtual-machine-scale-set/tests/e2e/windows/main.test.bicep
@@ -22,7 +22,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/container-instance/container-group/tests/e2e/defaults/main.test.bicep
+++ b/modules/container-instance/container-group/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cicgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/container-instance/container-group/tests/e2e/encr/main.test.bicep
+++ b/modules/container-instance/container-group/tests/e2e/encr/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/container-instance/container-group/tests/e2e/max/main.test.bicep
+++ b/modules/container-instance/container-group/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cicgmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/container-instance/container-group/tests/e2e/private/main.test.bicep
+++ b/modules/container-instance/container-group/tests/e2e/private/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'cicgprivate'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/container-instance/container-group/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/container-instance/container-group/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'cicgwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/dev-test-lab/lab/tests/e2e/defaults/main.test.bicep
+++ b/modules/dev-test-lab/lab/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'dtllmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/dev-test-lab/lab/tests/e2e/max/main.test.bicep
+++ b/modules/dev-test-lab/lab/tests/e2e/max/main.test.bicep
@@ -24,7 +24,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/dev-test-lab/lab/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/dev-test-lab/lab/tests/e2e/waf-aligned/main.test.bicep
@@ -24,7 +24,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/digital-twins/digital-twins-instance/tests/e2e/defaults/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'dtdtimin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/digital-twins/digital-twins-instance/tests/e2e/max/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'dtdtimax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/digital-twins/digital-twins-instance/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/digital-twins/digital-twins-instance/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'dtdtiwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/event-hub/namespace/tests/e2e/defaults/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ehnmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/event-hub/namespace/tests/e2e/encr/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/encr/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/event-hub/namespace/tests/e2e/max/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ehnmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/event-hub/namespace/tests/e2e/pe/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/pe/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'ehnpe'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/event-hub/namespace/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/event-hub/namespace/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'ehnwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/healthcare-apis/workspace/tests/e2e/defaults/main.test.bicep
+++ b/modules/healthcare-apis/workspace/tests/e2e/defaults/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'hawmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/healthcare-apis/workspace/tests/e2e/max/main.test.bicep
+++ b/modules/healthcare-apis/workspace/tests/e2e/max/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'hawmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/healthcare-apis/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/healthcare-apis/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'hawwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/machine-learning-services/workspace/tests/e2e/defaults/main.test.bicep
+++ b/modules/machine-learning-services/workspace/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'mlswmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/machine-learning-services/workspace/tests/e2e/encr/main.test.bicep
+++ b/modules/machine-learning-services/workspace/tests/e2e/encr/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/machine-learning-services/workspace/tests/e2e/max/main.test.bicep
+++ b/modules/machine-learning-services/workspace/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'mlswmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/machine-learning-services/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/machine-learning-services/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'mlswwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/managed-services/registration-definition/tests/e2e/max/main.test.bicep
+++ b/modules/managed-services/registration-definition/tests/e2e/max/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'msrdmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
+++ b/modules/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'msrdrg'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'msrdwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============== //
 // Test Execution //

--- a/modules/network/application-gateway-web-application-firewall-policy/tests/e2e/max/main.test.bicep
+++ b/modules/network/application-gateway-web-application-firewall-policy/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nagwafpmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/application-gateway-web-application-firewall-policy/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/application-gateway-web-application-firewall-policy/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nagwafpwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/application-gateway/tests/e2e/max/main.test.bicep
+++ b/modules/network/application-gateway/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nagmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/application-gateway/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/application-gateway/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nagwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/addpip/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/addpip/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'nafaddpip'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/custompip/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/custompip/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'nafcstpip'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/defaults/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nafmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/hubcommon/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/hubcommon/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'nafhubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/hubmin/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/hubmin/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'nafhubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/max/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nafmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/azure-firewall/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/azure-firewall/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nafwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/network-manager/tests/e2e/max/main.test.bicep
+++ b/modules/network/network-manager/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nnmmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/network-manager/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/network-manager/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nnmwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/network-watcher/tests/e2e/max/main.test.bicep
+++ b/modules/network/network-watcher/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nnwmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/network-watcher/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/network-watcher/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nnwwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/service-endpoint-policy/tests/e2e/defaults/main.test.bicep
+++ b/modules/network/service-endpoint-policy/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nsnpmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/service-endpoint-policy/tests/e2e/max/main.test.bicep
+++ b/modules/network/service-endpoint-policy/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nsnpmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/service-endpoint-policy/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/service-endpoint-policy/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nsnpwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-hub/tests/e2e/defaults/main.test.bicep
+++ b/modules/network/virtual-hub/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvhmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-hub/tests/e2e/max/main.test.bicep
+++ b/modules/network/virtual-hub/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvhmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-hub/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/virtual-hub/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvhwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-wan/tests/e2e/defaults/main.test.bicep
+++ b/modules/network/virtual-wan/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvwmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-wan/tests/e2e/max/main.test.bicep
+++ b/modules/network/virtual-wan/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvwmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/network/virtual-wan/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/network/virtual-wan/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'nvwwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/mg.common/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/mg.common/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'pirmgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/mg.min/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/mg.min/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'pirmgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/rg.common/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/rg.common/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'pirrgcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/rg.min/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/rg.min/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'pirrgmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/sub.common/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/sub.common/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'pirsubcom'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/policy-insights/remediation/tests/e2e/sub.min/main.test.bicep
+++ b/modules/policy-insights/remediation/tests/e2e/sub.min/main.test.bicep
@@ -14,7 +14,7 @@ param serviceShort string = 'pirsubmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/purview/account/tests/e2e/defaults/main.test.bicep
+++ b/modules/purview/account/tests/e2e/defaults/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'pvamin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/purview/account/tests/e2e/max/main.test.bicep
+++ b/modules/purview/account/tests/e2e/max/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'pvamax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 // =========== //
 // Deployments //
 // =========== //

--- a/modules/purview/account/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/purview/account/tests/e2e/waf-aligned/main.test.bicep
@@ -20,7 +20,7 @@ param serviceShort string = 'pvawaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 // =========== //
 // Deployments //
 // =========== //

--- a/modules/recovery-services/vault/tests/e2e/defaults/main.test.bicep
+++ b/modules/recovery-services/vault/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rsvmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/recovery-services/vault/tests/e2e/dr/main.test.bicep
+++ b/modules/recovery-services/vault/tests/e2e/dr/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'rsvdr'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/recovery-services/vault/tests/e2e/max/main.test.bicep
+++ b/modules/recovery-services/vault/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rsvmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/recovery-services/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/recovery-services/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rsvwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/relay/namespace/tests/e2e/defaults/main.test.bicep
+++ b/modules/relay/namespace/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rnmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/relay/namespace/tests/e2e/max/main.test.bicep
+++ b/modules/relay/namespace/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rnmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/relay/namespace/tests/e2e/pe/main.test.bicep
+++ b/modules/relay/namespace/tests/e2e/pe/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'rnpe'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/relay/namespace/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/relay/namespace/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'rnwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/resources/tags/tests/e2e/rg/main.test.bicep
+++ b/modules/resources/tags/tests/e2e/rg/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'rtrg'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/security/azure-security-center/tests/e2e/max/main.test.bicep
+++ b/modules/security/azure-security-center/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'sascmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/security/azure-security-center/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/security/azure-security-center/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'sascwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/service-fabric/cluster/tests/e2e/cert/main.test.bicep
+++ b/modules/service-fabric/cluster/tests/e2e/cert/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'sfccer'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/service-fabric/cluster/tests/e2e/defaults/main.test.bicep
+++ b/modules/service-fabric/cluster/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'sfcmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/service-fabric/cluster/tests/e2e/max/main.test.bicep
+++ b/modules/service-fabric/cluster/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'sfcmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/service-fabric/cluster/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/service-fabric/cluster/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'sfcwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/signal-r-service/signal-r/tests/e2e/defaults/main.test.bicep
+++ b/modules/signal-r-service/signal-r/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srsdrmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/signal-r-service/signal-r/tests/e2e/max/main.test.bicep
+++ b/modules/signal-r-service/signal-r/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srssrmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/signal-r-service/signal-r/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/signal-r-service/signal-r/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srssrwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // =========== //
 // Deployments //

--- a/modules/signal-r-service/web-pub-sub/tests/e2e/defaults/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srswpsmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/signal-r-service/web-pub-sub/tests/e2e/max/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srswpsmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/signal-r-service/web-pub-sub/tests/e2e/pe/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/tests/e2e/pe/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'srswpspe'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/signal-r-service/web-pub-sub/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/signal-r-service/web-pub-sub/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'srswpswaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/sql/managed-instance/tests/e2e/defaults/main.test.bicep
+++ b/modules/sql/managed-instance/tests/e2e/defaults/main.test.bicep
@@ -25,7 +25,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/sql/managed-instance/tests/e2e/max/main.test.bicep
+++ b/modules/sql/managed-instance/tests/e2e/max/main.test.bicep
@@ -28,7 +28,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/sql/managed-instance/tests/e2e/vulnAssm/main.test.bicep
+++ b/modules/sql/managed-instance/tests/e2e/vulnAssm/main.test.bicep
@@ -22,7 +22,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/sql/managed-instance/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/sql/managed-instance/tests/e2e/waf-aligned/main.test.bicep
@@ -28,7 +28,7 @@ param password string = newGuid()
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/private-link-hub/tests/e2e/defaults/main.test.bicep
+++ b/modules/synapse/private-link-hub/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'splhmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/private-link-hub/tests/e2e/max/main.test.bicep
+++ b/modules/synapse/private-link-hub/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'splhmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/private-link-hub/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/synapse/private-link-hub/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'splhwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/defaults/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'swmin'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/encrwsai/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/encrwsai/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/encrwuai/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/encrwuai/main.test.bicep
@@ -21,7 +21,7 @@ param baseTime string = utcNow('u')
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/managedvnet/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/managedvnet/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'swmanv'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/max/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'swmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/synapse/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/synapse/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'swwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/web/connection/tests/e2e/max/main.test.bicep
+++ b/modules/web/connection/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'wcmax'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/web/connection/tests/e2e/waf-aligned/main.test.bicep
+++ b/modules/web/connection/tests/e2e/waf-aligned/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'wcwaf'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/web/hosting-environment/tests/e2e/asev2/main.test.bicep
+++ b/modules/web/hosting-environment/tests/e2e/asev2/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'whasev2'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/modules/web/hosting-environment/tests/e2e/asev3/main.test.bicep
+++ b/modules/web/hosting-environment/tests/e2e/asev3/main.test.bicep
@@ -18,7 +18,7 @@ param serviceShort string = 'whasev3'
 param enableDefaultTelemetry bool = true
 
 @description('Optional. A token to inject into the name of each resource.')
-param namePrefix string = '[[namePrefix]]'
+param namePrefix string = '#_namePrefix_#'
 
 // ============ //
 // Dependencies //

--- a/settings.yml
+++ b/settings.yml
@@ -16,8 +16,8 @@ variables:
   localToken_namePrefix: '' # A 3-5 character length unique string, included in the resources names (e.g. 'cntso'). Used for local module testing and pipelines.
 
   # this determines the starting prefix and ending suffix of the token in your file.
-  tokenPrefix: '[['
-  tokenSuffix: ']]'
+  tokenPrefix: '#_'
+  tokenSuffix: '_#'
 
   ########################
   ##   Agent settings   ##

--- a/utilities/tools/Test-NamePrefixAvailability.ps1
+++ b/utilities/tools/Test-NamePrefixAvailability.ps1
@@ -107,7 +107,7 @@ function Test-NamePrefixAvailability {
 
                     # trim the entry and replace placeholder values
                     $temp = $temp.Replace("'", '') # remove trailing quotes
-                    $temp = $temp.Replace('[[namePrefix]]', $namePrefix)
+                    $temp = $temp.Replace('#_namePrefix_#', $namePrefix)
                     $temp = $temp.Replace('${serviceShort}', $serviceShort)
                     $temp = $temp.Replace(' ', '') # remove trailing whitespaces
 


### PR DESCRIPTION
# Description

Aligned the NamePrefix with the format in AVM:
- old: `[[NamePrefix]]`
- new: `#_NamePrefix_#`
