### PR TITLE
Added MOVED-TO-AVM.md for the App Configuration Store

### DIFF
--- a/modules/app-configuration/configuration-store/MOVED-TO-AVM.md
+++ b/modules/app-configuration/configuration-store/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/app-configuration/configuration-store/README.md
+++ b/modules/app-configuration/configuration-store/README.md
@@ -1,5 +1,7 @@
 # App Configuration Stores `[Microsoft.AppConfiguration/configurationStores]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an App Configuration Store.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `app-configuration/configuration-store`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1072
  - resolves #4504 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

