### PR TITLE
Added MOVED-TO-AVM.md for the Signal-R modules

### DIFF
--- a/modules/signal-r-service/signal-r/MOVED-TO-AVM.md
+++ b/modules/signal-r-service/signal-r/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/signal-r-service/signal-r/README.md
+++ b/modules/signal-r-service/signal-r/README.md
@@ -1,5 +1,7 @@
 # SignalR Service SignalR `[Microsoft.SignalRService/signalR]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a SignalR Service SignalR.
 
 ## Navigation

--- a/modules/signal-r-service/web-pub-sub/MOVED-TO-AVM.md
+++ b/modules/signal-r-service/web-pub-sub/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/signal-r-service/web-pub-sub/README.md
+++ b/modules/signal-r-service/web-pub-sub/README.md
@@ -1,5 +1,7 @@
 # SignalR Web PubSub Services `[Microsoft.SignalRService/webPubSub]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a SignalR Web PubSub Service.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `signal-r-service/signal-r`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1109
  - resolves #4511 

- `signal-r-service/web-pub-sub`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1219
  - resolves #4514 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

