### PR TITLE
Added MOVED-TO-AVM.md for the recently migrated modules

### DIFF
--- a/modules/healthcare-apis/workspace/MOVED-TO-AVM.md
+++ b/modules/healthcare-apis/workspace/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/healthcare-apis/workspace/README.md
+++ b/modules/healthcare-apis/workspace/README.md
@@ -1,5 +1,7 @@
 # Healthcare API Workspaces `[Microsoft.HealthcareApis/workspaces]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys a Healthcare API Workspace.
 
 ## Navigation

--- a/modules/network/application-gateway-web-application-firewall-policy/MOVED-TO-AVM.md
+++ b/modules/network/application-gateway-web-application-firewall-policy/MOVED-TO-AVM.md
@@ -1,0 +1,1 @@
+This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).

--- a/modules/network/application-gateway-web-application-firewall-policy/README.md
+++ b/modules/network/application-gateway-web-application-firewall-policy/README.md
@@ -1,5 +1,7 @@
 # Application Gateway Web Application Firewall (WAF) Policies `[Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies]`
 
+> This module has already been migrated to [AVM](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res). Only the AVM version is expected to receive updates / new features. Please do not work on improving this module in [CARML](https://aka.ms/carml).
+
 This module deploys an Application Gateway Web Application Firewall (WAF) Policy.
 
 ## Navigation


### PR DESCRIPTION
# Description

Added `MOVED-TO-AVM.md` files for  following modules:
- `healthcare-apis/workspace`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1467
  - resolves #4531 
- `network/application-gateway-web-application-firewall-policy`
  - PR: https://github.com/Azure/bicep-registry-modules/pull/1471
  - resolves #4532 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update to documentation

