### PR TITLE
[Fixes] Added missing slash to module path split

### DIFF
--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1623,7 +1623,7 @@ function Set-ModuleReadMe {
     }
 
     $moduleRoot = Split-Path $TemplateFilePath -Parent
-    $fullModuleIdentifier = $moduleRoot.Replace('\', '/').split('modules/')[-1]
+    $fullModuleIdentifier = $moduleRoot.Replace('\', '/').split('/modules/')[-1]
     # Custom modules are modules having the same resource type but different properties based on the name
     # E.g., web/site/config--appsetting vs web/site/config--authsettingv2
     $customModuleSeparator = '--'


### PR DESCRIPTION
# Description

- Based on found issue by a colleague where the script failed if 'modules' also appeared in other parts of the path
- The `/modules/` instead of `modules/` is in alignment with all other places where we split
- Tested & validated

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation
