### PR TITLE
Added MOVED-TO-AVM.md for the recently migrated modules

### DIFF
--- a/modules/relay/namespace/MOVED-TO-AVM.md
+++ b/modules/relay/namespace/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/relay/namespace/README.md
+++ b/modules/relay/namespace/README.md
@@ -1,5 +1,7 @@
 # Relay Namespaces `[Microsoft.Relay/namespaces]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Relay Namespace
 
 ## Navigation

--- a/modules/web/connection/MOVED-TO-AVM.md
+++ b/modules/web/connection/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/web/connection/README.md
+++ b/modules/web/connection/README.md
@@ -1,5 +1,7 @@
 # API Connections `[Microsoft.Web/connections]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Azure API Connection.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `relay/namespace`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1319
  - resolves #4528 
- `web/connection`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1318
  - resolves #4529 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

