### PR TITLE
Added MOVED-TO-AVM.md for the CDN Profile module

### DIFF
--- a/modules/cdn/profile/MOVED-TO-AVM.md
+++ b/modules/cdn/profile/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/cdn/profile/README.md
+++ b/modules/cdn/profile/README.md
@@ -1,5 +1,7 @@
 # CDN Profiles `[Microsoft.Cdn/profiles]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a CDN Profile.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `cdn/profile`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1106
  - resolves #4510 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

